### PR TITLE
Enable fpl security on aat

### DIFF
--- a/k8s/aat/common/family-public-law/fpl-case-service.yaml
+++ b/k8s/aat/common/family-public-law/fpl-case-service.yaml
@@ -31,7 +31,6 @@ spec:
         FEATURE_TOGGLE_ROBOTICS_CASE_NUMBER_NOTIFICATION_ENABLED: true
         FEATURE_TOGGLE_ROBOTICS_SUPPORT_API_ENABLED: true
         AUTH_IDAM_CLIENT_BASEURL: https://idam-api.aat.platform.hmcts.net
-        SPRING_SECURITY_ENABLED: false
     global:
       environment: aat
       subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"


### PR DESCRIPTION
Security was turn off temporarily for testing purpose on 19th April 2020
https://github.com/hmcts/cnp-flux-config/pull/3168/files