### PR TITLE
migrate CFS to AKS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -66,6 +66,7 @@ k8s/**/common/divorce/div-cms.yaml @hmcts/divorce
 k8s/**/common/divorce/div-dgs.yaml @hmcts/divorce
 k8s/**/common/divorce/div-cos.yaml @hmcts/divorce
 k8s/**/common/divorce/div-fps.yaml @hmcts/divorce
+k8s/**/common/divorce/div-cfs.yaml @hmcts/divorce
 k8s/**/common/divorce/div-hm.yaml @hmcts/divorce
 
 ## Financial Remedy

--- a/k8s/aat/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-00/divorce/div-cfs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: div-cfs
+  namespace: divorce
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: div-cfs
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: div-cfs
+    version: 1.3.0
+  values:
+    java:
+      replicas: 0
+      memoryRequests: '512Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '1500m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
+      image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
+      environment:
+        REFORM_SERVICE_NAME: "cfs"
+        REFORM_TEAM: "div"
+        SLOT: "PRODUCTION"
+      aadIdentityName: divorce
+      prometheus:
+        enabled: true
+    global:
+      environment: aat
+      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/aat/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-00/divorce/div-cfs.yaml
@@ -32,6 +32,9 @@ spec:
         REFORM_SERVICE_NAME: "cfs"
         REFORM_TEAM: "div"
         SLOT: "PRODUCTION"
+        DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-aat.service.core-compute-aat.internal"
+        REFORM_ENVIRONMENT: "aat"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/aat/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-00/divorce/div-cfs.yaml
@@ -29,9 +29,6 @@ spec:
       applicationInsightsInstrumentKey: "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
       image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
       environment:
-        REFORM_SERVICE_NAME: "cfs"
-        REFORM_TEAM: "div"
-        SLOT: "PRODUCTION"
         DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-aat.service.core-compute-aat.internal"
         REFORM_ENVIRONMENT: "aat"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/k8s/aat/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-00/divorce/div-cfs.yaml
@@ -18,10 +18,6 @@ spec:
   values:
     java:
       replicas: 0
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
@@ -37,6 +33,5 @@ spec:
         enabled: true
     global:
       environment: aat
-      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/aat/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-01/divorce/div-cfs.yaml
@@ -32,6 +32,9 @@ spec:
         REFORM_SERVICE_NAME: "cfs"
         REFORM_TEAM: "div"
         SLOT: "PRODUCTION"
+        DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-aat.service.core-compute-aat.internal"
+        REFORM_ENVIRONMENT: "aat"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/aat/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-01/divorce/div-cfs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: div-cfs
+  namespace: divorce
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: div-cfs
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: div-cfs
+    version: 1.3.0
+  values:
+    java:
+      replicas: 2
+      memoryRequests: '512Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '1500m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
+      image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
+      environment:
+        REFORM_SERVICE_NAME: "cfs"
+        REFORM_TEAM: "div"
+        SLOT: "PRODUCTION"
+      aadIdentityName: divorce
+      prometheus:
+        enabled: true
+    global:
+      environment: aat
+      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/aat/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-01/divorce/div-cfs.yaml
@@ -29,9 +29,6 @@ spec:
       applicationInsightsInstrumentKey: "63c30ef9-a27b-4d38-8afc-4c180fb6ac33"
       image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
       environment:
-        REFORM_SERVICE_NAME: "cfs"
-        REFORM_TEAM: "div"
-        SLOT: "PRODUCTION"
         DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-aat.service.core-compute-aat.internal"
         REFORM_ENVIRONMENT: "aat"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/k8s/aat/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/aat/cluster-01/divorce/div-cfs.yaml
@@ -18,10 +18,6 @@ spec:
   values:
     java:
       replicas: 2
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
@@ -37,6 +33,5 @@ spec:
         enabled: true
     global:
       environment: aat
