### PR TITLE
Tune draft-store config

### DIFF
--- a/k8s/aat/common/rpe/draft-store-service.yaml
+++ b/k8s/aat/common/rpe/draft-store-service.yaml
@@ -22,6 +22,9 @@ spec:
       cpuRequests: '500m'
       memoryLimits: '2048Mi'
       cpuLimits: '1000m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
       useInterpodAntiAffinity: true
       applicationInsightsInstrumentKey: "a2e12f21-e77a-4b9f-91f3-6e7b3867892e"
       image: hmctspublic.azurecr.io/draft-store/service:prod-ce1af948


### PR DESCRIPTION
Currently one instance is crash looping on AAT, logs look fine, wondering if it just can't start up in time

