### PR TITLE
Bump blob-router chart version in all envs

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.41
+    version: 0.0.42
   values:
     java:
       replicas: 2

--- a/k8s/demo/common/reform-scan/blob-router.yaml
+++ b/k8s/demo/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.41
+    version: 0.0.42
   values:
     java:
       replicas: 2
@@ -24,6 +24,7 @@ spec:
       environment:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: "true"
+        INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: false
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.41
+    version: 0.0.42
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -14,7 +14,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.0.41
+    version: 0.0.42
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1187

### Change description ###

Bump blob-router chart version in all envs and override `INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN` in demo.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
