### PR TITLE
Fix sandbox prometheus issue

### DIFF
--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -47,4 +47,4 @@ spec:
     prometheus:
       ingress: 
         enabled: true
-        hosts: prometheus-00.service.core-compute-sandbox.internal
+        hosts: [prometheus-00.service.core-compute-sandbox.internal]

--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -49,3 +49,6 @@ spec:
         enabled: true
         hosts: 
           - prometheus-00.service.core-compute-sandbox.internal
+    
+    prometheusOperator:
+      createCustomResource: false

--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -49,9 +49,7 @@ spec:
         enabled: true
         hosts: 
           - prometheus-00.service.core-compute-sandbox.internal
-<<<<<<< HEAD
-    
+          
     prometheusOperator:
       createCustomResource: false
-=======
->>>>>>> master
+

--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -47,4 +47,5 @@ spec:
     prometheus:
       ingress: 
         enabled: true
-        hosts: [prometheus-00.service.core-compute-sandbox.internal]
+        hosts: 
+          - prometheus-00.service.core-compute-sandbox.internal

--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -47,4 +47,5 @@ spec:
     prometheus:
       ingress: 
         enabled: true
-        hosts: [prometheus-01.service.core-compute-sandbox.internal]
+        hosts: 
+          - prometheus-01.service.core-compute-sandbox.internal

--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -47,4 +47,4 @@ spec:
     prometheus:
       ingress: 
         enabled: true
-        hosts: prometheus-01.service.core-compute-sandbox.internal
+        hosts: [prometheus-01.service.core-compute-sandbox.internal]


### PR DESCRIPTION
# JIRA link (if applicable) ###

[AB#504](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/504)

### Change description ###

Disabled CRD creation for prometheus-operator on Sbox00. Tried uninstalling the chart and  came across a known issue. Attempting to fix this as described in the uninstall guidelines by disabling the creation of CRDs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
