### PR TITLE
CMC bump chart after DB conns increased

### DIFF
--- a/k8s/demo/common/money-claims/cmc-demo.yaml
+++ b/k8s/demo/common/money-claims/cmc-demo.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: cmc
-    version: 0.0.5
+    version: 0.0.6
   values:
     ### CMC SERVICES ###
     cmc-claim-store:


### PR DESCRIPTION

### Change description ###

Run out of DB connections with update - too many new services grabbing conns. Doubled in chart to 300.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
