### PR TITLE
fix: updated ccd ui url for FPLA and added missing secrets

### DIFF
--- a/k8s/aat/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/aat/common/family-public-law/fpl-case-service.yaml
@@ -69,6 +69,7 @@ spec:
           - local-authority-fallback-inbox
           - robotics-notification-sender
           - robotics-notification-recipient
+          - ld-sdk-key
           - ctsc-inbox
       prometheus:
         enabled: true

--- a/k8s/aat/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/aat/common/family-public-law/fpl-case-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: fpl-case-service
-    version: 1.5.0
+    version: 1.6.0
   values:
     java:
       replicas: 2
@@ -31,7 +31,7 @@ spec:
         IDAM_S2S_AUTH_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
         CORE_CASE_DATA_API_URL: http://ccd-data-store-api-aat.service.core-compute-aat.internal
         DOCUMENT_MANAGEMENT_URL: http://dm-store-aat.service.core-compute-aat.internal
-        CCD_UI_BASE_URL: https://ccd-case-management-web-aat.service.core-compute-aat.internal
+        CCD_UI_BASE_URL: https://www-ccd.aat.platform.hmcts.net
         DOCMOSIS_TORNADO_URL: https://docmosis-development.platform.hmcts.net
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-aat.service.core-compute-aat.internal
         SEND_LETTER_URL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal

--- a/k8s/ithc/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/ithc/common/family-public-law/fpl-case-service.yaml
@@ -69,6 +69,9 @@ spec:
           - system-update-user-username
           - system-update-user-password
           - local-authority-fallback-inbox
+          - robotics-notification-sender
+          - robotics-notification-recipient
+          - ld-sdk-key
           - ctsc-inbox
       prometheus:
         enabled: true

--- a/k8s/perftest/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/perftest/common/family-public-law/fpl-case-service.yaml
@@ -69,6 +69,9 @@ spec:
           - system-update-user-username
           - system-update-user-password
           - local-authority-fallback-inbox
+          - robotics-notification-sender
+          - robotics-notification-recipient
+          - ld-sdk-key
           - ctsc-inbox
       prometheus:
         enabled: true

--- a/k8s/prod/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/prod/common/family-public-law/fpl-case-service.yaml
@@ -70,6 +70,7 @@ spec:
           - local-authority-fallback-inbox
           - robotics-notification-sender
           - robotics-notification-recipient
+          - ld-sdk-key
           - ctsc-inbox
       prometheus:
         enabled: true


### PR DESCRIPTION
### Change description ###

Update ccd ui url for FPLA (changed after ccd web migration to aks in aat)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
