### PR TITLE
CMC: add mailhog deployment to demo/money-claims

### DIFF
--- a/k8s/demo/common/money-claims/mailhog/mailhog.yaml
+++ b/k8s/demo/common/money-claims/mailhog/mailhog.yaml
@@ -36,7 +36,7 @@ metadata:
     app: mailhog
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.mailhog: regexp:^1.*
+    flux.weave.works/tag.mailhog: regexp:^v1.*
 spec:
   template:
     metadata:

--- a/k8s/demo/common/money-claims/mailhog/mailhog.yaml
+++ b/k8s/demo/common/money-claims/mailhog/mailhog.yaml
@@ -34,6 +34,9 @@ metadata:
   namespace: money-claims
   labels:
     app: mailhog
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.mailhog: regexp:^1.*
 spec:
   template:
     metadata:

--- a/k8s/demo/common/money-claims/mailhog/mailhog.yaml
+++ b/k8s/demo/common/money-claims/mailhog/mailhog.yaml
@@ -1,0 +1,70 @@
+# helm repo add codecentric https://codecentric.github.io/helm-charts
+# helm install --name mailhog --namespace namespace stable/mailhog
+# helm get mailhog > mailhog.yaml
+---
+# Source: mailhog/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailhog
+  namespace: money-claims
+  labels:
+    app: mailhog
+spec:
+  type: "ClusterIP"
+  clusterIP: ""
+  ports:
+    - name: http
+      port: 8025
+      protocol: TCP
+      targetPort: http
+    - name: smtp
+      port: 1025
+      protocol: TCP
+      targetPort: smtp
+  selector:
+    app: mailhog
+    release: mailhog
+---
+# Source: mailhog/templates/deployment.yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mailhog
+  namespace: money-claims
+  labels:
+    app: mailhog
+spec:
+  template:
+    metadata:
+      labels:
+        app: mailhog
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: mailhog
+          image: "mailhog/mailhog:v1.0.0"
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: MH_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          ports:
+            - name: http
+              containerPort: 8025
+              protocol: TCP
+            - name: smtp
+              containerPort: 1025
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: smtp
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            tcpSocket:
+              port: smtp
+          resources:
+            {}


### PR DESCRIPTION

### Change description ###

no peering for `mta.reform.hmcts.net` but probably don't want traffic to go there anyway 🤔 this follows on from desired service + all dependencies. we will share between all our demo instances.

could add with ingress if needed - but can port-forward for now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
