### PR TITLE
chore(http): use http only and K8s service discovery

### DIFF
--- a/k8s/preview/idam/idam-api.yaml
+++ b/k8s/preview/idam/idam-api.yaml
@@ -31,6 +31,9 @@ spec:
         SSL_TRUST_DNS_1: C=None,ST=None,L=None,OU=None,O=OpenDJ Self-Signed Certificate,CN=openidm-localhost
         SSL_TRUST_HOSTNAMES_0: forgerock-idm.service.core-compute-idam-preview.internal
         SSL_TRUST_HOSTNAMES_1: forgerock-am.service.core-compute-idam-preview.internal
+        STRATEGIC_ADMIN_URL: http://idam-web-admin
+        STRATEGIC_WEBPUBLIC_URL: http://idam-web-public
+        STRATEGIC_API_URL: http://idam-api
     global:
       environment: preview
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/preview/idam/idam-web-admin.yaml
+++ b/k8s/preview/idam/idam-web-admin.yaml
@@ -18,11 +18,11 @@ spec:
     java:
       image: hmctspublic.azurecr.io/idam/web-admin:preview
       ingressHost: idam-web-admin.service.core-compute-preview.internal
-    environment:
-      STRATEGIC_SERVICE_URL: https://idam-api.service.core-compute-preview.internal
-      STRATEGIC_PUBLIC_URL: https://idam-web-public.service.core-compute-preview.internal
-      SSL_VERIFICATION_ENABLED: false
-      FEIGN_HTTPCLIENT_DISABLE_SSL_VALIDATION: true
+      environment:
+        STRATEGIC_SERVICE_URL: http://idam-api
+        STRATEGIC_PUBLIC_URL: http://idam-web-public
+        SSL_VERIFICATION_ENABLED: false
+        FEIGN_HTTPCLIENT_DISABLE_SSL_VALIDATION: true
     global:
       environment: preview
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/preview/idam/idam-web-public.yaml
+++ b/k8s/preview/idam/idam-web-public.yaml
@@ -19,10 +19,10 @@ spec:
       image: hmctspublic.azurecr.io/idam/web-public:preview
       ingressHost: idam-web-public.service.core-compute-preview.internal
       replicas: 2
-    environment:
-      STRATEGIC_SERVICE_URL: https://idam-api.service.core-compute-preview.internal
-      SSL_VERIFICATION_ENABLED: false
-      ZUUL_SSLHOSTNAMEVALIDATIONENABLED: false
+      environment:
+        STRATEGIC_SERVICE_URL: http://idam-api
+        SSL_VERIFICATION_ENABLED: false
+        ZUUL_SSLHOSTNAMEVALIDATIONENABLED: false
     global:
       environment: preview
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

The DNS records for service.core-compute-preview.internal are not resolving currently.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
