### PR TITLE
Fix bad cast to 1.8e+06

### DIFF
--- a/k8s/aat/common/idam/idam-api.yaml
+++ b/k8s/aat/common/idam/idam-api.yaml
@@ -28,7 +28,7 @@ spec:
         ENDPOINTS_INFO_ENABLED: true
         CACHING_USERS_MAXTHREADS: 2
         CACHING_USERS_MAXHTTPCALLS: 1
-        CACHING_USERS_RECACHEINTERVAL: 1800000
+        CACHING_USERS_RECACHEINTERVAL: "1800000"
         STRATEGIC_ADMIN_URL: https://idam-web-admin.aat.platform.hmcts.net
         STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.aat.platform.hmcts.net
         STRATEGIC_API_URL: https://idam-api.aat.platform.hmcts.net


### PR DESCRIPTION
org.springframework.beans.TypeMismatchException: Failed to convert value of type 'java.lang.String' to required type 'long'; nested exception is java.lang.NumberFormatException: For input string: "1.8e+06"
### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
