### PR TITLE
Increase not ready time for kube-slack

### DIFF
--- a/k8s/common-base/admin/kube-slack/kube-slack.yaml
+++ b/k8s/common-base/admin/kube-slack/kube-slack.yaml
@@ -14,3 +14,6 @@ spec:
     version: 1.1.0
   valueFileSecrets:
     - name: "kube-slack-values"
+  values:
+    envVars:
+      NOT_READY_MIN_TIME: "180000"  # in ms


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
