### PR TITLE
Updated blob storage key env var for prod

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -27,6 +27,7 @@ spec:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
         SCAN_DELAY: 300000
         REUPLOAD_DELAY: 600000
+        STORAGE_BLOB_PUBLIC_KEY: trusted_public_key.der
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-841

### Change description ###

- By default in charts we use the non prod public key, hence overriding here for prod.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