-      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/ithc/common/divorce/div-cfs.yaml
+++ b/k8s/ithc/common/divorce/div-cfs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: div-cfs
+  namespace: divorce
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: div-cfs
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: div-cfs
+    version: 1.3.0
+  values:
+    java:
+      replicas: 2
+      memoryRequests: '512Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '1500m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "a4744b45-c8de-4b9d-aaad-f99dc84bec93"
+      image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
+      environment:
+        REFORM_SERVICE_NAME: "cfs"
+          REFORM_TEAM: "div"
+          SLOT: "PRODUCTION"
+      aadIdentityName: divorce
+      prometheus:
+        enabled: true
+    global:
+      environment: ithc
+      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/ithc/common/divorce/div-cfs.yaml
+++ b/k8s/ithc/common/divorce/div-cfs.yaml
@@ -29,12 +29,9 @@ spec:
       applicationInsightsInstrumentKey: "a4744b45-c8de-4b9d-aaad-f99dc84bec93"
       image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
       environment:
-        REFORM_SERVICE_NAME: "cfs"
-          REFORM_TEAM: "div"
-          SLOT: "PRODUCTION"
-          DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-ithc.service.core-compute-ithc.internal"
-          REFORM_ENVIRONMENT: "ithc"
-          MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
+        DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-ithc.service.core-compute-ithc.internal"
+        REFORM_ENVIRONMENT: "ithc"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/ithc/common/divorce/div-cfs.yaml
+++ b/k8s/ithc/common/divorce/div-cfs.yaml
@@ -32,6 +32,9 @@ spec:
         REFORM_SERVICE_NAME: "cfs"
           REFORM_TEAM: "div"
           SLOT: "PRODUCTION"
+          DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-ithc.service.core-compute-ithc.internal"
+          REFORM_ENVIRONMENT: "ithc"
+          MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/ithc/common/divorce/div-cfs.yaml
+++ b/k8s/ithc/common/divorce/div-cfs.yaml
@@ -18,10 +18,6 @@ spec:
   values:
     java:
       replicas: 2
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
@@ -37,6 +33,5 @@ spec:
         enabled: true
     global:
       environment: ithc
-      subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/perftest/common/divorce/div-cfs.yaml
+++ b/k8s/perftest/common/divorce/div-cfs.yaml
@@ -29,9 +29,6 @@ spec:
       applicationInsightsInstrumentKey: "eddbcec4-6ebc-4507-9f22-38d53a92e761"
       image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
       environment:
-        REFORM_SERVICE_NAME: "cfs"
-        REFORM_TEAM: "div"
-        SLOT: "PRODUCTION"
         DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-perftest.service.core-compute-perftest.internal"
         REFORM_ENVIRONMENT: "perftest"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/k8s/perftest/common/divorce/div-cfs.yaml
+++ b/k8s/perftest/common/divorce/div-cfs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: div-cfs
+  namespace: divorce
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: div-cfs
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: div-cfs
+    version: 1.3.0
+  values:
+    java:
+      replicas: 2
+      memoryRequests: '512Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '1500m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "eddbcec4-6ebc-4507-9f22-38d53a92e761"
+      image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
+      environment:
+        REFORM_SERVICE_NAME: "cfs"
+        REFORM_TEAM: "div"
+        SLOT: "PRODUCTION"
+      aadIdentityName: divorce
+      prometheus:
+        enabled: true
+    global:
+      environment: perftest
+      subscriptionId: "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/perftest/common/divorce/div-cfs.yaml
+++ b/k8s/perftest/common/divorce/div-cfs.yaml
@@ -32,6 +32,9 @@ spec:
         REFORM_SERVICE_NAME: "cfs"
         REFORM_TEAM: "div"
         SLOT: "PRODUCTION"
+        DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-perftest.service.core-compute-perftest.internal"
+        REFORM_ENVIRONMENT: "perftest"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/perftest/common/divorce/div-cfs.yaml
+++ b/k8s/perftest/common/divorce/div-cfs.yaml
@@ -18,10 +18,6 @@ spec:
   values:
     java:
       replicas: 2
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
@@ -37,6 +33,5 @@ spec:
         enabled: true
     global:
       environment: perftest
-      subscriptionId: "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/prod/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-00/divorce/div-cfs.yaml
@@ -29,9 +29,6 @@ spec:
       applicationInsightsInstrumentKey: "baaed5d0-7666-4dce-bf74-edfceeb566f9"
       image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
       environment:
