### PR TITLE
Api version change for all non prod clusters

### DIFF
--- a/k8s/aat/cluster-00/sscs/sscs-case-loader.yaml
+++ b/k8s/aat/cluster-00/sscs/sscs-case-loader.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/k8s/aat/cluster-01/sscs/sscs-case-loader.yaml
+++ b/k8s/aat/cluster-01/sscs/sscs-case-loader.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/k8s/aat/cluster-01/traefik/traefik-neuvector-api.yaml
+++ b/k8s/aat/cluster-01/traefik/traefik-neuvector-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: traefik-neuvector-api

--- a/k8s/aat/common/am/accessmgmt-api.yaml
+++ b/k8s/aat/common/am/accessmgmt-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: am-accessmgmt-api

--- a/k8s/aat/common/bar/bar-app.yaml
+++ b/k8s/aat/common/bar/bar-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/k8s/aat/common/bsp/bulk-scan-orchestrator.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-orchestrator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator

--- a/k8s/aat/common/bsp/bulk-scan-payment-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-payment-processor.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bulk-scan-payment-processor

--- a/k8s/aat/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-processor.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor

--- a/k8s/aat/common/bsp/bulk-scan-sample-app.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-sample-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bulk-scan-sample-app

--- a/k8s/aat/common/ccd/data-store-api.yaml
+++ b/k8s/aat/common/ccd/data-store-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/k8s/aat/common/ccd/definition-store-api.yaml
+++ b/k8s/aat/common/ccd/definition-store-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/k8s/aat/common/ccd/user-profile-api.yaml
+++ b/k8s/aat/common/ccd/user-profile-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/k8s/aat/common/ccpay/ccpay-bulkscanning-app.yaml
+++ b/k8s/aat/common/ccpay/ccpay-bulkscanning-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/k8s/aat/common/ccpay/ccpay-payment-app.yaml
+++ b/k8s/aat/common/ccpay/ccpay-payment-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccpay-payment-app

--- a/k8s/aat/common/ccpay/fees-register-api.yaml
+++ b/k8s/aat/common/ccpay/fees-register-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/k8s/aat/common/cnp/plum-recipe-backend.yaml
+++ b/k8s/aat/common/cnp/plum-recipe-backend.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/k8s/aat/common/ctsc/work-allocation.yaml
+++ b/k8s/aat/common/ctsc/work-allocation.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ctsc-work-allocation

--- a/k8s/aat/common/dg/dg-docassembly.yaml
+++ b/k8s/aat/common/dg/dg-docassembly.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: dg-docassembly

--- a/k8s/aat/common/divorce/div-cms.yaml
+++ b/k8s/aat/common/divorce/div-cms.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/k8s/aat/common/divorce/div-cos.yaml
+++ b/k8s/aat/common/divorce/div-cos.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/k8s/aat/common/divorce/div-dgs.yaml
+++ b/k8s/aat/common/divorce/div-dgs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/k8s/aat/common/divorce/div-emca.yaml
+++ b/k8s/aat/common/divorce/div-emca.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/k8s/aat/common/divorce/div-fps.yaml
+++ b/k8s/aat/common/divorce/div-fps.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/k8s/aat/common/divorce/div-hm.yaml
+++ b/k8s/aat/common/divorce/div-hm.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-hm

--- a/k8s/aat/common/dm-store/dm-store.yaml
+++ b/k8s/aat/common/dm-store/dm-store.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/k8s/aat/common/em/em-anno.yaml
+++ b/k8s/aat/common/em/em-anno.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/k8s/aat/common/em/em-ccd-orchestrator.yaml
+++ b/k8s/aat/common/em/em-ccd-orchestrator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/k8s/aat/common/em/em-npa.yaml
+++ b/k8s/aat/common/em/em-npa.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/k8s/aat/common/em/em-showcase.yaml
+++ b/k8s/aat/common/em/em-showcase.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-showcase

--- a/k8s/aat/common/em/em-stitching.yaml
+++ b/k8s/aat/common/em/em-stitching.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/k8s/aat/common/ethos/repl-docmosis-service.yaml
+++ b/k8s/aat/common/ethos/repl-docmosis-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/k8s/aat/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/aat/common/family-public-law/fpl-case-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/k8s/aat/common/financial-remedy/finrem-ns.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-ns.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: finrem-ns

