### PR TITLE
Fixed regular expression as all reform scan projects were not appearing

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -70,7 +70,7 @@ spec:
                     title: Platform
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_.*BSP.*\/(blob-router-service|bulk-scan-.*|reform-scan-*|send-letter-client|send-letter-service)\/master
+                      ^HMCTS_.*BSP.*\/(blob-router-service|bulk-scan-.*|reform-scan-.*|send-letter-client|send-letter-service)\/master
                     name: BSP
                     recurse: true
                     title: BSP


### PR DESCRIPTION
- Added dot to reform scan regular expression so that all reform scan projects are displayed in Jenkins view.