### PR TITLE
Change ingressClass for sscs-tribunals-frontend

### DIFF
--- a/k8s/demo/common/sscs/sscs-tribunals-frontend.yaml
+++ b/k8s/demo/common/sscs/sscs-tribunals-frontend.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: sscs
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:pr-897-*
+    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: sscs-tribunals-frontend
   rollback:
@@ -20,7 +20,8 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tribunals-frontend:pr-897-5d6fdf5f
+      ingressClass: traefik-no-proxy
+      image: hmctspublic.azurecr.io/sscs/tribunals-frontend:latest
       ingressHost: benefit-appeal.demo.platform.hmcts.net
     global:
       environment: demo


### PR DESCRIPTION
I spent a few hours debugging this yesterday with Jack

I diffed a working request arriving at the app and a broken one,
The only major difference I could tell was that `X-Forwarded-Proto` and `X-Forwarded-Port` were arriving as `http` and `80` when proxied, vs `https` and `443` when going direct to traefik

This is because the upstream of oauth_proxy is traefik:80, i.e. it talks to traefik over http, I can't see any support in oauth_proxy for setting those headers but possibly it is, I haven't tried putting anything between traefik and oauth_proxy or running it locally

I did try force overriding it at traefik with:
```
 ingress.kubernetes.io/custom-request-headers: X-Forwarded-Proto:https||header2:valueaaaaaaa
```

Traefik must set the `X-Forwarded-Proto` after processing custom headers as it was arriving as http but header2 was correctly arriving,

This might work properly in `traefik v2`, untested.

My recommendation is that we disable the proxy for this app as we have other priorities right now and I've created a ticket on our backlog so be able to dedicate more time to it