### PR TITLE
Fix the retrieval of test s2s secret for bulk-scan-processor in aat

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-processor.yaml
@@ -46,10 +46,7 @@ spec:
               storage-account-primary-key: TEST_STORAGE_ACCOUNT_KEY
               storage-account-name: TEST_STORAGE_ACCOUNT_NAME
               processed-envelopes-queue-send-connection-string: PROCESSED_ENVELOPES_QUEUE_WRITE_CONN_STRING
-          s2s:
-            resourceGroup: rpe-service-auth-provider
-            secrets:
-              microservicekey-bulk-scan-processor-tests: TEST_S2S_SECRET
+              test-s2s-secret: TEST_S2S_SECRET
         environment:
           TEST_URL: "http://bulk-scan-processor-java"
           SLACK_CHANNEL: "bsp-build-notices"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1229

### Change description ###

Fix the retrieval of test s2s secret for bulk-scan-processor in aat - take it from bulk-scan vault instead of s2s vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
