### PR TITLE
CMC: fix mailhog service to use defaults

### DIFF
--- a/k8s/demo/common/money-claims/mailhog/mailhog.yaml
+++ b/k8s/demo/common/money-claims/mailhog/mailhog.yaml
@@ -11,8 +11,6 @@ metadata:
   labels:
     app: mailhog
 spec:
-  type: "ClusterIP"
-  clusterIP: ""
   ports:
     - name: http
       port: 8025


### PR DESCRIPTION

### Change description ###

Error in Flux logs: `ts=2019-06-26T08:11:12.923322683Z caller=sync.go:153 component=daemon err="money-claims:service/mailhog: running kubectl: The Service \"mailhog\" is invalid: spec.clusterIP: Invalid value: \"\": field is immutable"`

Update service manifest to use defaults, i.e. `ClusterIP`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
