### PR TITLE
Revert "Remove the waiting for time processing in bulk-scan-processor prod"

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -27,7 +27,7 @@ spec:
         STORAGE_URL: https://bulkscan.platform.hmcts.net
         PROCESS_PAYMENTS_ENABLED: true
         SMTP_HOST: smtp.office365.com
-        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
+        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
         SCAN_DELAY: 300000
         REUPLOAD_DELAY: 600000
         STORAGE_BLOB_PUBLIC_KEY: trusted_public_key.der


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#2979

That was a temporary change to speed up tests with external provider.