### PR TITLE
New orgs beta file for AKS based Jenkins

### DIFF
--- a/k8s/admin/jenkins/jenkins.yaml
+++ b/k8s/admin/jenkins/jenkins.yaml
@@ -393,7 +393,7 @@ spec:
                           username: "jenkins-reform-bulkscan"
           jobs: |
             jobs:
-              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations.groovy
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations-beta.groovy
 
       sidecars:
         configAutoReload:


### PR DESCRIPTION
### JIRA link (if applicable) ###
[AB#697](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/697)


### Change description ###

reconfigured AKS based jenkins to use new orgs file whilst transition.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
