### PR TITLE
Add dummy env var to BSP AAT

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-processor.yaml
@@ -25,6 +25,7 @@ spec:
       environment:
         STORAGE_BLOB_SELECTED_CONTAINER: ALL
         ERROR_NOTIFICATIONS_ENABLED: true
+        TMP_DUMMY: "remove me"
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

Adding dummy env var to force release bulk scan processor on aat - it has gone somewhere for a nap 🤷‍♂ 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
