### PR TITLE
Revert "Increase the number of replicas for bulk-scan-orchestrator in prod"

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-orchestrator.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-orchestrator.yaml
@@ -23,7 +23,7 @@ spec:
     version: 0.2.11
   values:
     java:
-      replicas: 4
+      replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/bulk-scan/orchestrator:prod-c035f888
       environment:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#3949

The increased number of replicas is no longer needed.