### PR TITLE
Removed disabling of proxy for perftest as we need it to be enabled

### DIFF
--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -26,7 +26,6 @@ spec:
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"
         TASK_SCAN_DELAY: 300000
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
-        PROXY_ENABLED: false
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION

### Change description ###

- Removed disabling of proxy(enabled by default in application) as we need it to connect to perftest bulkscan blob storage.

- Previously connecting via proxy was giving 503 error as some was going on perftest. Now it looks fine.

- If this still doesn't work then we will have to add aks subnets or get the proxy working.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
