### PR TITLE
Bump blob-router service 0.0.5 -> 0.0.6

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.5
+    version: 0.0.6
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Notification Client for blob router](https://tools.hmcts.net/jira/browse/BPS-966)

### Change description ###

The change is PRed here: hmcts/blob-router-service#69

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
