### PR TITLE
chore(update charts): update all idam web apps to version 0.2.1

### DIFF
--- a/k8s/preview/idam/idam-api.yaml
+++ b/k8s/preview/idam/idam-api.yaml
@@ -14,13 +14,12 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: idam-api
-    version: 0.2.0
+    version: 0.2.1
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-620be04d
       ingressHost: idam-api.service.core-compute-preview.internal
       replicas: 2
-      aadIdentityName: null
       environment:
         TESTING_SUPPORT_ENABLED: true
         IDAM_SPI_FORGEROCK_AM_ROOT: https://forgerock-am.service.core-compute-idam-preview.internal:8443/openam

--- a/k8s/preview/idam/idam-web-admin.yaml
+++ b/k8s/preview/idam/idam-web-admin.yaml
@@ -14,12 +14,11 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: idam-web-admin
-    version: 0.2.0
+    version: 0.2.1
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-admin:preview
       ingressHost: idam-web-admin.service.core-compute-preview.internal
-      aadIdentityName: null
     environment:
       STRATEGIC_SERVICE_URL: https://idam-api.service.core-compute-preview.internal
       STRATEGIC_PUBLIC_URL: https://idam-web-public.service.core-compute-preview.internal

--- a/k8s/preview/idam/idam-web-public.yaml
+++ b/k8s/preview/idam/idam-web-public.yaml
@@ -14,13 +14,12 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: idam-web-public
-    version: 0.2.0
+    version: 0.2.1
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-public:preview
       ingressHost: idam-web-public.service.core-compute-preview.internal
       replicas: 2
-      aadIdentityName: null
     environment:
       STRATEGIC_SERVICE_URL: https://idam-api.service.core-compute-preview.internal
     global:

--- a/k8s/sandbox/common/idam/idam-api.yaml
+++ b/k8s/sandbox/common/idam/idam-api.yaml
@@ -14,12 +14,13 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: idam-api
-    version: 0.2.0
+    version: 0.2.1
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:preview
       ingressHost: idam-api-aks.sandbox.platform.hmcts.net
       replicas: 2
+      aadIdentityName: idam
       environment:
         TESTING_SUPPORT_ENABLED: true
         IDAM_SPI_FORGEROCK_AM_ROOT: https://forgerock-am.service.core-compute-idam-saat.internal:8443/openam

--- a/k8s/sandbox/common/idam/idam-web-admin.yaml
+++ b/k8s/sandbox/common/idam/idam-web-admin.yaml
@@ -14,11 +14,12 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: idam-web-admin
-    version: 0.2.0
+    version: 0.2.1
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-admin:preview
       ingressHost: idam-web-admin-aks.sandbox.platform.hmcts.net
+      aadIdentityName: idam
     environment:
       STRATEGIC_SERVICE_URL: https://idam-api-aks.sandbox.platform.hmcts.net
       STRATEGIC_PUBLIC_URL: https://idam-web-public-aks.sandbox.platform.hmcts.net

--- a/k8s/sandbox/common/idam/idam-web-public.yaml
+++ b/k8s/sandbox/common/idam/idam-web-public.yaml
@@ -14,12 +14,13 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: idam-web-public
-    version: 0.2.0
+    version: 0.2.1
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-public:preview
       ingressHost: idam-web-public-aks.sandbox.platform.hmcts.net
       replicas: 2
+      aadIdentityName: idam
     environment:
       STRATEGIC_SERVICE_URL: https://idam-api-aks.sandbox.platform.hmcts.net
     global:


### PR DESCRIPTION
### Change description ###

Version 0.2.0 set the default value of aadIdentityName to idam. This requires the value to be unset for preivew where the KV credentials are kvcreds. In Jenkins this worked with `null` however this did not work in fluxs helmRelease. 

Version 0.2.1 leaves aadIdentityName undefined in each chart and instead defines it in each environment template.

https://github.com/hmcts/idam-api/pull/474
https://github.com/hmcts/idam-web-admin/pull/200
https://github.com/hmcts/idam-web-public/pull/238

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
