### PR TITLE
Resolve app insights key correctly dg-docassembly

### DIFF
--- a/k8s/prod/common/dg/dg-docassembly.yaml
+++ b/k8s/prod/common/dg/dg-docassembly.yaml
@@ -18,6 +18,7 @@ spec:
   values:
     docassembly-api:
       replicas: 2
+      applicationInsightsInstrumentKey: "039faf8c-4682-432e-8fc5-f9735bb4b962"
       memoryRequests: '512Mi'
       cpuRequests: '250m'
       memoryLimits: '2048Mi'


### PR DESCRIPTION
The key coming from vault isn't being set correctly, no telemetry is being received currently