### PR TITLE
Updated Slack receiver output

### DIFF
--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -86,6 +86,7 @@ spec:
         - name: 'slack_alerting'
           slack_configs:
           - channel: prometheus-alerting
+            title_link: "http://alertmanager-01.sandbox.platform.hmcts.net/#/alerts"
             text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
 
 


### PR DESCRIPTION
# JIRA link (if applicable) ###

[AB#655](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/655)

### Change description ###

Updated Slack receiver configuration in alertmanager for sbox01. The Alertmanager dashboard url should now be actionable in the Slack alerts. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
