### PR TITLE
Prevent the conversion of an integer to scientific notation in bulk-scan-processor demo

### DIFF
--- a/k8s/demo/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/demo/common/bsp/bulk-scan-processor.yaml
@@ -26,7 +26,7 @@ spec:
       environment:
         STORAGE_BLOB_SELECTED_CONTAINER: ALL
         #60 days in seconds
-        SAS_TOKEN_VALIDITY: 5184000
+        SAS_TOKEN_VALIDITY: "5184000"
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1161

### Change description ###

Prevent the conversion of an integer to scientific notation in bulk-scan-processor. The setting must be a string, so that no conversion takes place.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
