### PR TITLE
Bump chart version to 0.0.7 on AAT and Prod

### DIFF
--- a/k8s/aat/common/rd/professional-api.yaml
+++ b/k8s/aat/common/rd/professional-api.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rd-professional-api
-    version: 0.0.6
+    version: 0.0.7
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/rd/professional-api.yaml
+++ b/k8s/prod/common/rd/professional-api.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rd-professional-api
-    version: 0.0.6
+    version: 0.0.7
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

### Change description ###
Bump up chart version to 0.0.7 on AAT and Prod to fix the below warning.

**Warning: AKS cluster prod-aks-01 is running rd/professional-api:prod-545ef235 instead of rd/professional-api:prod-50130c37 (2020-05-12T14:04:07.5011831Z).**



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
