### PR TITLE
Bump BSP processor on AAT to latest

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-processor.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.4
+    version: 0.2.7
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

processor jumped to 2.13 java chart which increases CPU. once it proves the problem solving situation - all bsp things shoudl migrate shortly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
