### PR TITLE
Lower log level in aat/demo for bsp payments

### DIFF
--- a/k8s/aat/common/bsp/bulk-scan-payment-processor.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-payment-processor.yaml
@@ -30,7 +30,7 @@ spec:
       applicationInsightsInstrumentKey: "f666440f-43c0-4abb-9c20-2ce175a374f0"
       image: hmctspublic.azurecr.io/bulk-scan/payment-processor:prod-bcb5cda6
       environment:
-        FORCE_RESTART: true
+        ROOT_LOGGING_LEVEL: DEBUG
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account

--- a/k8s/demo/cluster-00/bsp/bulk-scan-payment-processor.yaml
+++ b/k8s/demo/cluster-00/bsp/bulk-scan-payment-processor.yaml
@@ -22,7 +22,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/bulk-scan/payment-processor:prod-bcb5cda6
       environment:
-        FORCE_RESTART: true
+        ROOT_LOGGING_LEVEL: DEBUG
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Log the content of CCD error responses in non-production environments](https://tools.hmcts.net/jira/browse/BPS-697)

### Change description ###

There's a single call in payment processor - amending level for those environments too. Will only take into affect once

- hmcts/bulk-scan-payment-processor#242
- future pr to bump logging version to 5.1.6 is merged

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
