### PR TITLE
Sandbox enable acr in flux, but with secret instead of mount

### DIFF
--- a/k8s/namespaces/admin/flux/patches/sandbox/flux.yaml
+++ b/k8s/namespaces/admin/flux/patches/sandbox/flux.yaml
@@ -11,7 +11,7 @@ spec:
       user: "Flux sandbox"
     registry:
       acr:
-        enabled: false
+        enabled: true
         secretName: 'acr-credentials'
       includeImage: 'hmctspublic.azurecr.io/*,hmctsprivate.azurecr.io/*'
     prometheus:


### PR DESCRIPTION
Reenable acr, mount will not be turned on again as it is either mount or secret and secret is now enabled.
Relevant code in flux is here - https://github.com/fluxcd/flux/blob/master/chart/flux/templates/deployment.yaml#L75

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
