### PR TITLE
Update flags for test images for notification service aks tests

### DIFF
--- a/k8s/aat/common/reform-scan/notification-service.yaml
+++ b/k8s/aat/common/reform-scan/notification-service.yaml
@@ -45,10 +45,10 @@ spec:
           S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
       smoketests:
         enabled: true
-        image: hmctspublic.azurecr.io/reform-scan/notification-service-test:latest
+        image: hmctspublic.azurecr.io/reform-scan/notification-service-test:prod-786668fa
       functionaltests:
         enabled: true
-        image: hmctspublic.azurecr.io/reform-scan/notification-service-test:latest
+        image: hmctspublic.azurecr.io/reform-scan/notification-service-test:prod-786668fa
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/prod/common/reform-scan/notification-service.yaml
+++ b/k8s/prod/common/reform-scan/notification-service.yaml
@@ -38,7 +38,7 @@ spec:
           SLACK_NOTIFY_SUCCESS: true
       smoketests:
         enabled: true
-        image: hmctspublic.azurecr.io/reform-scan/notification-service-test:latest
+        image: hmctspublic.azurecr.io/reform-scan/notification-service-test:prod-786668fa
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

> Error response from daemon: manifest for hmctspublic.azurecr.io/reform-scan/notification-service-test:latest not found: manifest unknown: manifest tagged by "latest" is not found

Using the one which just got deployed :rocket: 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
