### PR TITLE
Don't pass basic auth to apps

### DIFF
--- a/k8s/demo/cluster-00/traefik/traefik-auth.yaml
+++ b/k8s/demo/cluster-00/traefik/traefik-auth.yaml
@@ -66,6 +66,7 @@ spec:
           - "--tls-cert=/var/oauth2/demo-platform-hmcts-crt.pem"
           - "--tls-key=/var/oauth2/demo-platform-hmcts-key.pem"
           - "--proxy-prefix=/oauth-proxy"
+          - "--pass-basic-auth=false"
 ---
 kind: Service
 apiVersion: v1


### PR DESCRIPTION
Should fix ccd-admin-web and sscs-tribunals-frontend

