### PR TITLE
Point traefik ingress status to fwd auth

### DIFF
--- a/k8s/demo/cluster-00/static-overlay/static/traefik/traefik.yaml
+++ b/k8s/demo/cluster-00/static-overlay/static/traefik/traefik.yaml
@@ -6,5 +6,8 @@ metadata:
 spec:
   values:
     loadBalancerIP: 10.11.15.220
+    kubernetes:
+      ingressEndpoint:
+        ip: 51.143.184.251
     dashboard:
       domain: traefik00.demo.platform.hmcts.net

--- a/k8s/demo/demo-base/admin/traefik/traefik.yaml
+++ b/k8s/demo/demo-base/admin/traefik/traefik.yaml
@@ -8,10 +8,6 @@ spec:
   # valueFileSecrets:
   #   - name: "traefik-values"
   values:
-    service:
-    kubernetes:
-      ingressEndpoint:
-        useDefaultPublishedService: true
     ssl:
       enabled: true
       # enforced: true


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
The ingress status field isn't populated which is causing external-dns not to setup DNS, traefik is configured invalidly so trying to point it at forward auth to see if it works =/
```
$ kubectl get ingress -o yaml | grep status  -A 3
  status:
    loadBalancer: {}
kind: List
metadata:
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
