### PR TITLE
Disabling linting for cmc-ccd as flux is overrding indentation

### DIFF
--- a/k8s/demo/common/money-claims/cmc-ccd.yaml
+++ b/k8s/demo/common/money-claims/cmc-ccd.yaml
@@ -112,16 +112,19 @@ spec:
 
     ccd-user-profile-importer:
       image: hmctspublic.azurecr.io/ccd/user-profile-importer:db3j14
+      # yamllint disable rule:indentation
       users:
       - civilmoneyclaims+ccd@gmail.com|CMC|MoneyClaimCase|open
       - civilmoneyclaims+judge@gmail.com|CMC|MoneyClaimCase|orderForJudgeReview
       - civilmoneyclaims+la@gmail.com|CMC|MoneyClaimCase|readyForDirections
+      # yamllint enable rule:indentation
 
     ccd-definition-importer:
       image: hmctspublic.azurecr.io/cmc/ccd-definition-importer:1.5.15.4
       environment:
         CCD_DEF_CLAIM_STORE_BASE_URL: "{{ .Values.global.cmcBackendUrl }}"
       definitionFilename: cmc-ccd.xlsx
+      # yamllint disable rule:indentation
       userRoles:
       - citizen
       - caseworker-cmc
@@ -132,3 +135,4 @@ spec:
       - caseworker-cmc-anonymouscitizen
       - caseworker-cmc-judge
       - caseworker-cmc-legaladvisor
+      # yamllint enable rule:indentation


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
