### PR TITLE
Disable build failure analyser

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -264,7 +264,7 @@ spec:
               buildFailureAnalyzer:
                 doNotAnalyzeAbortedJob: false
                 gerritTriggerEnabled: true
-                globalEnabled: true
+                globalEnabled: false
                 graphsEnabled: true
                 knowledgeBase:
                   mongoDB:

--- a/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
@@ -112,7 +112,7 @@ spec:
               buildFailureAnalyzer:
                 doNotAnalyzeAbortedJob: false
                 gerritTriggerEnabled: true
-                globalEnabled: true
+                globalEnabled: false
                 graphsEnabled: true
                 knowledgeBase:
                   mongoDB:


### PR DESCRIPTION
Agreed to disable it due to it being poorly maintained and it causes a lot of IO load when scanning build logs