### PR TITLE
update fluent bit image and chart

### DIFF
--- a/k8s/common-base/neuvector/fluentbit.yaml
+++ b/k8s/common-base/neuvector/fluentbit.yaml
@@ -11,12 +11,12 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: fluentbit-log
-    version: 0.0.4
+    version: 0.0.5
   values:
     image:
       registry: docker.io
       repository: fluent/fluent-bit
-      tag: 1.1.2
+      tag: 1.2.1
       imagePullPolicy: IfNotPresent
       logLevel: debug
     replicaCount: 1


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://dev.azure.com/hmcts/Platform%20Engineering/_workitems/edit/394

### Change description ###

Update fluent bit image to 1.2.1 and chart to 0.0.5 for all clusters

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[n] No
```
