### PR TITLE
Revert "Increase deployment timeout for blob-router in aat to 15 minutes"

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -9,7 +9,6 @@ metadata:
     flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: reform-scan-blob-router
-  timeout: 900
   rollback:
     enable: true
     retry: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#3674

Reson: not necessary in blob-router. Should have been bulk-scan-orchestrator