### PR TITLE
increase def store mem to allow imports

### DIFF
--- a/k8s/demo/common/ccd/latest-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/latest-ccd-chart.yaml
@@ -85,7 +85,11 @@ spec:
           ADMINWEB_WHOAMI_URL: '{{ .Values.global.ccdDefinitionStoreUrl }}/api/idam/profile'
           ADMINWEB_IMPORT_AUDITS_URL: '{{ .Values.global.ccdDefinitionStoreUrl }}/api/import-audits'
           ADMINWEB_AUTHORIZATION_URL: '{{ .Values.global.ccdDefinitionStoreUrl }}/api/idam/adminweb/authorization'
-    
+    ccd-definition-store-api:
+      java:
+        memoryRequests: "1G"
+        memoryLimits: "2G"
+
     # CCD Supporting services
     ccd-case-print-service:
       nodejs:


### PR DESCRIPTION
Imports are failing on CCD Demo with the following:
{"timestamp":"2019-10-29T13:07:53.189+0000","status":500,"error":"Internal Server Error","message":"GC overhead limit exceeded","path":"/import"}
Trying to give more mem to see if that fixes the issue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
