### PR TITLE
Standardise fees and pay urls

### DIFF
--- a/k8s/prod/common/divorce/div-pfe.yaml
+++ b/k8s/prod/common/divorce/div-pfe.yaml
@@ -26,7 +26,6 @@ spec:
         DECREE_NISI_FRONTEND_URL: https://www.decree-nisi.apply-divorce.service.gov.uk
         IDAM_LOGIN_URL: https://hmcts-access.service.gov.uk/login
         IDAM_API_URL: https://idam-api.platform.hmcts.net
-        PAYMENT_SERVICE_URL: https://payment.platform.hmcts.net
         GOOGLE_ANALYTICS_ID: UA-93824767-3
         FEATURE_WEBCHAT: "true"
         WEBCHAT_CHAT_ID: 10308349715d949f6bd7a989.00577994

--- a/k8s/prod/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/prod/common/money-claims/cmc-citizen-frontend.yaml
@@ -32,8 +32,6 @@ spec:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_AUTHENTICATION_WEB_URL: https://hmcts-access.service.gov.uk
 
-        FEES_URL: https://fees-register-api.platform.hmcts.net
-        PAY_URL: https://payment.platform.hmcts.net
         FEATURE_WEB_CHAT: false
     global:
       environment: prod

--- a/k8s/prod/common/money-claims/cmc-legal-frontend.yaml
+++ b/k8s/prod/common/money-claims/cmc-legal-frontend.yaml
@@ -30,9 +30,6 @@ spec:
 
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_AUTHENTICATION_WEB_URL: https://hmcts-access.service.gov.uk
-
-        PAY_URL: https://payment.platform.hmcts.net
-        FEES_URL: https://fees-register-api.platform.hmcts.net
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
As part of migrating fees and pay apps to AKS we need to standardise on only one url,

We've ran a report and nearly 3x the number of apps are using the standard URLs, so moving the other apps back to the standard ones