### PR TITLE
Disable admin monitors through code

### DIFF
--- a/k8s/admin/jenkins/jenkins.yaml
+++ b/k8s/admin/jenkins/jenkins.yaml
@@ -78,6 +78,9 @@ spec:
               markupFormatter:
                 rawHtml:
                   disableSyntaxHighlighting: false
+              disabledAdministrativeMonitors:
+                - "jenkins.security.QueueItemAuthenticatorMonitor"
+                - "jenkins.security.s2m.MasterKillSwitchWarning"
               numExecutors: 0
           default-view: |
             jenkins:


### PR DESCRIPTION
The below admin monitors aren't a concern for us, + they are known to have performance issues which we don't want to have to deal with.

They were disabled manually previously, jenkins 2.230 now supports doing this via configuration-as-code