### PR TITLE
Updated App Insights Key Name

### DIFF
--- a/k8s/demo/common/rd/rd-demo.yaml
+++ b/k8s/demo/common/rd/rd-demo.yaml
@@ -27,7 +27,7 @@ spec:
         image: hmctspublic.azurecr.io/rd/user-profile-api:pr-204-45b7e6d8
         ingressHost: rd-user-profile-api.demo.platform.hmcts.net
         ingressClass: traefik-no-proxy
-        applicationInsightsInstrumentKey: 05e3fead-38f4-41f5-948d-f7b70a0a7fbe
+        devApplicationInsightsInstrumentKey: 05e3fead-38f4-41f5-948d-f7b70a0a7fbe
         environment:
           AUTH_IDAM_CLIENT_BASEURL: "{{ .Values.global.idamApiUrl }}"
 


### PR DESCRIPTION
# Change description ###

The key name for the App Insights config was not used correctly. If the chart devMode value is enabled ( see https://github.com/hmcts/chart-java/blob/master/java/templates/deployment.yaml#L69) the name of the app insights key is slightly different. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
