### PR TITLE
Use default published service

### DIFF
--- a/k8s/demo/cluster-00/traefik/traefik.yaml
+++ b/k8s/demo/cluster-00/traefik/traefik.yaml
@@ -15,6 +15,9 @@ spec:
   values:
     imageTag: 1.7.9
     loadBalancerIP: 51.145.127.93
+    kubernetes:
+      ingressEndpoint:
+        useDefaultPublishedService: true
     resources:
       requests:
         cpu: 100m

--- a/k8s/demo/cluster-01/traefik/traefik.yaml
+++ b/k8s/demo/cluster-01/traefik/traefik.yaml
@@ -15,6 +15,9 @@ spec:
   values:
     imageTag: 1.7.9
     loadBalancerIP: 51.145.127.88
+    kubernetes:
+      ingressEndpoint:
+        useDefaultPublishedService: true
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
### JIRA link (if applicable) ###
[AB#128](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/128)


### Change description ###
Fix external DNS:
https://github.com/kubernetes-incubator/external-dns/blob/master/docs/faq.md#which-service-and-ingress-controllers-are-supported


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
