### PR TITLE
Amend queue consumption frequency for notification service

### DIFF
--- a/k8s/prod/common/reform-scan/notification-service.yaml
+++ b/k8s/prod/common/reform-scan/notification-service.yaml
@@ -27,6 +27,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/reform-scan/notification-service:prod-86b05c70
       environment:
+        NOTIFICATIONS_CONSUME_TASK_DELAY_IN_MS: "600000"
         PENDING_NOTIFICATIONS_TASK_DELAY_IN_MS: "1800000"
         PENDING_NOTIFICATIONS_TASK_ENABLED: false
       testsConfig:


### PR DESCRIPTION
### Change description ###

There is no need to run every 3 seconds in case error notifications never show up. Ideally they should never show up. We are OK with 10 minutes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
