### PR TITLE
Fix/docmosis update perftest

### DIFF
--- a/k8s/perftest/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/perftest/common/family-public-law/fpl-case-service.yaml
@@ -26,6 +26,7 @@ spec:
       image: hmctspublic.azurecr.io/fpl/case-service:prod-c3812bde
       ingressHost: fpl-case-service-perftest.service.core-compute-perftest.internal
       environment:
+        DUMMY: TRIGGER_BUILD
         IDAM_API_URL: https://idam-api.perftest.platform.hmcts.net
         IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-perftest.service.core-compute-perftest.internal
         CORE_CASE_DATA_API_URL: http://ccd-data-store-api-perftest.service.core-compute-perftest.internal

--- a/k8s/perftest/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/perftest/common/family-public-law/fpl-case-service.yaml
@@ -26,13 +26,12 @@ spec:
       image: hmctspublic.azurecr.io/fpl/case-service:prod-c3812bde
       ingressHost: fpl-case-service-perftest.service.core-compute-perftest.internal
       environment:
-        DUMMY: TRIGGER_BUILD
         IDAM_API_URL: https://idam-api.perftest.platform.hmcts.net
         IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-perftest.service.core-compute-perftest.internal
         CORE_CASE_DATA_API_URL: http://ccd-data-store-api-perftest.service.core-compute-perftest.internal
         DOCUMENT_MANAGEMENT_URL: http://dm-store-perftest.service.core-compute-perftest.internal
         CCD_UI_BASE_URL: https://www-ccd.perftest.platform.hmcts.net
-        DOCMOSIS_TORNADO_URL: https://docmosis-perftest.platform.hmcts.net
+        DOCMOSIS_TORNADO_URL: https://docmosis-testing.platform.hmcts.net
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-perftest.service.core-compute-perftest.internal
         SEND_LETTER_URL: http://rpe-send-letter-service-perftest.service.core-compute-perftest.internal
         IDAM_CLIENT_ID: fpl_case_service


### PR DESCRIPTION
Change docmosis url on perftest env to https://docmosis-testing.platform.hmcts.net as https://docmosis-perftest.platform.hmcts.net does not exists

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
