### PR TITLE
Remove blob processing delay in blob-router

### DIFF
--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -26,7 +26,7 @@ spec:
         HANDLE_REJECTED_FILES_CRON: "0 0 7 * * *"
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"
         TASK_SCAN_DELAY: 300000
-        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
+        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: true
     global:
       environment: perftest

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -30,7 +30,7 @@ spec:
         HANDLE_REJECTED_FILES_CRON: "0 0 7 * * *"
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"
         TASK_SCAN_DELAY: 300000
-        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 30
+        STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         STORAGE_URL: https://reformscan.platform.hmcts.net
         STORAGE_BULKSCAN_URL: https://bulkscan.platform.hmcts.net
         STORAGE_BLOB_PUBLIC_KEY: "trusted_public_key.der"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-1266

### Change description ###

Remove blob processing delay in blob-router. It used to be half an hour before blob-router would pick up files for processing (in prod and perftest), but now the wait is unnecessary.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
