### PR TITLE
Feature toggle off FEATURE_PAPER_UPDATE on demo

### DIFF
--- a/k8s/demo/common/divorce/div-cos.yaml
+++ b/k8s/demo/common/divorce/div-cos.yaml
@@ -32,7 +32,7 @@ spec:
       environment:
         IDAM_API_URL: "https://idam-api.demo.platform.hmcts.net"
         FEATURE_DN_REFUSAL: "true"
-        FEATURE_PAPER_UPDATE: true
+        FEATURE_PAPER_UPDATE: false
         DOCUMENT_GENERATOR_SERVICE_API_BASEURL: "http://div-dgs-java.divorce"
         FEATURE_RESP_SOLICITOR_DETAILS: "true"
         SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: false


### PR DESCRIPTION
Just to make sure bulk printing will not happen.

According to email I've got docs sent to bulk printing service on demo WILL BE printed and sent.

This is why I switch it off.  We can easily turn it on when needed (eg for acceptance testing).