### PR TITLE
Use latest TYA Notif image

### DIFF
--- a/k8s/aat/common/sscs/sscs-tya-notif.yml
+++ b/k8s/aat/common/sscs/sscs-tya-notif.yml
@@ -22,7 +22,7 @@ spec:
       cpuLimits: '1500m'
       useInterpodAntiAffinity: true
       applicationInsightsInstrumentKey: "e2300a5f-a16f-4657-a63b-41913805661e"
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-e07d0898
+      image: hmctspublic.azurecr.io/sscs/tya-notif:latest
       aadIdentityName: sscs
     global:
       environment: aat


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-6617

I think in the original PR for the creation of TYA Notif, I didn't use the "latest" version, instead commiting a tag reference which I'm guessing I pulled from Azure.