### PR TITLE
Removing botkube alerts for daemonsets as it just spams when a node is added/removed

### DIFF
--- a/k8s/namespaces/monitoring/botkube/botkube.yaml
+++ b/k8s/namespaces/monitoring/botkube/botkube.yaml
@@ -98,7 +98,6 @@ spec:
             includeDiff: true
             fields:
               - spec.template.spec.containers[*].image
-              - status.numberReady
         - name: job
           namespaces:
             include:


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
