### PR TITLE
Extend lease timeout for bulk-scan-processor in prod

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -36,6 +36,7 @@ spec:
         OCR_VALIDATION_URL_DIVORCE: ""
         OCR_VALIDATION_URL_FINREM: ""
         DELETE_COMPLETE_FILES_CRON: "* 0/10 * * * *"
+        STORAGE_BLOB_LEASE_TIMEOUT: 60
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

Extend lease timeout for bulk-scan-processor in prod, in order to avoid conflicts due to poor DB performance.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
