### PR TITLE
Fix permission for watching service

### DIFF
--- a/k8s/namespaces/admin/external-dns/external-dns-clusterrole.yaml
+++ b/k8s/namespaces/admin/external-dns/external-dns-clusterrole.yaml
@@ -4,10 +4,7 @@ metadata:
   name: external-dns
 rules:
 - apiGroups: [""]
-  resources: ["services"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: [""]
-  resources: ["pods"]
+  resources: ["services", "endpoints", "pods"]
   verbs: ["get", "watch", "list"]
 - apiGroups: ["extensions"]
   resources: ["ingresses"]


### PR DESCRIPTION
Mentioned in release notes:
https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.7.2

[AB#947](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/947)