### PR TITLE
Removed ucmc build dashboard and github app entry

### DIFF
--- a/k8s/namespaces/jenkins/jenkins.yaml
+++ b/k8s/namespaces/jenkins/jenkins.yaml
@@ -522,11 +522,6 @@ spec:
                           id: "hmcts-jenkins-rse"
                           privateKey: "${hmcts-jenkins-rse-ghapp}"
                       - gitHubApp:
-                          appID: "68302"
-                          description: "GitHub APP Key - ucmc"
-                          id: "hmcts-jenkins-ucmc"
-                          privateKey: "${hmcts-jenkins-ucmc-ghapp}"
-                      - gitHubApp:
                           appID: "72816"
                           description: "GitHub APP Key - unspec"
                           id: "hmcts-jenkins-unspec"

--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -226,12 +226,6 @@ spec:
                     title: Evidence Management
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_.*UCMC.*\/.+\/master
-                    name: UCMC
-                    recurse: true
-                    title: UCMC Data Dashboard
-                - buildMonitor:
-                    includeRegex: >-
                       ^HMCTS_.*UNSPEC.*\/.+\/master
                     name: UNSPEC
                     recurse: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-468

### Change description ###

UCMC is not used anymore, the team moved to Unspec name.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
