### PR TITLE
Bump bulk-scan-processor 0.2.23 -> 0.2.24

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-processor.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.23
+    version: 0.2.24
   values:
     java:
       replicas: 2
@@ -25,9 +25,6 @@ spec:
       image: hmctspublic.azurecr.io/bulk-scan/processor:prod-be43cc96
       environment:
         STORAGE_BLOB_SELECTED_CONTAINER: ALL
-        ERROR_NOTIFICATIONS_ENABLED: true
-        # temporary var to recreate pod and pick up current values from key vault
-        DUMMY_VAR: remove-it
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/demo/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/demo/common/bsp/bulk-scan-processor.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.23
+    version: 0.2.24
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/perftest/common/bsp/bulk-scan-processor.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.23
+    version: 0.2.24
   values:
     java:
       replicas: 2
@@ -25,7 +25,6 @@ spec:
       image: hmctspublic.azurecr.io/bulk-scan/processor:prod-be43cc96
       environment:
         STORAGE_BLOB_SELECTED_CONTAINER: ALL
-        ERROR_NOTIFICATIONS_ENABLED: true
         OCR_VALIDATION_URL_DIVORCE: ""
         OCR_VALIDATION_URL_FINREM: ""
         OCR_VALIDATION_URL_PROBATE: ""

--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.2.23
+    version: 0.2.24
   values:
     java:
       replicas: 2
@@ -31,7 +31,6 @@ spec:
         SCAN_DELAY: 300000
         REUPLOAD_DELAY: 600000
         STORAGE_BLOB_PUBLIC_KEY: trusted_public_key.der
-        ERROR_NOTIFICATIONS_ENABLED: true
         NO_NEW_ENVELOPES_TASK_ENABLED: true
         OCR_VALIDATION_URL_DIVORCE: ""
         OCR_VALIDATION_URL_FINREM: ""


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Clean up legacy notification code in bulk scan processor](https://tools.hmcts.net/jira/browse/BPS-1090)

### Change description ###

Removes unused configuration: hmcts/bulk-scan-processor#1207

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
