### PR TITLE
Removed ServiceMonitorSelector using Tiller label

### DIFF
--- a/k8s/monitoring/prom-operator.yaml
+++ b/k8s/monitoring/prom-operator.yaml
@@ -40,10 +40,6 @@ spec:
         time: true
 
     prometheus:
-      prometheusSpec:
-        serviceMonitorSelector:
-          matchLabels:
-            heritage: Tiller
       additionalServiceMonitors:
         - name: "flux-monitor"
           selector:


### PR DESCRIPTION

### Change description ###

Removed ServiceMonitorSelector that was using the Tiller label as Tiller no longer exists after Helm3 upgrade. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
