### PR TITLE
IAC AIP Adding prod config

### DIFF
--- a/k8s/prod/common/ia/aip-frontend.yaml
+++ b/k8s/prod/common/ia/aip-frontend.yaml
@@ -23,7 +23,7 @@ spec:
       image: hmctspublic.azurecr.io/ia/aip-frontend:prod-5d1f9ba1
       ingressHost: immigration-appeal.platform.hmcts.net
       environment:
-        IDAM_WEB_URL: "https://idam-web-public.platform.hmcts.net"
+        IDAM_WEB_URL: "https://hmcts-access.service.gov.uk/"
         IDAM_API_URL: "https://idam-api.platform.hmcts.net"
         RESTART_ME: "1"
     global:

--- a/k8s/prod/common/ia/aip-frontend.yaml
+++ b/k8s/prod/common/ia/aip-frontend.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-aip-frontend
+  namespace: ia
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.nodejs: glob:prod-*
+spec:
+  releaseName: ia-aip-frontend
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: ia-aip-frontend
+    version: 0.0.10
+  values:
+    nodejs:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/ia/aip-frontend:prod-5d1f9ba1
+      ingressHost: immigration-appeal.platform.hmcts.net
+      environment:
+        IDAM_WEB_URL: "https://idam-web-public.platform.hmcts.net"
+        IDAM_API_URL: "https://idam-api.platform.hmcts.net"
+        RESTART_ME: "1"
+    global:
+      environment: prod
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true


### PR DESCRIPTION
Adding flux config for `ia-aip-frontend` which is a new nodejs app due to go live 1st April.

Prod idam urls have been taken from Idam docs here: https://tools.hmcts.net/confluence/display/SISM/Environments

Ingress host matches what is expected to be our url in prod: `immigration-appeal.platform.hmcts.net`

Chart version number kept the same as `AAT`