### PR TITLE
Disable case loader cron on cluster 01

### DIFF
--- a/k8s/prod/cluster-00/sscs/sscs-case-loader.yaml
+++ b/k8s/prod/cluster-00/sscs/sscs-case-loader.yaml
@@ -17,7 +17,7 @@ spec:
     version: 0.0.3
   values:
     job:
-      schedule: "0 0/4 * * *"
+      schedule: "0 0/1 * * *"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/case-loader:prod-edafa11b
       startingDeadlineSeconds: 1800

--- a/k8s/prod/cluster-01/sscs/sscs-case-loader.yaml
+++ b/k8s/prod/cluster-01/sscs/sscs-case-loader.yaml
@@ -17,7 +17,7 @@ spec:
     version: 0.0.3
   values:
     job:
-      schedule: "0 2/4 * * *"
+      schedule: "0 2 31 2 *"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/case-loader:prod-edafa11b
       startingDeadlineSeconds: 1800


### PR DESCRIPTION
We have 2 clusters running 2 versions of the case loader. The 2 clusters have no knowledge of each other. If both clusters were to run at the same time then that could be disastrous for us as the case updates could potentially get processed in the wrong order.

Therefore, set one of the clusters to only fire on 31st Feb so should never execute. If we need to switch the clusters for any reason in the future then just swap the CRON expressions. 