### PR TITLE
Revert "Remove blob processing delay from blob-router in perftest"

### DIFF
--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -25,7 +25,7 @@ spec:
         HANDLE_REJECTED_FILES_CRON: "0 0 7 * * *"
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"
         TASK_SCAN_DELAY: 300000
-        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
+        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
         CRIME_ENABLED: true
     global:
       environment: perftest


### PR DESCRIPTION
The change that's being reverted, has been introduced temporarily, to speed up testing.

Should be merged after or at the end of 6th March.