### PR TITLE
Change blob-router prod config to recreate pods

### DIFF
--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -27,6 +27,7 @@ spec:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
         STORAGE_URL: https://reformscan.platform.hmcts.net
         STORAGE_BLOB_PUBLIC_KEY: "trusted_public_key.der"
+        RESTART_ME: "Added just to recreate pods. Delete it."
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

Change blob-router prod config to recreate pods. It seems that the pods haven't picked up the latest infra change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
