### PR TITLE
Remove test config for blob-router in aat

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -7,15 +7,6 @@ metadata:
   annotations:
     flux.weave.works/automated: "true"
     flux.weave.works/tag.java: glob:prod-*
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/functionalcron: java.functionaltestscron.image
-    filter.fluxcd.io/functionalcron: glob:prod-*
-    repository.fluxcd.io/smoke: java.smoketests.image
-    filter.fluxcd.io/smoke: glob:prod-*
-    repository.fluxcd.io/functional: java.functionaltests.image
-    filter.fluxcd.io/functional: glob:prod-*
 spec:
   releaseName: reform-scan-blob-router
   rollback:
@@ -33,43 +24,6 @@ spec:
       environment:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: "true"
-      testsConfig:
-        memoryLimits: "3072Mi"
-        serviceAccountName: tests-service-account
-        keyVaults:
-          reform-scan:
-            resourceGroup: reform-scan
-            secrets:
-              # Base64-encoded PKCS 12 key store, containing client's private key and certificate known to the API
-              test-valid-key-store: TEST_VALID_KEY_STORE
-              test-valid-key-store-password: TEST_VALID_KEY_STORE_PASSWORD
-              # Base64-encoded PKCS 12 key store containing private key and certificate known to the API, but expired
-              test-expired-key-store: TEST_EXPIRED_KEY_STORE
-              test-expired-key-store-password: TEST_EXPIRED_KEY_STORE_PASSWORD
-              # Base64-encoded PKCS12 key store containing private key and certificate known to the API, but not yet valid
-              test-not-yet-valid-key-store: TEST_NOT_YET_VALID_KEY_STORE
-              test-not-yet-valid-key-store-password: TEST_NOT_YET_VALID_KEY_STORE_PASSWORD
-              test-subscription-key: TEST_SUBSCRIPTION_KEY
-              storage-account-secondary-key: TEST_STORAGE_ACCOUNT_KEY
-              storage-account-name: TEST_STORAGE_ACCOUNT_NAME
-        environment:
-          TEST_URL: "http://reform-scan-blob-router-aat.service.core-compute-aat.internal"
-          SLACK_CHANNEL: "bsp-test-notices"
-          SLACK_NOTIFY_SUCCESS: true
-          TEST_STORAGE_CONTAINER_NAME: "bulkscan"
-          TEST_STORAGE_ACCOUNT_URL: "https://reformscanaat.blob.core.windows.net"
-          API_GATEWAY_URL: "https://core-api-mgmt-aat.azure-api.net/reform-scan"
-          RUN_END_TO_END_TESTS: true
-      functionaltestscron:
-        enabled: true
-        image: hmctspublic.azurecr.io/reform-scan/blob-router-test:prod-26bd21d6
-        schedule: "5/30 6-19 * * mon-fri"
-      smoketests:
-        enabled: true
-        image: hmctspublic.azurecr.io/reform-scan/blob-router-test:prod-26bd21d6
-      functionaltests:
-        enabled: true
-        image: hmctspublic.azurecr.io/reform-scan/blob-router-test:prod-26bd21d6
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

Remove test config for blob-router in aat. Those tests were failing due to an error in runTests.sh and as a result, the service pods were being killed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
