### PR TITLE
Change bulk-scan-processor chart version in demo to 0.2.19

### DIFF
--- a/k8s/demo/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/demo/common/bsp/bulk-scan-processor.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.20
+    version: 0.2.19
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Change bulk-scan-processor chart version in demo to 0.2.19. Newer chart hasn't been deployed, yet, and bulk-scan-processor hasn't been deployed to demo at all.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
