### PR TITLE
Fix evidence share crashing on AAT

### DIFF
--- a/k8s/aat/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/aat/common/sscs/sscs-evidence-share.yaml
@@ -14,21 +14,13 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: sscs-evidence-share
-    version: 0.0.7
+    version: 0.0.8
   values:
     java:
       replicas: 2
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       useInterpodAntiAffinity: true
       applicationInsightsInstrumentKey: "e2300a5f-a16f-4657-a63b-41913805661e"
       image: hmctspublic.azurecr.io/sscs/evidence-share:prod-aa9377f5
-      environment:
-        JAVA_TOOL_OPTIONS: -XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0
-          -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -javaagent:/opt/app/applicationinsights-agent-2.5.0-BETA.5.jar
-      aadIdentityName: sscs
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
(Application insights agent was upgraded, no longer need to specify the version here)
