### PR TITLE
Bump chart-bulk-scan to v0.1.5 in standalone processor

### DIFF
--- a/k8s/demo/common/bsp/standalone-processor.yaml
+++ b/k8s/demo/common/bsp/standalone-processor.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan
-    version: 0.1.4
+    version: 0.1.5
   values:
     bulk-scan-processor:
       java:


### PR DESCRIPTION
### Change description ###

Bump chart-bulk-scan to v0.1.5 in standalone processor, which has the latest java chart

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
