### PR TITLE
RPET-238: Add payment keyword to FR prod

### DIFF
--- a/k8s/aat/common/financial-remedy/finrem-ps.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-ps.yaml
@@ -21,8 +21,6 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/finrem/ps:prod-8ce34d71
-      environment:
-        GENERAL_APPLICATION_WITHOUT_NOTICE_FEE_KEYWORD: "GeneralAppWithoutNotice"
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/demo/common/financial-remedy/finrem-ps.yaml
+++ b/k8s/demo/common/financial-remedy/finrem-ps.yaml
@@ -21,8 +21,6 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/finrem/ps:prod-8ce34d71
-      environment:
-        GENERAL_APPLICATION_WITHOUT_NOTICE_FEE_KEYWORD: "GeneralAppWithoutNotice"
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/prod/common/financial-remedy/finrem-ps.yaml
+++ b/k8s/prod/common/financial-remedy/finrem-ps.yaml
@@ -25,7 +25,6 @@ spec:
         singleRequestTcp: false
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
-        GENERAL_APPLICATION_WITHOUT_NOTICE_FEE_KEYWORD: "without-notice"
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RPET-238

### Change description ###

Changing General Application Without Notice fee keyword on prod for FR - coordinated with FeePay. 
As flux was used to merge per environment, this is now deleted. 
The value is instead stored in finrem-payments-service in values.yaml as all environments will from this PR onwards use the same keyword. 

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