--- a/k8s/aat/common/ia/case-api.yaml
+++ b/k8s/aat/common/ia/case-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/k8s/aat/common/ia/case-documents-api.yaml
+++ b/k8s/aat/common/ia/case-documents-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/k8s/aat/common/ia/case-notifications-api.yaml
+++ b/k8s/aat/common/ia/case-notifications-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/k8s/aat/common/money-claims/claim-store.yaml.disabled
+++ b/k8s/aat/common/money-claims/claim-store.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/k8s/aat/common/probate/business-service.yaml
+++ b/k8s/aat/common/probate/business-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-business-service

--- a/k8s/aat/common/probate/orchestrator-service.yaml
+++ b/k8s/aat/common/probate/orchestrator-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/k8s/aat/common/probate/submit-service.yaml
+++ b/k8s/aat/common/probate/submit-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-submit-service

--- a/k8s/aat/common/rd/professional-api.yaml
+++ b/k8s/aat/common/rd/professional-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/k8s/aat/common/rd/profile-sync.yaml
+++ b/k8s/aat/common/rd/profile-sync.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/k8s/aat/common/rd/user-profile-api.yaml
+++ b/k8s/aat/common/rd/user-profile-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router

--- a/k8s/aat/common/rpe/draft-store-service.yaml
+++ b/k8s/aat/common/rpe/draft-store-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/k8s/aat/common/rpe/pdf-service.yaml
+++ b/k8s/aat/common/rpe/pdf-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: pdf-service

--- a/k8s/aat/common/rpe/rpe-service-auth-provider.yaml
+++ b/k8s/aat/common/rpe/rpe-service-auth-provider.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rpe-service-auth-provider

--- a/k8s/aat/common/rpe/send-letter-service.yaml
+++ b/k8s/aat/common/rpe/send-letter-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/k8s/aat/common/sscs/sscs-bulk-scan.yaml
+++ b/k8s/aat/common/sscs/sscs-bulk-scan.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-bulk-scan

--- a/k8s/aat/common/sscs/sscs-ccd-callback-orchestrator.yaml
+++ b/k8s/aat/common/sscs/sscs-ccd-callback-orchestrator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/k8s/aat/common/sscs/sscs-cor-backend.yaml
+++ b/k8s/aat/common/sscs/sscs-cor-backend.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-cor-backend

--- a/k8s/aat/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/aat/common/sscs/sscs-evidence-share.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/k8s/aat/common/sscs/sscs-tribunals-api.yaml
+++ b/k8s/aat/common/sscs/sscs-tribunals-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/k8s/aat/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/aat/common/sscs/sscs-tya-notif.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/k8s/demo/cluster-00/traefik/traefik-no-proxy.yaml
+++ b/k8s/demo/cluster-00/traefik/traefik-no-proxy.yaml
@@ -1,6 +1,6 @@
 # required for apps that can't handle oauth-proxy
 # i.e. ccd-api-gateway
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: traefik-no-proxy

--- a/k8s/demo/cluster-00/traefik/traefik-private.yaml
+++ b/k8s/demo/cluster-00/traefik/traefik-private.yaml
@@ -1,6 +1,6 @@
 # required for apps that can't handle oauth-proxy and not public
 # i.e. bulks-scan-processor
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: traefik-private

--- a/k8s/demo/common/bsp/bsp-demo.yaml
+++ b/k8s/demo/common/bsp/bsp-demo.yaml
@@ -1,6 +1,6 @@
 ---
 # it is not getting deployed. keeping it as an example, later it will be deleted.
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bsp-demo-ignore

--- a/k8s/demo/common/bsp/bsp-sample-app.yaml
+++ b/k8s/demo/common/bsp/bsp-sample-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bsp-sample-app

--- a/k8s/demo/common/bsp/standalone-processor.yaml
+++ b/k8s/demo/common/bsp/standalone-processor.yaml
@@ -1,6 +1,6 @@
 ---
 # this chart for Exela to get SAS token, always keep it running in demo standalone
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: standalone-processor

--- a/k8s/demo/common/ccd/ccd-demo-three.yaml
+++ b/k8s/demo/common/ccd/ccd-demo-three.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-demo-3

--- a/k8s/demo/common/ccd/ccd-demo.yaml.disabled
+++ b/k8s/demo/common/ccd/ccd-demo.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-demo

--- a/k8s/demo/common/ccd/latest-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/latest-ccd-chart.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-demo

--- a/k8s/demo/common/ccd/second-ccd-chart.yaml
+++ b/k8s/demo/common/ccd/second-ccd-chart.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-demo-2

