### PR TITLE
Divorce - Increase Log Level for Backends

### DIFF
--- a/k8s/prod/common/divorce/div-dgs.yaml
+++ b/k8s/prod/common/divorce/div-dgs.yaml
@@ -35,6 +35,7 @@ spec:
         DOCMOSIS_SERVICE_DEV_MODE_FLAG: "false"
         PDF_TEST_ENABLED: "false"
         TEMP_ENV: "false"
+        ROOT_LOGGING_LEVEL: "DEBUG"
       aadIdentityName: divorce
       prometheus:
         enabled: true


### PR DESCRIPTION
### Change description ###

To debug an issue with a COS / DGS gateway timeout, which is only happening on Prod and not AAT. Possibly affects EMCA and CMS (to CCD) side as well so adding DEBUG level logs on those two apps as well.

EDIT: Only enabling on DGS for now to reduce bloat.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
