### PR TITLE
Not validate ocr data for probate on prod

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.11
+    version: 0.2.12
   values:
     java:
       replicas: 2
@@ -31,6 +31,8 @@ spec:
         REUPLOAD_DELAY: 600000
         STORAGE_BLOB_PUBLIC_KEY: trusted_public_key.der
         ERROR_NOTIFICATIONS_ENABLED: true
+        # remove following once onboarded
+        OCR_VALIDATION_URL_PROBATE: ""
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

Config used to be on AAT but not PROD. Since hmcts/bulk-scan-processor#935 is for all - silencing here

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
