### PR TITLE
Added dummy var to force restart pods

### DIFF
--- a/k8s/prod/common/bsp/bulk-scan-processor.yaml
+++ b/k8s/prod/common/bsp/bulk-scan-processor.yaml
@@ -42,6 +42,7 @@ spec:
         OCR_VALIDATION_URL_SSCS: ""
         DELETE_COMPLETE_FILES_CRON: "0 0/10 * * * *"
         STORAGE_BLOB_LEASE_TIMEOUT: 60
+        FORCE_RESTART: true
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account


### PR DESCRIPTION

### Change description ###

- Storage keys have refreshed in key vault but pods still have the old keys hence adding a dummy var for force restart

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
