### PR TITLE
Added alertmanager config to Sbox01

### DIFF
--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -49,3 +49,9 @@ spec:
         enabled: true
         hosts: 
           - prometheus-01.service.core-compute-sandbox.internal
+
+    alertmanager:
+      alertmanagerSpec: 
+        secrets:
+          - name: slackapi-url-secret   
+


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#504](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/504)

### Change description ###

Added alert manager config to sandbox for testing purposes. This should make the existing secrets in the monitoring namespace available in the alert manager pods.  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
