### PR TITLE
Added alertmanager ingress to sandbox

### DIFF
--- a/k8s/mgmt-sandbox/common/monitoring/prom-operator.yaml
+++ b/k8s/mgmt-sandbox/common/monitoring/prom-operator.yaml
@@ -95,3 +95,21 @@ spec:
             datasource: Prometheus
           Spring-Boot:
             url: https://gist.githubusercontent.com/timja/665f0c6cbd33120c88e91af67701954d/raw/eef2718e0d3e007a8476ac2cd34c04ef6724387d/spring-boot-dashboard.json
+
+    alertmanager:
+      ingress:
+        enabled: true
+        hosts:
+          - alertmanager-mgmt-sbox.sandbox.platform.hmcts.net
+      config:
+        route:
+          receiver: 'slack_alerting'
+          routes:
+          - match:
+              alertname: Watchdog
+            receiver: "slack_alerting"        
+        receivers:
+        - name: 'slack_alerting'
+          slack_configs:
+          - channel: prometheus-alerting
+            text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"         

--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -14,6 +14,8 @@ spec:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: prometheus-operator
     version: 8.2.0
+  valueFileSecrets:
+  - name: "prometheus-values"
   values:
     defaultRules:
       create: true
@@ -57,3 +59,21 @@ spec:
         serviceMonitorSelector:
           matchLabels:
             heritage: Tiller
+
+    alertmanager:
+      ingress:
+        enabled: true
+        hosts:
+          - alertmanager-00.sandbox.platform.hmcts.net
+      config:
+        route:
+          receiver: 'slack_alerting'
+          routes:
+          - match:
+              alertname: Watchdog
+            receiver: "slack_alerting"        
+        receivers:
+        - name: 'slack_alerting'
+          slack_configs:
+          - channel: prometheus-alerting
+            text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"

--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -14,8 +14,6 @@ spec:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: prometheus-operator
     version: 8.2.0
-  valueFileSecrets:
-  - name: "prometheus-values"
   values:
     defaultRules:
       create: true
@@ -65,15 +63,3 @@ spec:
         enabled: true
         hosts:
           - alertmanager-00.sandbox.platform.hmcts.net
-      config:
-        route:
-          receiver: 'slack_alerting'
-          routes:
-          - match:
-              alertname: Watchdog
-            receiver: "slack_alerting"        
-        receivers:
-        - name: 'slack_alerting'
-          slack_configs:
-          - channel: prometheus-alerting
-            text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"

--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -71,6 +71,10 @@ spec:
       createCustomResource: false
 
     alertmanager:
+      ingress:
+        enabled: true
+        hosts:
+          - alertmanager-01.sandbox.platform.hmcts.net
       config:
         route:
           receiver: 'slack_alerting'


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#655](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/655)

### Change description ###

Added AlertManager Ingress to Sandbox clusters. The dashboard will be accessible via the URL in the Slack alerts. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
