### PR TITLE
Copy same configuration as `bsp-demo`

### DIFF
--- a/k8s/demo/common/bsp/bsp-sample-app.yaml
+++ b/k8s/demo/common/bsp/bsp-sample-app.yaml
@@ -6,7 +6,14 @@ metadata:
   namespace: bsp
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.div-fps: glob:prod-*
+    repository.fluxcd.io/bulk-scan-processor: bulk-scan-processor.java.image
+    filter.fluxcd.io/bulk-scan-processor: glob:prod-*
+    repository.fluxcd.io/bulk-scan-orchestrator: bulk-scan-orchestrator.java.image
+    filter.fluxcd.io/bulk-scan-orchestrator: glob:prod-*
+    repository.fluxcd.io/rpe-service-auth-provider: rpe-service-auth-provider.java.image
+    filter.fluxcd.io/rpe-service-auth-provider: glob:prod-*
+    repository.fluxcd.io/dm-store: dm-store.java.image
+    filter.fluxcd.io/dm-store: glob:prod-*
 spec:
   releaseName: bsp-sample-app
   timeout: 900
@@ -20,5 +27,54 @@ spec:
     version: 1.0.0
   values:
     global:
+      idamApiUrl: "https://idam-api.demo.platform.hmcts.net"
+      idamWebUrl: idam-web-public.demo.platform.hmcts.net
+      ccdDataStoreUrl: "http://ccd-data-store"
+    ccd:
+      postgresql:
+        enabled: false
+      rpeServiceAuthProvider:
+        enabled: true
+      draftStoreService:
+        enabled: false
+      dmStore:
+        enabled: false
+      paymentApi:
+        enabled: false
+      managementWeb:
+        enabled: false
+      apiGatewayWeb:
+        enabled: false
+      adminWeb:
+        enabled: false
+      printService:
+        enabled: false
+      activityApi:
+        enabled: false
+      testStubsService:
+        enabled: false
     bulkscan:
       enabled: true
+      ccd:
+        enabled: true
+    bulk-scan-processor:
+      java:
+        image: hmctspublic.azurecr.io/bulk-scan/processor:prod-732e2ec3
+    bulk-scan-orchestrator:
+      java:
+        image: hmctspublic.azurecr.io/bulk-scan/orchestrator:prod-5cdc3187
+    rpe-service-auth-provider:
+      java:
+        image: hmctspublic.azurecr.io/rpe/service-auth-provider:prod-1a7aed61
+    dm-store:
+      java:
+        image: hmctspublic.azurecr.io/dm/store:prod-88368b8e
+    postgresql:
+      initdbScripts:
+        init.sql: |-
+          CREATE DATABASE "data-store" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
+          CREATE DATABASE "definition-store" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
+          CREATE DATABASE "user-profile" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
+          CREATE DATABASE "draftstore" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
+          CREATE DATABASE "payment_api" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
+          CREATE DATABASE "evidence" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Add Sample App to bulk-scan product chart](https://tools.hmcts.net/jira/browse/BPS-882)

### Change description ###

errors:

- `MountVolume.SetUp failed for volume "custom-init-scripts" : configmap "bsp-sample-app-postgresql-init-scripts" not found`
- `Error: cannot find volume "default-token-76r7t" to mount into container "bsp-sample-app-s2s"`
- `Error: secret "servicebus-secret-namespace-bsp-sample-app-sb" not found`

not sure about servicebus errors. ideally bulk scan should provide all this by default so chart inclusion is minimally disruptive. open to comments/suggestions

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
