### PR TITLE
Add plum to sandbox for aat-like deployment tests

### DIFF
--- a/k8s/sandbox/cnp/cnp-plum-recipes-service.rc.yaml
+++ b/k8s/sandbox/cnp/cnp-plum-recipes-service.rc.yaml
@@ -20,11 +20,6 @@ spec:
       image: hmcts.azurecr.io/hmcts/plum-recipe-backend:aat-rc-301f251eab1904d382467433160c23db77fb1ad3
       ingressHost: plum-recipe-backend.service.core-compute-aat-rc.internal
       applicationPort: 4550
-      environment:
-        IDAM_OAUTH2_TOKEN_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/oauth2/token
-        IDAM_OAUTH2_LOGOUT_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/session/:token
-        IDAM_BASE_URL: https://preprod-idamapi.reform.hmcts.net:3511
-        IDAM_S2S_URL: https://rpe-service-auth-provider.service.core-compute-aat.internal
       keyVaults:
         "plumsi-aat":
           resourceGroup: plum-shared-infrastructure-aat

--- a/k8s/sandbox/cnp/cnp-plum-recipes-service.rc.yaml
+++ b/k8s/sandbox/cnp/cnp-plum-recipes-service.rc.yaml
@@ -1,0 +1,42 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: plum-recipe-backend-rc
+  namespace: cnp
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:aat-rc-*
+spec:
+  releaseName: plum-recipe-backend-rc
+  chart:
+    repository: https://hmcts.azurecr.io/helm/v1/repo/
+    name: plum-recipe-backend
+    version: 0.0.2
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "2700c28a-aa8c-4669-8718-1e4239dee797"
+      image: hmcts.azurecr.io/hmcts/plum-recipe-backend:aat-rc-301f251eab1904d382467433160c23db77fb1ad3
+      ingressHost: plum-recipe-backend.service.core-compute-aat-rc.internal
+      applicationPort: 4550
+      environment:
+        IDAM_OAUTH2_TOKEN_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/oauth2/token
+        IDAM_OAUTH2_LOGOUT_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/session/:token
+        IDAM_BASE_URL: https://preprod-idamapi.reform.hmcts.net:3511
+        IDAM_S2S_URL: https://rpe-service-auth-provider.service.core-compute-aat.internal
+      keyVaults:
+        "plumsi-aat":
+          resourceGroup: plum-shared-infrastructure-aat
+          secrets:
+            - recipe-backend-POSTGRES-DATABASE
+            - recipe-backend-POSTGRES-HOST
+            - recipe-backend-POSTGRES-PASS
+            - recipe-backend-POSTGRES-PORT
+            - recipe-backend-POSTGRES-USER
+    tags:
+      postgresql-pod: false
+    global:
+      environment: aat
+      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/sandbox/cnp/cnp-plum-recipes-service.yaml
+++ b/k8s/sandbox/cnp/cnp-plum-recipes-service.yaml
@@ -20,11 +20,6 @@ spec:
       image: hmcts.azurecr.io/hmcts/plum-recipe-backend:aat-301f251eab1904d382467433160c23db77fb1ad3
       ingressHost: plum-recipe-backend.service.core-compute-aat.internal
       applicationPort: 4550
-      environment:
-        IDAM_OAUTH2_TOKEN_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/oauth2/token
-        IDAM_OAUTH2_LOGOUT_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/session/:token
-        IDAM_BASE_URL: https://preprod-idamapi.reform.hmcts.net:3511
-        IDAM_S2S_URL: https://rpe-service-auth-provider.service.core-compute-aat.internal
       keyVaults:
         "plumsi-aat":
           resourceGroup: plum-shared-infrastructure-aat

--- a/k8s/sandbox/cnp/cnp-plum-recipes-service.yaml
+++ b/k8s/sandbox/cnp/cnp-plum-recipes-service.yaml
@@ -1,0 +1,42 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: plum-recipe-backend
+  namespace: cnp
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:aat-*
+spec:
+  releaseName: plum-recipe-backend
+  chart:
+    repository: https://hmcts.azurecr.io/helm/v1/repo/
+    name: plum-recipe-backend
+    version: 0.0.2
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "2700c28a-aa8c-4669-8718-1e4239dee797"
+      image: hmcts.azurecr.io/hmcts/plum-recipe-backend:aat-301f251eab1904d382467433160c23db77fb1ad3
+      ingressHost: plum-recipe-backend.service.core-compute-aat.internal
+      applicationPort: 4550
+      environment:
+        IDAM_OAUTH2_TOKEN_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/oauth2/token
+        IDAM_OAUTH2_LOGOUT_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/session/:token
+        IDAM_BASE_URL: https://preprod-idamapi.reform.hmcts.net:3511
+        IDAM_S2S_URL: https://rpe-service-auth-provider.service.core-compute-aat.internal
+      keyVaults:
+        "plumsi-aat":
+          resourceGroup: plum-shared-infrastructure-aat
+          secrets:
+            - recipe-backend-POSTGRES-DATABASE
+            - recipe-backend-POSTGRES-HOST
+            - recipe-backend-POSTGRES-PASS
+            - recipe-backend-POSTGRES-PORT
+            - recipe-backend-POSTGRES-USER
+    tags:
+      postgresql-pod: false
+    global:
+      environment: aat
+      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/sandbox/cnp/namespace.yaml
+++ b/k8s/sandbox/cnp/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+   name: cnp
+---


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPE-1006


### Change description ###
HelmRelease files so that aat-like flux managed deployments can be tested in sandbox


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```