### PR TITLE
Bump blob-router component 0.0.17 -> 0.0.18

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.17
+    version: 0.0.18
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create blob processing component](https://tools.hmcts.net/jira/browse/BPS-919)

### Change description ###

Change is adding App GW url to blob-router configuration. Reference: hmcts/blob-router-service#123

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
