### PR TITLE
CMC: remove release from mailhog svc selector

### DIFF
--- a/k8s/demo/common/money-claims/mailhog/mailhog.yaml
+++ b/k8s/demo/common/money-claims/mailhog/mailhog.yaml
@@ -22,7 +22,6 @@ spec:
       targetPort: smtp
   selector:
     app: mailhog
-    release: mailhog
 ---
 # Source: mailhog/templates/deployment.yaml
 apiVersion: apps/v1beta1


### PR DESCRIPTION

### Change description ###

Service not finding backend: `2019-06-26T16:25:46.856 WARN  [http-nio-4400-exec-8] o.s.boot.actuate.mail.MailHealthIndicatorcom.sun.mail.util.MailConnectException: Couldn't connect to host, port: mailhog, 1025; timeout -1`

Selectors look wrong.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
