### PR TITLE
Remove an unused environment variable from blob-router's config

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -31,7 +31,6 @@ spec:
       environment:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: "true"
-        INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: false
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account

--- a/k8s/demo/cluster-00/reform-scan/blob-router.yaml
+++ b/k8s/demo/cluster-00/reform-scan/blob-router.yaml
@@ -24,7 +24,6 @@ spec:
       environment:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: "true"
-        INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: false
         TASK_SCAN_DELAY: 300000
     global:
       environment: demo

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -38,7 +38,6 @@ spec:
         CRIME_ENABLED: true
         SEND_DAILY_REPORT_ENABLED: true
         SMTP_HOST: smtp.office365.com
-        INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN: false
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1187

### Change description ###

Remove a no longer used environment variable (`INCLUDE_WRITE_PERMISSION_IN_STORAGE_SAS_TOKEN`) from blob-router's config

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
