### PR TITLE
Adding seperate ingress for pdf service

### DIFF
--- a/k8s/aat/common/rpe/pdf-service-ingress.yaml
+++ b/k8s/aat/common/rpe/pdf-service-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+  name: rpe-pdf-service
+  namespace: rpe
+spec:
+  rules:
+  - host: cmc-pdf-service-aat.service.core-compute-aat.internal
+    http:
+      paths:
+      - backend:
+          serviceName: pdf-service-java
+          servicePort: 80
+        path: /

--- a/k8s/demo/common/rpe/pdf-service-ingress.yaml
+++ b/k8s/demo/common/rpe/pdf-service-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+  name: rpe-pdf-service
+  namespace: rpe
+spec:
+  rules:
+  - host: cmc-pdf-service-demo.service.core-compute-demo.internal
+    http:
+      paths:
+      - backend:
+          serviceName: pdf-service-java
+          servicePort: 80
+        path: /

--- a/k8s/ithc/common/rpe/pdf-service-ingress.yaml
+++ b/k8s/ithc/common/rpe/pdf-service-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+  name: rpe-pdf-service
+  namespace: rpe
+spec:
+  rules:
+  - host: cmc-pdf-service-ithc.service.core-compute-ithc.internal
+    http:
+      paths:
+      - backend:
+          serviceName: pdf-service-java
+          servicePort: 80
+        path: /

--- a/k8s/perftest/common/rpe/pdf-service-ingress.yaml
+++ b/k8s/perftest/common/rpe/pdf-service-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+  name: rpe-pdf-service
+  namespace: rpe
+spec:
+  rules:
+  - host: cmc-pdf-service-perftest.service.core-compute-perftest.internal
+    http:
+      paths:
+      - backend:
+          serviceName: pdf-service-java
+          servicePort: 80
+        path: /


### PR DESCRIPTION
Idea is to change the chart ingress to rpe-pdf-service and ask service teams to point to it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
