### PR TITLE
Bump blob router 0.0.38 -> 0.0.39

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.38
+    version: 0.0.39
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.38
+    version: 0.0.39
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.38
+    version: 0.0.39
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Removes not used configs: hmcts/blob-router-service#395

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
