### PR TITLE
Reduce SAS token permissions in blob-router aat

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -24,6 +24,7 @@ spec:
       environment:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: "true"
+        INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: false
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1187

### Change description ###

Remove write permission from SAS tokens served by blob-router in aat.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
