### PR TITLE
SIDM-4063 - increase idam-api aat replicas to 4

### DIFF
--- a/k8s/aat/common/idam/idam-api.yaml
+++ b/k8s/aat/common/idam/idam-api.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:aat-009c6214
-      replicas: 2
+      replicas: 4
       ingressHost: idam-api.aat.platform.hmcts.net
       aadIdentityName: idam
       environment:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-4063


### Change description ###
SIDM-4063 - increase idam-api aat replicas to 4

AAT is throwing UnknownHostExceptions so we are increasing replicast to 4 to see if it helps.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
