### PR TITLE
Revert "Making fpla locked to last working version"

### DIFF
--- a/k8s/prod/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/prod/common/family-public-law/fpl-case-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fpl-case-service
   namespace: family-public-law
   annotations:
-    flux.weave.works/automated: "false"
+    flux.weave.works/automated: "true"
     flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: fpl-case-service
@@ -23,7 +23,7 @@ spec:
       readinessPeriod: 15
       useInterpodAntiAffinity: true
       applicationInsightsInstrumentKey: 1dfa1cca-46c8-4f9a-a4d9-adea4a7f3ed6
-      image: hmctspublic.azurecr.io/fpl/case-service:prod-3b8d2cc7
+      image: hmctspublic.azurecr.io/fpl/case-service:prod-1eeadcd5
       ingressHost: fpl-case-service-prod.service.core-compute-prod.internal
       environment:
         FPL_LOCAL_AUTHORITY_CODES_FORBIDDEN_CASE_SUBMISSION: FPLA


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#1873 - the underlying secrets should now be fixed

