### PR TITLE
Silence continuous success slack notifications for reform-scan-notificaiton-service

### DIFF
--- a/k8s/aat/common/reform-scan/notification-service.yaml
+++ b/k8s/aat/common/reform-scan/notification-service.yaml
@@ -41,7 +41,7 @@ spec:
         environment:
           TEST_URL: "http://reform-scan-notification-service-aat.service.core-compute-aat.internal"
           SLACK_CHANNEL: "bsp-test-notices"
-          SLACK_NOTIFY_SUCCESS: true
+          SLACK_NOTIFY_SUCCESS: false
           TEST_S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
       smoketests:
         enabled: true

--- a/k8s/prod/common/reform-scan/notification-service.yaml
+++ b/k8s/prod/common/reform-scan/notification-service.yaml
@@ -35,7 +35,7 @@ spec:
         environment:
           TEST_URL: "http://reform-scan-notification-service-prod.service.core-compute-prod.internal"
           SLACK_CHANNEL: "bsp-test-notices"
-          SLACK_NOTIFY_SUCCESS: true
+          SLACK_NOTIFY_SUCCESS: false
       smoketests:
         enabled: true
         image: hmctspublic.azurecr.io/reform-scan/notification-service-test:prod-c790abea


### PR DESCRIPTION
### Change description ###

Verified things are working as expected. Team practice applied - silencing those notifications now

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
