### PR TITLE
Update traefik aat to use ssl with no cert

### DIFF
--- a/k8s/aat/traefik/traefik.yaml
+++ b/k8s/aat/traefik/traefik.yaml
@@ -32,3 +32,5 @@ spec:
     startupArguments:
       - "--ping"
       - "--ping.entrypoint=http"
+      - --insecureskipverify
+      - --logLevel=DEBUG


### PR DESCRIPTION

### JIRA link (if applicable) ###

[[AB#244](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/244)]

### Change description ###

Update traefik aat to use ssl with no cert verification when talking to services. Needed by Neuvector controller


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```