### PR TITLE
disable ccpay s2s in ccd-full release

### DIFF
--- a/k8s/demo/common/ccd/ccd-full.yaml
+++ b/k8s/demo/common/ccd/ccd-full.yaml
@@ -88,5 +88,9 @@ spec:
       definitions:
        - https://github.com/hmcts/ccd-definition-store-api/raw/master/aat/src/resource/CCD_CNP_27.xlsx
       userRoles:
-       - caseworker-autotest1     
+       - caseworker-autotest1   
+
+    ccpay:
+      rpe-service-auth-provider:
+        enabled: false  
           


### PR DESCRIPTION

### Change description ###

disabled  ccpay- s2s as ccd-full release creating two s2s instances

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
