### PR TITLE
Increase memory for osba controller manager

### DIFF
--- a/k8s/osba/service-catalog.yaml
+++ b/k8s/osba/service-catalog.yaml
@@ -16,7 +16,7 @@ spec:
     apiserver:
       resources:
         limits:
-          memory: 1500Mi
+          memory: 1000Mi
       storage:
         etcd:
           useEmbedded: false
@@ -26,3 +26,6 @@ spec:
     controllermanager:
       healthcheck:
         enabled: false
+      resources:
+        limits:
+          memory: 100Mi


### PR DESCRIPTION
Increased the wrong value before. 

Controller Manager is set to too low in base chart https://github.com/kubernetes-sigs/service-catalog/blob/v0.2/charts/catalog-v0.2/values.yaml#L187

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
