### PR TITLE
Removing automated overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ Weave Flux config for AKS clusters
     │   └── kustomization.yaml                          # Kustomize file for common-base referring to nested directories
     ├── env(sandbox)                                     
     │   ├── cluster-xx                                  # Folder per cluster
-    │   │   └── automated-overlay                       # Directory containing Kustomized workloads having image automation.
-    │   │       └── .flux.yaml                          # Flux Kustomize file with patch.
-    │   │       └── overlay
-    │   │           ├── kustomization.yaml              # kustomization file. 
-    │   │           └── ...                             # Folder per namespace containing patch workloads.
-    │   │               └── ...
     │   │   ├── static                                  # Directory containing workloads which aren't overlays / Kustomized.
     │   │   │   └── ...                                 # Folder per namespace.
     │   │   │       └── ...

--- a/k8s/demo/cluster-00/static-overlay/static/flux/flux.yaml
+++ b/k8s/demo/cluster-00/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/demo/common,k8s/demo/cluster-00/static,k8s/demo/cluster-00/static-overlay,k8s/demo/cluster-00/automated-overlay,k8s/common"
+      path: "k8s/demo/common,k8s/demo/cluster-00/static,k8s/demo/cluster-00/static-overlay,k8s/common"
       label: "demo-cluster-00"

--- a/k8s/demo/cluster-01/static-overlay/static/flux/flux.yaml
+++ b/k8s/demo/cluster-01/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/demo/common,k8s/demo/cluster-01/static,k8s/demo/cluster-01/static-overlay,k8s/demo/cluster-01/automated-overlay,k8s/common"
+      path: "k8s/demo/common,k8s/demo/cluster-01/static,k8s/demo/cluster-01/static-overlay,k8s/common"
       label: "demo-cluster-01"

--- a/k8s/ithc/cluster-00/static-overlay/static/flux/flux.yaml
+++ b/k8s/ithc/cluster-00/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/ithc/common,k8s/ithc/cluster-00/static,k8s/ithc/cluster-00/static-overlay,k8s/ithc/cluster-00/automated-overlay,k8s/common"
+      path: "k8s/ithc/common,k8s/ithc/cluster-00/static,k8s/ithc/cluster-00/static-overlay,k8s/common"
       label: "ithc-cluster-00"

--- a/k8s/ithc/cluster-01/static-overlay/static/flux/flux.yaml
+++ b/k8s/ithc/cluster-01/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/ithc/common,k8s/ithc/cluster-01/static,k8s/ithc/cluster-01/static-overlay,k8s/ithc/cluster-01/automated-overlay,k8s/common"
+      path: "k8s/ithc/common,k8s/ithc/cluster-01/static,k8s/ithc/cluster-01/static-overlay,k8s/common"
       label: "ithc-cluster-01"

--- a/k8s/mgmt-sandbox/cluster-00/static-overlay/static/flux/flux.yaml
+++ b/k8s/mgmt-sandbox/cluster-00/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/mgmt-sandbox/common,k8s/mgmt-sandbox/cluster-00/static,k8s/mgmt-sandbox/cluster-00/static-overlay,k8s/mgmt-sandbox/cluster-00/automated-overlay,k8s/common"
+      path: "k8s/mgmt-sandbox/common,k8s/mgmt-sandbox/cluster-00/static,k8s/mgmt-sandbox/cluster-00/static-overlay,k8s/common"
       label: "mgmt-sandbox-cluster-00"

--- a/k8s/mi-sbox/cluster-00/static-overlay/static/flux/flux.yaml
+++ b/k8s/mi-sbox/cluster-00/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/mi-sbox/common,k8s/mi-sbox/cluster-00/static,k8s/mi-sbox/cluster-00/static-overlay,k8s/mi-sbox/cluster-00/automated-overlay,k8s/common"
+      path: "k8s/mi-sbox/common,k8s/mi-sbox/cluster-00/static,k8s/mi-sbox/cluster-00/static-overlay,k8s/common"
       label: "mi-sbox-cluster-00"

--- a/k8s/mi-sbox/cluster-01/static-overlay/static/flux/flux.yaml
+++ b/k8s/mi-sbox/cluster-01/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/mi-sbox/common,k8s/mi-sbox/cluster-01/static,k8s/mi-sbox/cluster-01/static-overlay,k8s/mi-sbox/cluster-01/automated-overlay,k8s/common"
+      path: "k8s/mi-sbox/common,k8s/mi-sbox/cluster-01/static,k8s/mi-sbox/cluster-01/static-overlay,k8s/common"
       label: "mi-sbox-cluster-01"

--- a/k8s/papi-sbox/cluster-00/static-overlay/static/flux/flux.yaml
+++ b/k8s/papi-sbox/cluster-00/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/papi-sbox/common,k8s/papi-sbox/cluster-00/static,k8s/papi-sbox/cluster-00/static-overlay,k8s/papi-sbox/cluster-00/automated-overlay,k8s/common"
+      path: "k8s/papi-sbox/common,k8s/papi-sbox/cluster-00/static,k8s/papi-sbox/cluster-00/static-overlay,k8s/common"
       label: "papi-sbox-cluster-00"

--- a/k8s/papi-sbox/cluster-01/static-overlay/static/flux/flux.yaml
+++ b/k8s/papi-sbox/cluster-01/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/papi-sbox/common,k8s/papi-sbox/cluster-01/static,k8s/papi-sbox/cluster-01/static-overlay,k8s/papi-sbox/cluster-01/automated-overlay,k8s/common"
+      path: "k8s/papi-sbox/common,k8s/papi-sbox/cluster-01/static,k8s/papi-sbox/cluster-01/static-overlay,k8s/common"
       label: "papi-sbox-cluster-01"

--- a/k8s/sandbox/cluster-00/static-overlay/static/flux/flux.yaml
+++ b/k8s/sandbox/cluster-00/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/sandbox/common,k8s/sandbox/cluster-00/static,k8s/sandbox/cluster-00/static-overlay,k8s/sandbox/cluster-00/automated-overlay,k8s/common"
+      path: "k8s/sandbox/common,k8s/sandbox/cluster-00/static,k8s/sandbox/cluster-00/static-overlay,k8s/common"
       label: "sandbox-cluster-00"

--- a/k8s/sandbox/cluster-01/static-overlay/static/flux/flux.yaml
+++ b/k8s/sandbox/cluster-01/static-overlay/static/flux/flux.yaml
@@ -7,5 +7,5 @@ metadata:
 spec:
   values:
     git:
-      path: "k8s/sandbox/common,k8s/sandbox/cluster-01/static-overlay,k8s/sandbox/cluster-01/automated-overlay,k8s/common"
+      path: "k8s/sandbox/common,k8s/sandbox/cluster-01/static-overlay,k8s/common"
       label: "sandbox-cluster-01"


### PR DESCRIPTION
Remove automated overlay folder as flux isn't currently supporting multiple pacthes in single git path

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
