### PR TITLE
CMC: add timeout to demo deployment

### DIFF
--- a/k8s/demo/common/money-claims/demo.yaml
+++ b/k8s/demo/common/money-claims/demo.yaml
@@ -9,6 +9,7 @@ metadata:
     flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: demo
+  timeout: 900
   chart:
     repository: https://hmcts.azurecr.io/helm/v1/repo/
     name: cmc


### PR DESCRIPTION

### Change description ###

Default timeout of 300 seconds will not be enough for full CMC deployment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
