### PR TITLE
Fixing up IA config after updating chart config

### DIFF
--- a/k8s/aat/common/ia/case-documents-api.yaml
+++ b/k8s/aat/common/ia/case-documents-api.yaml
@@ -14,15 +14,13 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: ia-case-documents-api
-    version: 0.0.4
+    version: 0.0.5
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ia/case-documents-api:prod-94bf9e43
       ingressHost: ia-case-documents-api-aat.service.core-compute-aat.internal
-      aadIdentityName: ia
-      applicationInsightsInstrumentKey: "bf7eeffe-bd72-4350-b336-cf4020806c02"
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/aat/common/ia/case-notifications-api.yaml
+++ b/k8s/aat/common/ia/case-notifications-api.yaml
@@ -15,15 +15,13 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: ia-case-notifications-api
-    version: 0.0.3
+    version: 0.0.4
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ia/case-notifications-api:prod-a5e6e59d
       ingressHost: ia-case-notifications-api-aat.service.core-compute-aat.internal
-      aadIdentityName: ia
-      applicationInsightsInstrumentKey: "bf7eeffe-bd72-4350-b336-cf4020806c02"
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/prod/common/ia/case-documents-api.yaml
+++ b/k8s/prod/common/ia/case-documents-api.yaml
@@ -14,11 +14,10 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: ia-case-documents-api
-    version: 0.0.4
+    version: 0.0.5
   values:
     java:
       replicas: 2
-      applicationInsightsInstrumentKey: "71f1292c-eadf-4ea9-8444-b82a6b09405a"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ia/case-documents-api:prod-94bf9e43
       ingressHost: ia-case-documents-api-prod.service.core-compute-prod.internal
@@ -27,7 +26,6 @@ spec:
         RESTART_ME: "Update due to vault change"
       prometheus:
         enabled: true
-      aadIdentityName: ia
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/prod/common/ia/case-notifications-api.yaml
+++ b/k8s/prod/common/ia/case-notifications-api.yaml
@@ -14,11 +14,10 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: ia-case-notifications-api
-    version: 0.0.3
+    version: 0.0.4
   values:
     java:
       replicas: 2
-      applicationInsightsInstrumentKey: "71f1292c-eadf-4ea9-8444-b82a6b09405a"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ia/case-notifications-api:prod-a5e6e59d
       ingressHost: ia-case-notifications-api-prod.service.core-compute-prod.internal
@@ -27,7 +26,6 @@ spec:
         RESTART_ME: "Update due to vault change"
       prometheus:
         enabled: true
-      aadIdentityName: ia
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
After updating docs and notification api charts to include Appinisightskey and identityName we can remove from here.

Refer to:
https://github.com/hmcts/ia-case-notifications-api/pull/91
https://github.com/hmcts/ia-case-documents-api/pull/87