### PR TITLE
RDM-6435 AAT Bump up max number of connections to 25 for the ASE to AKS transition period only. It should come back to 32 after ASE is decommissioned.

### DIFF
--- a/k8s/aat/common/ccd/definition-store-api.yaml
+++ b/k8s/aat/common/ccd/definition-store-api.yaml
@@ -21,7 +21,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-6f2ed8e4
       environment:
-        DEFINITION_STORE_DB_MAX_POOL_SIZE: 10
+        DEFINITION_STORE_DB_MAX_POOL_SIZE: 125
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/aat/common/ccd/definition-store-api.yaml
+++ b/k8s/aat/common/ccd/definition-store-api.yaml
@@ -21,7 +21,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-6f2ed8e4
       environment:
-        DEFINITION_STORE_DB_MAX_POOL_SIZE: 125
+        DEFINITION_STORE_DB_MAX_POOL_SIZE: 25
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6435


### Change description ###
AAT Bump up max number of connections to 25 for the ASE to AKS transition period only. It should come back to 32 after ASE is decommissioned.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
