### PR TITLE
Disable env-injector automation

### DIFF
--- a/k8s/namespaces/admin/env-injector/env-injector.yaml
+++ b/k8s/namespaces/admin/env-injector/env-injector.yaml
@@ -5,7 +5,7 @@ metadata:
   name: env-injector-webhook
   namespace: admin
   annotations:
-    fluxcd.io/automated: "true"
+    fluxcd.io/automated: "false"
     fluxcd.io/tag.job: glob:*
 spec:
   releaseName: env-injector-webhook


### PR DESCRIPTION
```
done success=false err="applying changes: updating resource admin:helmrelease/env-injector-webhook in k8s/prod/cluster-00-overlay/.flux.yaml: no update.containerImage commands to run in .flux.yaml (from path k8s/prod/cluster-00-overlay)"
```