### PR TITLE
Restarting docs api

### DIFF
--- a/k8s/ithc/common/ia/case-documents-api.yaml
+++ b/k8s/ithc/common/ia/case-documents-api.yaml
@@ -22,7 +22,7 @@ spec:
       image: hmctspublic.azurecr.io/ia/case-documents-api:prod-884ec533
       ingressHost: ia-case-documents-api-ithc.service.core-compute-ithc.internal
       environment:
-        RESTART_ME: "Update due to vault change"
+        RESTART_ME: "Update due to vault Change"
     global:
       environment: ithc
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
Restart of `ia-case-documents-api` after changing em orchestrator url.

