### PR TITLE
Fix env var in reform-scan-notification-service-aat for functional tests

### DIFF
--- a/k8s/aat/common/reform-scan/notification-service.yaml
+++ b/k8s/aat/common/reform-scan/notification-service.yaml
@@ -42,7 +42,7 @@ spec:
           TEST_URL: "http://reform-scan-notification-service-aat.service.core-compute-aat.internal"
           SLACK_CHANNEL: "bsp-test-notices"
           SLACK_NOTIFY_SUCCESS: true
-          S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+          TEST_S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
       smoketests:
         enabled: true
         image: hmctspublic.azurecr.io/reform-scan/notification-service-test:prod-c790abea


### PR DESCRIPTION
### Change description ###

:facepalm: so obvious. must've copied from actual source and didn't apply this single place for testing job

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
