### PR TITLE
Bump blob router service 0.0.2 -> 0.0.3

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.2
+    version: 0.0.3
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Don't remember when version got bumped, but flux config is not updated. Doing it now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
