### PR TITLE
Remove blob processing delay from blob-router in perftest

### DIFF
--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -25,7 +25,7 @@ spec:
         HANDLE_REJECTED_FILES_CRON: "0 0 7 * * *"
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"
         TASK_SCAN_DELAY: 300000
-        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
+        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: true
     global:
       environment: perftest


### PR DESCRIPTION
### Change description ###

Remove blob processing delay from blob-router in perftest. This is temporary, to speed up connectivity testing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
