### PR TITLE
SIDM-3816 - idam-aat2 - use idam-idam-aat keyvault explicitly

### DIFF
--- a/k8s/aat/common/idam/idam-api.yaml
+++ b/k8s/aat/common/idam/idam-api.yaml
@@ -22,6 +22,24 @@ spec:
       replicas: 1
       ingressHost: idam-api-aat.service.core-compute-aat.internal
       aadIdentityName: idam
+      keyVaults:
+        "idam-idam-aat":
+          resourceGroup: idam-idam-aat
+          excludeEnvironmentSuffix: true
+          secretRef: "kvcreds"
+          secrets:
+            - web-admin-client-secret
+            - notify-api-key
+            - am-password
+            - idm-password
+            - pin-user-pass
+            - event-bus-access-key
+            - idam-api-POSTGRES-HOST
+            - idam-api-POSTGRES-PORT
+            - idam-api-POSTGRES-DATABASE
+            - idam-api-POSTGRES-USER
+            - idam-api-POSTGRES-PASS
+            - AppInsightsInstrumentationKey
       environment:
         TESTING_SUPPORT_ENABLED: true
         ENDPOINTS_INFO_ENABLED: true

--- a/k8s/aat/common/idam/idam-web-admin.yaml
+++ b/k8s/aat/common/idam/idam-web-admin.yaml
@@ -21,6 +21,13 @@ spec:
       image: hmctspublic.azurecr.io/idam/web-admin:prod-3f69a75f
       ingressHost: idam-web-admin-aat.service.core-compute-aat.internal
       aadIdentityName: idam
+      keyVaults:
+        "idam-idam-aat":
+          resourceGroup: idam-idam-aat
+          excludeEnvironmentSuffix: false
+          secretRef: "kvcreds"
+          secrets:
+            - AppInsightsInstrumentationKey
       environment:
         STRATEGIC_SERVICE_URL: http://idam-api-aat.service.core-compute-aat.internal
         STRATEGIC_PUBLIC_URL: https://idam-web-public.aat.platform.hmcts.net

--- a/k8s/aat/common/idam/idam-web-public.yaml
+++ b/k8s/aat/common/idam/idam-web-public.yaml
@@ -21,6 +21,13 @@ spec:
       image: hmctspublic.azurecr.io/idam/web-public:prod-1ebdebd1
       ingressHost: idam-web-public-aat2.aat.platform.hmcts.net
       aadIdentityName: idam
+      keyVaults:
+        "idam-idam-aat":
+          resourceGroup: idam-idam-aat
+          excludeEnvironmentSuffix: false
+          secretRef: "kvcreds"
+          secrets:
+            - AppInsightsInstrumentationKey
       environment:
         STRATEGIC_SERVICE_URL: http://idam-api-aat.service.core-compute-aat.internal
     global:

--- a/k8s/perftest/common/idam/idam-api.yaml
+++ b/k8s/perftest/common/idam/idam-api.yaml
@@ -23,10 +23,6 @@ spec:
       replicas: 1
       ingressHost: idam-api-perftest.service.core-compute-perftest.internal
       aadIdentityName: idam
-      cpuRequests: '3000m'
-      cpuLimits: '3500m'
-      memoryRequests: '2048Mi'
-      memoryLimits: '4096Mi'
       environment:
         TESTING_SUPPORT_ENABLED: true
         ENDPOINTS_INFO_ENABLED: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-3816

### Change description ###

idam-aat2 - use idam-idam-aat keyvault explicitly

Because idam-shared-infrastructure is not required for AAT2 , there is no idam-idam-aat2 KeyVault, only idamvaultaat2. This forces AKS to use idam-idam-aat KeyVault for the following secrets:

            - web-admin-client-secret
            - notify-api-key
            - am-password
            - idm-password
            - pin-user-pass
            - event-bus-access-key
            - idam-api-POSTGRES-HOST
            - idam-api-POSTGRES-PORT
            - idam-api-POSTGRES-DATABASE
            - idam-api-POSTGRES-USER
            - idam-api-POSTGRES-PASS
            - AppInsightsInstrumentationKey

This means AKS AAT2 pods will log to idam-idam-aat AI, connect to idam-api PostgresDB idam-api-idam-aat. Secrets are shared between 1.5.1 and 2.0.0.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```