### PR TITLE
Remove references to kubeconfig

### DIFF
--- a/k8s/aat/pod-identity/pod-identity.yaml
+++ b/k8s/aat/pod-identity/pod-identity.yaml
@@ -104,13 +104,9 @@ spec:
         imagePullPolicy: Always
         args:
           - mic
-          - "--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig"
           - "--cloudconfig=/etc/kubernetes/azure.json"
           - "--logtostderr"
         volumeMounts:
-          - name: kubeconfig
-            mountPath: /etc/kubernetes/kubeconfig
-            readOnly: true
           - name: certificates
             mountPath: /etc/kubernetes/certs
             readOnly: true
@@ -118,9 +114,6 @@ spec:
             mountPath: /etc/kubernetes/azure.json
             readOnly: true
       volumes:
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kubelet
       - name: certificates
         hostPath:
           path: /etc/kubernetes/certs


### PR DESCRIPTION
### JIRA link (if applicable) ###


### Change description ###

See: https://github.com/Azure/aad-pod-identity/pull/178/commits/6fb27d7517398279d22d310c59b4b2548e2ba2df

Trying to fix error in mic:

E0607 10:05:12.646923       1 reflector.go:205] github.com/Azure/aad-pod-identity/pkg/crd/crd.go:154: Failed to list *v1.AzureIdentityBinding: unknown (get azureidentitybindings.aadpodidentity.k8s.io)
E0607 10:05:12.846752       1 crd.go:197] unknown (get azureidentitybindings.aadpodidentity.k8s.io)
E0607 10:05:13.046189       1 crd.go:197] unknown (get azureidentitybindings.aadpodidentity.k8s.io)
E0607 10:05:13.246893       1 reflector.go:205] github.com/Azure/aad-pod-identity/pkg/crd/crd.go:155: Failed to list *v1.AzureIdentity: unknown (get azureidentities.aadpodidentity.k8s.io)
E0607 10:05:13.451898       1 crd.go:197] unknown (get azureidentitybindings.aadpodidentity.k8s.io)
E0607 10:05:13.646845       1 crd.go:197] unknown (get azureidentitybindings.aadpodidentity.k8s.io)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