-        REFORM_SERVICE_NAME: "cfs"
-        REFORM_TEAM: "div"
-        SLOT: "PRODUCTION"
         DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-prod.service.core-compute-prod.internal"
         REFORM_ENVIRONMENT: "prod"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/k8s/prod/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-00/divorce/div-cfs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: div-cfs
+  namespace: divorce
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: div-cfs
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: div-cfs
+    version: 1.3.0
+  values:
+    java:
+      replicas: 0
+      memoryRequests: '512Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '1500m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "baaed5d0-7666-4dce-bf74-edfceeb566f9"
+      image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
+      environment:
+        REFORM_SERVICE_NAME: "cfs"
+        REFORM_TEAM: "div"
+        SLOT: "PRODUCTION"
+      aadIdentityName: divorce
+      prometheus:
+        enabled: true
+    global:
+      environment: prod
+      subscriptionId: "8999dec3-0104-4a27-94ee-6588559729d1"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/prod/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-00/divorce/div-cfs.yaml
@@ -32,6 +32,9 @@ spec:
         REFORM_SERVICE_NAME: "cfs"
         REFORM_TEAM: "div"
         SLOT: "PRODUCTION"
+        DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-prod.service.core-compute-prod.internal"
+        REFORM_ENVIRONMENT: "prod"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/prod/cluster-00/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-00/divorce/div-cfs.yaml
@@ -18,10 +18,6 @@ spec:
   values:
     java:
       replicas: 0
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
@@ -37,6 +33,5 @@ spec:
         enabled: true
     global:
       environment: prod
-      subscriptionId: "8999dec3-0104-4a27-94ee-6588559729d1"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/prod/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-01/divorce/div-cfs.yaml
@@ -29,9 +29,6 @@ spec:
       applicationInsightsInstrumentKey: "baaed5d0-7666-4dce-bf74-edfceeb566f9"
       image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
       environment:
-        REFORM_SERVICE_NAME: "cfs"
-        REFORM_TEAM: "div"
-        SLOT: "PRODUCTION"
         DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-prod.service.core-compute-prod.internal"
         REFORM_ENVIRONMENT: "prod"
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/k8s/prod/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-01/divorce/div-cfs.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: div-cfs
+  namespace: divorce
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: div-cfs
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: div-cfs
+    version: 1.3.0
+  values:
+    java:
+      replicas: 2
+      memoryRequests: '512Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '1500m'
+      readinessDelay: 45
+      readinessTimeout: 5
+      readinessPeriod: 15
+      useInterpodAntiAffinity: true
+      applicationInsightsInstrumentKey: "baaed5d0-7666-4dce-bf74-edfceeb566f9"
+      image: hmctspublic.azurecr.io/div/cfs:prod-f3004785
+      environment:
+        REFORM_SERVICE_NAME: "cfs"
+        REFORM_TEAM: "div"
+        SLOT: "PRODUCTION"
+      aadIdentityName: divorce
+      prometheus:
+        enabled: true
+    global:
+      environment: prod
+      subscriptionId: "8999dec3-0104-4a27-94ee-6588559729d1"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/prod/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-01/divorce/div-cfs.yaml
@@ -32,6 +32,9 @@ spec:
         REFORM_SERVICE_NAME: "cfs"
         REFORM_TEAM: "div"
         SLOT: "PRODUCTION"
+        DOCUMENT_MANAGEMENT_STORE_URL: "http://dm-store-prod.service.core-compute-prod.internal"
+        REFORM_ENVIRONMENT: "prod"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
       aadIdentityName: divorce
       prometheus:
         enabled: true

--- a/k8s/prod/cluster-01/divorce/div-cfs.yaml
+++ b/k8s/prod/cluster-01/divorce/div-cfs.yaml
@@ -18,10 +18,6 @@ spec:
   values:
     java:
       replicas: 2
-      memoryRequests: '512Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
@@ -37,6 +33,5 @@ spec:
         enabled: true
     global:
       environment: prod
-      subscriptionId: "8999dec3-0104-4a27-94ee-6588559729d1"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true


### PR DESCRIPTION
Migrate CFS to AKS.

This was meant to be extracted into a lib, but we didn't have enough time to test this solution so we now need to migrate into AKS in terms of creating AKS demo env.
