### PR TITLE
Removed cluster name from Slack receiver alert title

### DIFF
--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -74,5 +74,4 @@ spec:
         - name: 'slack_alerting'
           slack_configs:
           - channel: prometheus-alerting
-            title: 'sbox-00-aks - {{ template "slack.default.title" . }}'
             text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"

--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -86,7 +86,6 @@ spec:
         - name: 'slack_alerting'
           slack_configs:
           - channel: prometheus-alerting
-            title: 'sbox-01-aks - {{ template "slack.default.title" . }}'
             text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
 
 


### PR DESCRIPTION
# JIRA link (if applicable) ###

[AB#655](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/655)

### Change description ###

Removed cluster name from alert title as it's no longer required. The URL in the alert redirects you to the correct Cluster Alert manager. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
