### PR TITLE
increase memory for AAT

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -26,6 +26,7 @@ spec:
   values:
     java:
       replicas: 2
+      memoryLimits: "4096Mi"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/reform-scan/blob-router:prod-d5473a38
       environment:


### PR DESCRIPTION
### Change description ###

blolb router pods in aat-01 get OutOfMemoryError: Java heap space
pods are crashing constantly and sometimes request goes this cluster and gets "404 page not found" error.
that is why e2e test are failing currently.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
