### PR TITLE
Reduce SAS token permissions in blob-router prod

### DIFF
--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -33,7 +33,7 @@ spec:
         CRIME_ENABLED: true
         SEND_DAILY_REPORT_ENABLED: true
         SMTP_HOST: smtp.office365.com
-        DUMMY_VAR: true
+        INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: false
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1187

### Change description ###

Remove `write` permission from SAS tokens served by blob-router in prod.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
