### PR TITLE
Removed probate ocr validation url which is set empty for prod

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -33,9 +33,7 @@ spec:
         STORAGE_BLOB_PUBLIC_KEY: trusted_public_key.der
         ERROR_NOTIFICATIONS_ENABLED: true
         # remove following once onboarded
-        OCR_VALIDATION_URL_PROBATE: ""
         OCR_VALIDATION_URL_DIVORCE: ""
-        DUMMY_VAR: "Restart me"
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
- I believe this was added temporarily here but this should not be empty and it should use one defined in values.yaml.