### PR TITLE
blob-router - bump the version

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.30
+    version: 0.0.31
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.30
+    version: 0.0.31
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -28,7 +28,6 @@ spec:
         STORAGE_URL: https://reformscan.platform.hmcts.net
         STORAGE_BULKSCAN_URL: https://bulkscan.platform.hmcts.net
         STORAGE_BLOB_PUBLIC_KEY: "trusted_public_key.der"
-        RESTART_ME: "Added just to recreate pods. Delete it."
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.30
+    version: 0.0.31
   values:
     java:
       replicas: 2


### PR DESCRIPTION

### Change description ###

bump  prod-aat-perftest versions
and RESTART_ME var removed from Prod.

related code change:
https://github.com/hmcts/blob-router-service/pull/319

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
