### PR TITLE
Rdm 6566 -fix app insight error

### DIFF
--- a/k8s/demo/common/ccd/ccd-demo-three.yaml
+++ b/k8s/demo/common/ccd/ccd-demo-three.yaml
@@ -28,6 +28,7 @@ spec:
 #     TODO remove protocol to allow better reusability?
       idamApiUrl: https://idam-api.demo.platform.hmcts.net
       idamWebUrl: https://idam-web-public.demo.platform.hmcts.net
+      devMode: true
 
     ccd-api-gateway-web:
       nodejs:

--- a/k8s/demo/common/ccd/ccd-demo-three.yaml
+++ b/k8s/demo/common/ccd/ccd-demo-three.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     name: ccd
-    version: 4.0.0-rc.2
+    version: 4.0.0-rc.7
   values:
     tags:
       idam-pr: true

--- a/k8s/demo/common/ccd/latest-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/latest-ccd-chart.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ccd-demo
   namespace: ccd
   annotations:
-    flux.weave.works/automated: 'false'
+    flux.weave.works/automated: 'true'
     flux.weave.works/tag.java: 'glob:prod-*'
 spec:
   releaseName: ccd-demo
@@ -17,7 +17,7 @@ spec:
   chart:
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     name: ccd
-    version: 4.0.0-rc.6
+    version: 4.0.0-rc.7
   values:
     tags:
       idam-pr: true

--- a/k8s/demo/common/ccd/latest-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/latest-ccd-chart.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ccd-demo
   namespace: ccd
   annotations:
-    flux.weave.works/automated: 'true'
+    flux.weave.works/automated: 'false'
     flux.weave.works/tag.java: 'glob:prod-*'
 spec:
   releaseName: ccd-demo

--- a/k8s/demo/common/ccd/latest-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/latest-ccd-chart.yaml
@@ -28,6 +28,7 @@ spec:
 #     TODO remove protocol to allow better reusability?
       idamApiUrl: https://idam-api.demo.platform.hmcts.net
       idamWebUrl: https://idam-web-public.demo.platform.hmcts.net
+      devMode: true
 
     ccd-api-gateway-web:
       nodejs:

--- a/k8s/demo/common/ccd/second-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/second-ccd-chart.yaml
@@ -28,6 +28,7 @@ spec:
 #     TODO remove protocol to allow better reusability?
       idamApiUrl: https://idam-api.demo.platform.hmcts.net
       idamWebUrl: https://idam-web-public.demo.platform.hmcts.net
+      devMode: true
 
     ccd-api-gateway-web:
       nodejs:

--- a/k8s/demo/common/ccd/second-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/second-ccd-chart.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     name: ccd
-    version: 4.0.0-rc.2
+    version: 4.0.0-rc.7
   values:
     tags:
       idam-pr: true


### PR DESCRIPTION

### Change description ###
Fix for the following error
Parameter 0 of constructor in uk.gov.hmcts.ccd.AppInsights required a bean of type 'com.microsoft.applicationinsights.TelemetryClient' that could not be found.
The following candidates were found but could not be injected:
    - Bean method 'telemetryClient' in 'ApplicationInsightsTelemetryAutoConfiguration' not loaded because instrumentation key or connection string not found

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
