### PR TITLE
CCD Demo: double memory setting for def-store pod

### DIFF
--- a/k8s/demo/common/ccd/ccd-develop.yaml
+++ b/k8s/demo/common/ccd/ccd-develop.yaml
@@ -87,6 +87,8 @@ spec:
 
     ccd-definition-store-api:
       java:
+        devmemoryRequests: '1024Mi'
+        devmemoryLimits: '2048Mi'
         image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-469-adda74fd
         secrets:
           STORAGE_ACCOUNT_NAME:


### PR DESCRIPTION
### Change description ###
devmemoryRequests 512 -> 1024Mi
devmemoryLimits 1024 -> 2048Mi

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
