### PR TITLE
Bumped blob router version to 0.0.27

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.26
+    version: 0.0.27
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1026


### Change description ###
Bumped blob router version to 0.0.27
blob router service PR: https://github.com/hmcts/blob-router-service/pull/272

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
