### PR TITLE
Disable neuvector SSL for manager so ingress works

### DIFF
--- a/k8s/neuvector/patches/aat/neuvector.yaml
+++ b/k8s/neuvector/patches/aat/neuvector.yaml
@@ -12,6 +12,9 @@ spec:
   values:
     neuvector:
       tag: 3.1.1
+      manager:
+        env:
+          ssl: 'off'
     keyvault:
       name: cftapps-stg
       resourcegroup: core-infra-stg-rg


### PR DESCRIPTION
### JIRA link (if applicable) ###
[AB#640](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/640)


### Change description ###
https://github.com/neuvector/neuvector-helm/commit/6e7302ebefebb02b35609b16361fe7036c533c31#diff-ecc22587970e2955fe9ae137009f864e


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
