### PR TITLE
Bump notification service 0.0.13 -> 0.1.0

### DIFF
--- a/k8s/aat/common/reform-scan/notification-service.yaml
+++ b/k8s/aat/common/reform-scan/notification-service.yaml
@@ -37,7 +37,7 @@ spec:
             secrets:
               notifications-queue-listen-connection-string: NOTIFICATION_QUEUE_CONN_STRING_READ
               notifications-queue-send-connection-string: NOTIFICATION_QUEUE_CONN_STRING_WRITE
-              s2s-secret: S2S_SECRET
+              test-s2s-secret: TEST_S2S_SECRET
         environment:
           TEST_URL: "http://reform-scan-notification-service-aat.service.core-compute-aat.internal"
           SLACK_CHANNEL: "bsp-test-notices"

--- a/k8s/aat/common/reform-scan/notification-service.yaml
+++ b/k8s/aat/common/reform-scan/notification-service.yaml
@@ -22,7 +22,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-notification-service
-    version: 0.0.13
+    version: 0.1.0
   values:
     java:
       replicas: 2
@@ -32,15 +32,12 @@ spec:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account
         keyVaults:
-          bulk-scan:
-            resourceGroup: bulk-scan
-            secrets:
-              s2s-secret: S2S_SECRET
           reform-scan:
             resourceGroup: reform-scan
             secrets:
               notifications-queue-listen-connection-string: NOTIFICATION_QUEUE_CONN_STRING_READ
               notifications-queue-send-connection-string: NOTIFICATION_QUEUE_CONN_STRING_WRITE
+              s2s-secret: S2S_SECRET
         environment:
           TEST_URL: "http://reform-scan-notification-service-aat.service.core-compute-aat.internal"
           SLACK_CHANNEL: "bsp-test-notices"

--- a/k8s/perftest/common/reform-scan/notification-service.yaml
+++ b/k8s/perftest/common/reform-scan/notification-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-notification-service
-    version: 0.0.13
+    version: 0.1.0
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/reform-scan/notification-service.yaml
+++ b/k8s/prod/common/reform-scan/notification-service.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-notification-service
-    version: 0.0.13
+    version: 0.1.0
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

[AKS tests - notification service](https://tools.hmcts.net/jira/browse/BPS-1233)

### Change description ###

No significant change is involved. Marking to next step mainly for chart change - keeps next bumps cleaner too :)

Change involve: hmcts/reform-scan-notification-service#155

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
