### PR TITLE
Add identity of blob-router component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -162,3 +162,8 @@ k8s/**/common/bsp/bulk-scan-processor.yaml @hmcts/platform-engineering @hmcts/bu
 k8s/aat/common/bsp/bulk-scan-orchestrator.yaml @hmcts/platform-engineering @hmcts/bulk-scan
 k8s/aat/common/bsp/bulk-scan-sample-app.yaml @hmcts/platform-engineering @hmcts/bulk-scan
 k8s/demo/common/bsp/bsp-demo.yaml @hmcts/bulk-scan
+
+### BSP but separate namespace and identity
+k8s/**/common/reform-scan/namespace.yaml @hmcts/bulk-scan
+k8s/**/common/reform-scan/identity.yaml @hmcts/bulk-scan
+k8s/**/common/reform-scan/blob-router.yaml @hmcts/bulk-scan

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -166,4 +166,4 @@ k8s/demo/common/bsp/bsp-demo.yaml @hmcts/bulk-scan
 ### BSP but separate namespace and identity
 k8s/**/common/reform-scan/namespace.yaml @hmcts/bulk-scan
 k8s/**/common/reform-scan/identity.yaml @hmcts/bulk-scan
-k8s/**/common/reform-scan/blob-router.yaml @hmcts/bulk-scan
+k8s/aat/common/reform-scan/blob-router.yaml @hmcts/bulk-scan

--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: flux.weave.works/v1beta1
+kind: HelmRelease
+metadata:
+  name: reform-scan-blob-router
+  namespace: reform-scan
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.java: glob:prod-*
+spec:
+  releaseName: reform-scan-blob-router
+  rollback:
+    enable: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: blob-router-service
+    version: 0.0.1
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/hmcts/blob-router-service:latest
+    global:
+      environment: aat
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -19,7 +19,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/hmcts/blob-router-service:latest
+      image: hmctspublic.azurecr.io/reform-scan/blob-router:latest
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -13,7 +13,7 @@ spec:
     enable: true
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: blob-router-service
+    name: reform-scan-blob-router
     version: 0.0.1
   values:
     java:

--- a/k8s/aat/common/reform-scan/identity.yaml
+++ b/k8s/aat/common/reform-scan/identity.yaml
@@ -1,0 +1,20 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: reform-scan
+  namespace: reform-scan
+spec:
+  type: 0
+  ResourceID: "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/reform-scan-aat-mi"
+  ClientID: "ad5a1130-3cb8-468a-8d6d-4e188f11b613"
+
+---
+
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: reform-scan-binding
+  namespace: reform-scan
+spec:
+  AzureIdentity: reform-scan
+  Selector: reform-scan

--- a/k8s/aat/common/reform-scan/namespace.yaml
+++ b/k8s/aat/common/reform-scan/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reform-scan
+---

--- a/k8s/perftest/common/reform-scan/identity.yaml
+++ b/k8s/perftest/common/reform-scan/identity.yaml
@@ -1,0 +1,20 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: reform-scan
+  namespace: reform-scan
+spec:
+  type: 0
+  ResourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/reform-scan-perftest-mi"
+  ClientID: "72c210b0-bcb7-4c7a-8bf5-25abcd131180"
+
+---
+
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: reform-scan-binding
+  namespace: reform-scan
+spec:
+  AzureIdentity: reform-scan
+  Selector: reform-scan

--- a/k8s/perftest/common/reform-scan/namespace.yaml
+++ b/k8s/perftest/common/reform-scan/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reform-scan
+---


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Router: Create a new Micro service](https://tools.hmcts.net/jira/browse/BPS-794)

### Change description ###

Adding default scripts generated with script. Including `blob-router` component. Please review it with care as I am not 100% sure put down correct values:

- jar in repo will be `blob-router-service.jar`
- docker published (i believe) to `hmcts/blob-router-service`. perhaps best to make it `reform-scan/blob-router` instead?
- azule cloud related stuff:
  - product: `reform-scan`
  - component: `blob-router`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
