### PR TITLE
blob router- bump the versions and override prod url

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.29
+    version: 0.0.30
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.29
+    version: 0.0.30
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.29
+    version: 0.0.30
   values:
     java:
       replicas: 2
@@ -26,6 +26,7 @@ spec:
         TASK_SCAN_DELAY: 300000
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
         STORAGE_URL: https://reformscan.platform.hmcts.net
+        STORAGE_BULKSCAN_URL: https://bulkscan.platform.hmcts.net
         STORAGE_BLOB_PUBLIC_KEY: "trusted_public_key.der"
         RESTART_ME: "Added just to recreate pods. Delete it."
     global:


### PR DESCRIPTION


### JIRA link (if applicable) ###

changes
https://github.com/hmcts/blob-router-service/pull/286/

### Change description ###

bump the version and override prod url

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
