### PR TITLE
Re-enabled CRD creation for Prometheus Operator

### DIFF
--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -49,7 +49,3 @@ spec:
         enabled: true
         hosts: 
           - prometheus-00.service.core-compute-sandbox.internal
-          
-    prometheusOperator:
-      createCustomResource: false
-


### PR DESCRIPTION

### JIRA link (if applicable) ###

[AB#504](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/504)

### Change description ###

Re-enabled CRD creation for Prometheus Operator. This was previously disabled due to a known issue caused by manually removing the release. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