--- a/k8s/demo/common/ccpay/ccpay-demo.yaml
+++ b/k8s/demo/common/ccpay/ccpay-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccpay-demo

--- a/k8s/demo/common/dg-docassembly/dg-docassembly-demo.yaml
+++ b/k8s/demo/common/dg-docassembly/dg-docassembly-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: dg-docassembly-demo

--- a/k8s/demo/common/divorce/div-demo.yaml
+++ b/k8s/demo/common/divorce/div-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-demo

--- a/k8s/demo/common/em/em-annotation-demo.yaml
+++ b/k8s/demo/common/em/em-annotation-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-annotation-demo

--- a/k8s/demo/common/em/em-bundling-demo.yaml
+++ b/k8s/demo/common/em/em-bundling-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-bundling-demo

--- a/k8s/demo/common/money-claims/cmc-demo.yaml
+++ b/k8s/demo/common/money-claims/cmc-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: cmc-demo

--- a/k8s/demo/common/probate/probate-chart.yaml
+++ b/k8s/demo/common/probate/probate-chart.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-demo

--- a/k8s/demo/common/rd/rd-demo.yaml
+++ b/k8s/demo/common/rd/rd-demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rd-demo

--- a/k8s/demo/common/sscs/tribunals/dwp-sscs-tribunals.yaml.old
+++ b/k8s/demo/common/sscs/tribunals/dwp-sscs-tribunals.yaml.old
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: chart-sscs-tribunals-release

--- a/k8s/ithc/common/dg/dg-docassembly.yaml
+++ b/k8s/ithc/common/dg/dg-docassembly.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: dg-docassembly

--- a/k8s/ithc/common/divorce/div-cms.yaml
+++ b/k8s/ithc/common/divorce/div-cms.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/k8s/ithc/common/divorce/div-cos.yaml
+++ b/k8s/ithc/common/divorce/div-cos.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/k8s/ithc/common/divorce/div-da.yaml
+++ b/k8s/ithc/common/divorce/div-da.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-da

--- a/k8s/ithc/common/divorce/div-dgs.yaml
+++ b/k8s/ithc/common/divorce/div-dgs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/k8s/ithc/common/divorce/div-dn.yaml
+++ b/k8s/ithc/common/divorce/div-dn.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/k8s/ithc/common/divorce/div-emca.yaml
+++ b/k8s/ithc/common/divorce/div-emca.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/k8s/ithc/common/divorce/div-fps.yaml
+++ b/k8s/ithc/common/divorce/div-fps.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/k8s/ithc/common/divorce/div-hm.yaml
+++ b/k8s/ithc/common/divorce/div-hm.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-hm

--- a/k8s/ithc/common/divorce/div-pfe.yaml
+++ b/k8s/ithc/common/divorce/div-pfe.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/k8s/ithc/common/divorce/div-rfe.yaml
+++ b/k8s/ithc/common/divorce/div-rfe.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/k8s/ithc/common/draft-store/draft-store-service.yaml
+++ b/k8s/ithc/common/draft-store/draft-store-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/k8s/ithc/common/em/em-anno.yaml
+++ b/k8s/ithc/common/em/em-anno.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/k8s/ithc/common/em/em-ccd-orchestrator.yaml
+++ b/k8s/ithc/common/em/em-ccd-orchestrator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/k8s/ithc/common/em/em-npa.yaml
+++ b/k8s/ithc/common/em/em-npa.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/k8s/ithc/common/em/em-stitching.yaml
+++ b/k8s/ithc/common/em/em-stitching.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/k8s/ithc/common/idam/idam-api.yaml
+++ b/k8s/ithc/common/idam/idam-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/k8s/ithc/common/idam/idam-web-admin.yaml
+++ b/k8s/ithc/common/idam/idam-web-admin.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/k8s/ithc/common/idam/idam-web-public.yaml
+++ b/k8s/ithc/common/idam/idam-web-public.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/k8s/ithc/common/rpe/rpe-service-auth-provider.yaml
+++ b/k8s/ithc/common/rpe/rpe-service-auth-provider.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rpe-service-auth-provider

--- a/k8s/osba/etcd-operator.yaml
+++ b/k8s/osba/etcd-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: etcd-operator

--- a/k8s/osba/osba.yaml
+++ b/k8s/osba/osba.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: osba

--- a/k8s/osba/patches/demo/osba.yaml
+++ b/k8s/osba/patches/demo/osba.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: osba

--- a/k8s/osba/service-catalog.yaml
+++ b/k8s/osba/service-catalog.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: svc-cat

