### PR TITLE
Add ia-home-office-mock-api to AAT

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -85,6 +85,7 @@ k8s/**/common/ia/case-documents-api.yaml @hmcts/immigration-asylum
 k8s/**/common/ia/case-notifications-api.yaml @hmcts/immigration-asylum
 k8s/**/common/ia/aip-frontend.yaml @hmcts/immigration-asylum
 k8s/aat/common/ia/home-office-integration-api.yaml @hmcts/immigration-asylum
+k8s/aat/common/ia/home-office-mock-api.yaml @hmcts/immigration-asylum
 k8s/aat/common/ia/timed-event-service.yaml @hmcts/immigration-asylum
 k8s/aat/common/ia/case-payments-api.yaml @hmcts/immigration-asylum
 

--- a/k8s/aat/common/ia/home-office-mock-api.yaml
+++ b/k8s/aat/common/ia/home-office-mock-api.yaml
@@ -22,7 +22,6 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ia/home-office-mock-api:latest
-      ingressHost: ia-home-office-mock-api-aat.service.core-compute-aat.internal
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/aat/common/ia/home-office-mock-api.yaml
+++ b/k8s/aat/common/ia/home-office-mock-api.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-home-office-mock-api
+  namespace: ia
+  annotations:
+    fluxcd.io/automated: "true"
+    repository.fluxcd.io/java: java.image
+    filter.fluxcd.io/java: glob:prod-*
+spec:
+  releaseName: ia-home-office-mock-api
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: ia-home-office-mock-api
+    version: 0.0.1
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/ia/home-office-mock-api:latest
+      ingressHost: ia-home-office-mock-api-aat.service.core-compute-aat.internal
+    global:
+      environment: aat
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true


### PR DESCRIPTION
Run ia-home-office-mock-api in AAT environment
ia-home-office-integration-api needs a mock server, for testing purpose.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-3074
https://tools.hmcts.net/jira/browse/RIA-3071

### Change description ###
ia-home-office-integration-api needs a mock server, for testing purpose. We have generated a server stub in ia-home-office-mock-api, which should be available in AAT
The server in Preview gets stale and is removed after some time.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
