### PR TITLE
Remove /opt/jenkins pod volume

### DIFF
--- a/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
@@ -172,9 +172,6 @@ spec:
                       - hostPathVolume:
                           hostPath: "/var/run/docker.sock"
                           mountPath: "/var/run/docker.sock"
-                      - emptyDirVolume:
-                          memory: false
-                          mountPath: "/opt/jenkins"
                       yaml: |-
                         metadata:
                           labels:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

By the look of it it's causing this error:

BUG! exception in phase 'class generation' in source unit '/home/jenkins/agent/workspace/_Test_cnp-jenkins-library_PR-650/src/uk/gov/hmcts/contino/Gatling.groovy' unsupported Target MODULE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
