### PR TITLE
Update jenkins / plugins / enable system read

### DIFF
--- a/k8s/namespaces/jenkins/jenkins.yaml
+++ b/k8s/namespaces/jenkins/jenkins.yaml
@@ -22,7 +22,7 @@ spec:
       # Used for label app.kubernetes.io/component
       componentName: "jenkins-master"
       image: "hmctspublic.azurecr.io/jenkins"
-      imageTag: "db3qfy"
+      imageTag: "db3v47"
       imagePullPolicy: "IfNotPresent"
       podLabels:
         aadpodidbinding: jenkins
@@ -106,6 +106,7 @@ spec:
                     - "Overall/Administer:300e771f-856c-45cc-b899-40d78281e9c1"
                     - "Overall/Administer:c36eaede-a0ae-4967-8fed-0a02960b1370"
                     - "Overall/Administer:3830f73c-22c0-436c-893d-e1869d2bc551" # platform engineering in RPE899 tenant
+                    - "Overall/SystemRead:authenticated"
                     - "Overall/Read:authenticated"
                     - "View/Read:authenticated"
                     - "Run/Replay:authenticated"


### PR DESCRIPTION
system read is: https://jenkins.io/jep/224

Grants read only access to most of jenkins, means people can see plugin versions, and some system logs