### PR TITLE
CMC: fix smtp ssl settings

### DIFF
--- a/k8s/demo/common/money-claims/demo.yaml
+++ b/k8s/demo/common/money-claims/demo.yaml
@@ -56,6 +56,9 @@ spec:
           RESPOND_TO_CLAIM_URL: https://cmc-citizen-frontend.demo.platform.hmcts.net/first-contact/start
           SPRING_MAIL_HOST: mailhog
           SPRING_MAIL_PORT: 1025
+          SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_TRUST: mailhog
+          SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: false
+
       ccd:
         idamApiUrl: https://idam-api.demo.platform.hmcts.net
         idamWebUrl: https://idam-web-public.demo.platform.hmcts.net


### PR DESCRIPTION

### Change description ###

Fixing from describing pod:

```
SPRING_MAIL_HOST:                                  mailhog
SPRING_MAIL_PORT:                                  1025
SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_TRUST:        mta.reform.hmcts.net
SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE:  true
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
