### PR TITLE
updating traefik helm chart version

### DIFF
--- a/k8s/common-base/admin/traefik/traefik.yaml
+++ b/k8s/common-base/admin/traefik/traefik.yaml
@@ -10,9 +10,9 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: traefik
-    version: 1.61.1
+    version: 1.75.0
   values:
-    imageTag: 1.7.9
+    imageTag: 1.7.12
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDO-4598

### Change description ###

updating traefik helm chart to 1.75.0 from 1.61.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
