### PR TITLE
Bump send-letter-service 0.1.0 -> 0.1.1

### DIFF
--- a/k8s/aat/common/rpe/send-letter-service.yaml
+++ b/k8s/aat/common/rpe/send-letter-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/demo/common/rpe/send-letter-service.yaml
+++ b/k8s/demo/common/rpe/send-letter-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/ithc/common/rpe/send-letter-service.yaml
+++ b/k8s/ithc/common/rpe/send-letter-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/rpe/send-letter-service.yaml
+++ b/k8s/perftest/common/rpe/send-letter-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/rpe/send-letter-service.yaml
+++ b/k8s/prod/common/rpe/send-letter-service.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: rpe-send-letter-service
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Migrate send letter DB to version 11](https://tools.hmcts.net/jira/browse/BPS-1057)

### Change description ###

Enables 2nd db config: hmcts/send-letter-service#760

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
