### PR TITLE
CMC: add forceUpgrade

### DIFF
--- a/k8s/demo/common/money-claims/cmc-demo.yaml
+++ b/k8s/demo/common/money-claims/cmc-demo.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   releaseName: cmc-demo
   timeout: 900
+  forceUpgrade: true
   chart:
     repository: https://hmcts.azurecr.io/helm/v1/repo/
     name: cmc


### PR DESCRIPTION

### Change description ###

Weird state since I updated release name with https://github.com/hmcts/cnp-flux-config/pull/257. 

```
NAME                            READY     STATUS              RESTARTS   AGE
cmc-demo-idam-pr-delete-9gkdx   0/1       ContainerCreating   0          34m
```

This should only kick in - will fix idam-pr chart with helm hooks on configmaps.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
