### PR TITLE
Added ServiceMonitor for flux in proemtheus config

### DIFF
--- a/k8s/mgmt-sandbox/common/monitoring/prom-operator.yaml
+++ b/k8s/mgmt-sandbox/common/monitoring/prom-operator.yaml
@@ -37,6 +37,18 @@ spec:
         prometheusOperator: true
         time: true
 
+    prometheus:
+      additionalServiceMonitors:
+        - name: "flux-monitor"
+          selector:
+            app: flux
+          namespaceSelector: 
+            matchNames:
+              - admin
+          endpoints: 
+          - targetPort: 3030
+          path: /metrics
+
     prometheusOperator:
       enabled: true
       createCustomResource: false
@@ -112,4 +124,6 @@ spec:
         - name: 'slack_alerting'
           slack_configs:
           - channel: prometheus-alerting
-            text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"         
+            text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"       
+
+          

--- a/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-00/monitoring/prom-operator.yaml
@@ -58,6 +58,17 @@ spec:
           matchLabels:
             heritage: Tiller
 
+      additionalServiceMonitors:
+        - name: "flux-monitor"
+          selector:
+            app: flux
+          namespaceSelector: 
+            matchNames:
+              - admin
+          endpoints: 
+          - targetPort: 3030
+          path: /metrics
+
     alertmanager:
       ingress:
         enabled: true

--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -67,7 +67,6 @@ spec:
           matchLabels:
             heritage: Tiller
 
-      prometheus:
       additionalServiceMonitors:
         - name: "flux-monitor"
           selector:

--- a/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
+++ b/k8s/sandbox/cluster-01/monitoring/prom-operator.yaml
@@ -66,6 +66,19 @@ spec:
         serviceMonitorSelector:
           matchLabels:
             heritage: Tiller
+
+      prometheus:
+      additionalServiceMonitors:
+        - name: "flux-monitor"
+          selector:
+            app: flux
+          namespaceSelector: 
+            matchNames:
+              - admin
+          endpoints: 
+          - targetPort: 3030
+          path: /metrics
+
     prometheusOperator:
       enabled: true
       createCustomResource: false


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AB#683](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/683)

### Change description ###

Added a service monitor for flux in prometheus. Flux exposes prom metrics by default. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
