### PR TITLE
fix:AM-api helm version reverted back to 0.0.5

### DIFF
--- a/k8s/aat/common/am/accessmgmt-api.yaml
+++ b/k8s/aat/common/am/accessmgmt-api.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: am-accessmgmt-api
-    version: 0.0.6
+    version: 0.0.5
   values:
     java:
       replicas: 2


### PR DESCRIPTION

### JIRA link (if applicable) ###
NA

### Change description ###
fix:AM-api helm version reverted back to 0.0.5

