### PR TITLE
Remove fee keyword from ithc Divorce

### DIFF
--- a/k8s/ithc/common/divorce/div-fps.yaml
+++ b/k8s/ithc/common/divorce/div-fps.yaml
@@ -32,8 +32,6 @@ spec:
       aadIdentityName: divorce
       prometheus:
         enabled: true
-      environment:
-        GENERAL_APPLICATION_WITHOUT_NOTICE_FEE_KEYWORD: "without-notice"
     global:
       environment: ithc
       subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"


### PR DESCRIPTION
### Change description ###

As ithc is not used in Divorce, then removing the recently added fee keyword variable. 

**Does this PR introduce a breaking change?** 

```
[ ] Yes
[x] No
```