--- a/k8s/perftest/common/am/accessmgmt-api.yaml
+++ b/k8s/perftest/common/am/accessmgmt-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: am-accessmgmt-api

--- a/k8s/perftest/common/bar/bar-app.yaml
+++ b/k8s/perftest/common/bar/bar-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/k8s/perftest/common/ccd/data-store-api.yaml
+++ b/k8s/perftest/common/ccd/data-store-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/k8s/perftest/common/ccd/definition-store-api.yaml
+++ b/k8s/perftest/common/ccd/definition-store-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/k8s/perftest/common/ccd/user-profile-api.yaml
+++ b/k8s/perftest/common/ccd/user-profile-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/k8s/perftest/common/ccpay/ccpay-bulkscanning-app.yaml
+++ b/k8s/perftest/common/ccpay/ccpay-bulkscanning-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/k8s/perftest/common/ccpay/ccpay-payment-app.yaml
+++ b/k8s/perftest/common/ccpay/ccpay-payment-app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ccpay-payment-app

--- a/k8s/perftest/common/ctsc/work-allocation.yaml
+++ b/k8s/perftest/common/ctsc/work-allocation.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ctsc-work-allocation

--- a/k8s/perftest/common/dg/dg-docassembly.yaml
+++ b/k8s/perftest/common/dg/dg-docassembly.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: dg-docassembly

--- a/k8s/perftest/common/divorce/div-cms.yaml
+++ b/k8s/perftest/common/divorce/div-cms.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/k8s/perftest/common/divorce/div-cos.yaml
+++ b/k8s/perftest/common/divorce/div-cos.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/k8s/perftest/common/divorce/div-dgs.yaml
+++ b/k8s/perftest/common/divorce/div-dgs.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/k8s/perftest/common/divorce/div-emca.yaml
+++ b/k8s/perftest/common/divorce/div-emca.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/k8s/perftest/common/divorce/div-fps.yaml
+++ b/k8s/perftest/common/divorce/div-fps.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/k8s/perftest/common/dm-store/dm-store.yaml
+++ b/k8s/perftest/common/dm-store/dm-store.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/k8s/perftest/common/em/em-anno.yaml
+++ b/k8s/perftest/common/em/em-anno.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/k8s/perftest/common/em/em-ccd-orchestrator.yaml
+++ b/k8s/perftest/common/em/em-ccd-orchestrator.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/k8s/perftest/common/em/em-npa.yaml
+++ b/k8s/perftest/common/em/em-npa.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/k8s/perftest/common/em/em-stitching.yaml
+++ b/k8s/perftest/common/em/em-stitching.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/k8s/perftest/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/perftest/common/family-public-law/fpl-case-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/k8s/perftest/common/ia/case-api.yaml
+++ b/k8s/perftest/common/ia/case-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: case-api

--- a/k8s/perftest/common/ia/case-documents-api.yaml
+++ b/k8s/perftest/common/ia/case-documents-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: case-documents-api

--- a/k8s/perftest/common/ia/case-notifications-api.yaml
+++ b/k8s/perftest/common/ia/case-notifications-api.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: case-notifications-api

--- a/k8s/perftest/common/money-claims/claim-store.yaml
+++ b/k8s/perftest/common/money-claims/claim-store.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/k8s/perftest/common/money-claims/claim-store.yaml.disabled
+++ b/k8s/perftest/common/money-claims/claim-store.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/k8s/perftest/common/probate/business-service.yaml
+++ b/k8s/perftest/common/probate/business-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-business-service

--- a/k8s/perftest/common/probate/orchestrator-service.yaml
+++ b/k8s/perftest/common/probate/orchestrator-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/k8s/perftest/common/probate/submit-service.yaml
+++ b/k8s/perftest/common/probate/submit-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: probate-submit-service

--- a/k8s/perftest/common/rpe/draft-store-service.yaml
+++ b/k8s/perftest/common/rpe/draft-store-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/k8s/perftest/common/rpe/pdf-service.yaml
+++ b/k8s/perftest/common/rpe/pdf-service.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: pdf-service

--- a/k8s/perftest/common/rpe/rpe-service-auth-provider.yaml
+++ b/k8s/perftest/common/rpe/rpe-service-auth-provider.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: flux.weave.works/v1beta1
+apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rpe-service-auth-provider


### PR DESCRIPTION
This is in prepration for the change scheduled today afternoon to rollout helm 2.16.1 and helm operator RC4

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
