### PR TITLE
Bump send letter 0.0.9 -> 0.0.10

### DIFF
--- a/k8s/aat/common/rpe/send-letter-service.yaml
+++ b/k8s/aat/common/rpe/send-letter-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.0.9
+    version: 0.0.10
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/rpe/send-letter-service.yaml
+++ b/k8s/prod/common/rpe/send-letter-service.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.0.9
+    version: 0.0.10
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Resolving aad identity name deprecation. Didn't realise how old the java chart version was. This bump applies these changes: https://github.com/hmcts/send-letter-service/pull/649

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
