### PR TITLE
Adding kustomize to reduce duplications across environments

### DIFF
--- a/k8s/common-base/flux/flux.yaml
+++ b/k8s/common-base/flux/flux.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: flux
+  namespace: admin
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: flux
+  chart:
+    repository: https://weaveworks.github.io/flux
+    name: flux
+    version: 0.10.1
+  values:
+    git:
+      url: git@github.com:hmcts/cnp-flux-config
+      pollInterval: 1m
+    syncGarbageCollection:
+      enabled: true
+    registry:
+      acr:
+        enabled: true
+    helmOperator:
+      create: true
+      chartsSyncInterval: 1m
+      configureRepositories:
+        enable: true
+    additionalArgs:
+      - --connect=ws://fluxcloud
+      - --manifest-generation=true

--- a/k8s/common-base/flux/kustomization.yaml
+++ b/k8s/common-base/flux/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- flux.yaml

--- a/k8s/common-base/kustomization.yaml
+++ b/k8s/common-base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- flux
+- traefik

--- a/k8s/common-base/traefik/kustomization.yaml
+++ b/k8s/common-base/traefik/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- traefik.yaml

--- a/k8s/common-base/traefik/traefik.yaml
+++ b/k8s/common-base/traefik/traefik.yaml
@@ -1,0 +1,34 @@
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: admin
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: traefik
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    name: traefik
+    version: 1.61.1
+  values:
+    imageTag: 1.7.9
+    resources:
+      requests:
+        cpu: 100m
+        memory: 20Mi
+      limits:
+        cpu: 1000m
+        memory: 300Mi
+    service:
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    rbac:
+      enabled: true
+    dashboard:
+      enabled: true
+    ssl:
+      enabled: true
+    startupArguments:
+      - "--ping"
+      - "--ping.entrypoint=http"

--- a/k8s/common-base/traefik/traefik.yaml
+++ b/k8s/common-base/traefik/traefik.yaml
@@ -29,6 +29,8 @@ spec:
       enabled: true
     ssl:
       enabled: true
+      tlsMinVersion: VersionTLS12
+      cipherSuites: ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256","TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
     startupArguments:
       - "--ping"
       - "--ping.entrypoint=http"

--- a/k8s/sandbox/cluster-01/.flux.yaml
+++ b/k8s/sandbox/cluster-01/.flux.yaml
@@ -1,0 +1,4 @@
+version: 1
+commandUpdated:
+  generators:
+    - command: kustomize build .

--- a/k8s/sandbox/cluster-01/kustomization.yaml
+++ b/k8s/sandbox/cluster-01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../sandbox-base/
+resources:
+  - fluxcloud/fluxcloud-values.yaml
+  - kube-slack/kube-slack-values.yaml
+  - kured/kured-values.yaml
+patchesStrategicMerge:
+- flux/flux.yaml
+- traefik/traefik.yaml

--- a/k8s/sandbox/cluster-01/traefik/traefik.yaml
+++ b/k8s/sandbox/cluster-01/traefik/traefik.yaml
@@ -3,35 +3,8 @@ kind: HelmRelease
 metadata:
   name: traefik
   namespace: admin
-  annotations:
-    #flux.weave.works/ignore: "true"
-    flux.weave.works/automated: "false"
 spec:
-  releaseName: traefik
-  chart:
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    name: traefik
-    version: 1.61.1
   values:
-    imageTag: 1.7.9
     loadBalancerIP: 10.10.3.250
-    resources:
-      requests:
-        cpu: 100m
-        memory: 20Mi
-      limits:
-        cpu: 1000m
-        memory: 300Mi
-    service:
-      annotations:
-        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    rbac:
-      enabled: true
     dashboard:
-      enabled: true
       domain: traefik01.service.core-compute-sandbox.internal
-    ssl:
-      enabled: true
-    startupArguments:
-      - "--ping"
-      - "--ping.entrypoint=http"

--- a/k8s/sandbox/sandbox-base/flux/flux.yaml
+++ b/k8s/sandbox/sandbox-base/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/sandbox/common,k8s/sandbox/cluster-01/,k8s/common"
-      label: "sandbox-cluster-01"
+      email: "hmcts-flux-sandbox@hmcts.net"
+      user: "Flux sandbox"

--- a/k8s/sandbox/sandbox-base/kustomization.yaml
+++ b/k8s/sandbox/sandbox-base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../common-base/
+patchesStrategicMerge:
+- flux/flux.yaml


### PR DESCRIPTION

Adding Kustomize to flux , to be able to override base manifests at env level instead of duplicating them across. Testing only on sandbox 01 for now.

Working on [AB#224](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/224)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
