### PR TITLE
Fix resource group name for s2s in bulk-scan-processor tests aat

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-processor.yaml
@@ -47,7 +47,7 @@ spec:
               storage-account-name: TEST_STORAGE_ACCOUNT_NAME
               processed-envelopes-queue-send-connection-string: PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING
           s2s:
-            resourceGroup: rpe-service-auth-provider-aat
+            resourceGroup: rpe-service-auth-provider
             secrets:
               microservicekey-bulk-scan-processor-tests: TEST_S2S_SECRET
         environment:


### PR DESCRIPTION
### Change description ###

Fix resource group name for s2s in bulk-scan-processor tests aat. Env suffix shouldn't be added by default.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
