### PR TITLE
Reduce logging level in aat/demo for bulk scan orchestrator

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-orchestrator.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-orchestrator.yaml
@@ -29,6 +29,8 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/bulk-scan/orchestrator:prod-dcbdc1de
+      environment:
+        ROOT_LOGGING_LEVEL: DEBUG
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account

--- a/k8s/demo/cluster-00/bsp/bulk-scan-orchestrator.yaml
+++ b/k8s/demo/cluster-00/bsp/bulk-scan-orchestrator.yaml
@@ -21,6 +21,8 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/bulk-scan/orchestrator:pr-1021-83d361f4
+      environment:
+        ROOT_LOGGING_LEVEL: DEBUG
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Log the content of CCD error responses in non-production environments](https://tools.hmcts.net/jira/browse/BPS-697)

### Change description ###

App Insights will take into affect after hmcts/bulk-scan-orchestrator#1023 image is deployed to those environments

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
