### PR TITLE
Enable autorelease - 2.1 html error patch

### DIFF
--- a/k8s/prod/common/idam/idam-web-public.yaml
+++ b/k8s/prod/common/idam/idam-web-public.yaml
@@ -5,7 +5,7 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    fluxcd.io/automated: "false"
+    fluxcd.io/automated: "true"
     filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: idam-web-public

--- a/k8s/prod/common/idam/idam-web-public.yaml
+++ b/k8s/prod/common/idam/idam-web-public.yaml
@@ -5,7 +5,7 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    fluxcd.io/automated: "true"
+    fluxcd.io/automated: "false"
     filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: idam-web-public


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-4398

### Change description ###

Front Door caching drops `accept` and `accept-language` headers. This fixes the default content-type for errors on idam-web-public.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
