### PR TITLE
Downgraded chart version as latest is not published

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.26
+    version: 0.0.25
   values:
     java:
       replicas: 2


### PR DESCRIPTION

### Change description ###

- aat-00-aks has issues and all the pods have disappeared.

- aat-01-aks just has staging container as flux can't deploy 0.0.26 due to chart not being published.

- Chart is being published after smoke tests and currently smoke tests can't pass as the pods are unavailable.

- Once pods are recreated smoke tests will pass and 0.0.26 chart will be published and then we can bump the version in flux(revert this PR)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
