### PR TITLE
Revert "debugging with PR image tag for dm_link issue"

### DIFF
--- a/k8s/aat/common/ccd/case-management-web.yaml
+++ b/k8s/aat/common/ccd/case-management-web.yaml
@@ -5,8 +5,8 @@ metadata:
   name: ccd-case-management-web
   namespace: ccd
   annotations:
-    flux.weave.works/automated: "false"
-    flux.weave.works/tag.nodejs: glob:pr-922-*
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: ccd-case-management-web
   rollback:
@@ -20,7 +20,7 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/ccd/case-management-web:pr-922-baad8c4c
+      image: hmctspublic.azurecr.io/ccd/case-management-web:prod-1ba96c70
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#2614
Document view is working fine on latest deployment (PR image tag).  Lets revert and re-check on master image 🤞 

<img width="1363" alt="Screenshot 2020-03-23 at 07 55 55" src="https://user-images.githubusercontent.com/976999/77294345-07577b00-6cdc-11ea-9e47-0e9875ef5fab.png">
