### PR TITLE
Add automation tests for kustomize folders

### DIFF
--- a/tests/test-kustomize.sh
+++ b/tests/test-kustomize.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -x
 
 curl -s "https://raw.githubusercontent.com/\
 kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
@@ -33,5 +33,23 @@ kustomizepaths=(
 )
 
 for path in "${kustomizepaths[@]}"; do
-    ./kustomize build --load_restrictor none $path >/dev/null
+    kustomize build --load_restrictor none $path >/dev/null
+    if [ $? -eq 1 ]
+    then
+     echo "Kustomize failing for env $path" && exit 1
+    fi
+done
+
+aat_whitelist_helm_release_pattern='sample\|another-sample' # Helm Release names seperated by `\|`
+prod_whitelist_helm_release_pattern='sample\|another-sample' # Helm Release names seperated by `\|`
+
+for env in $(echo "aat prod"); do
+  env_white_list=${env}_whitelist_helm_release_pattern
+  for path in $(echo "k8s/$env/cluster-00-overlay k8s/$env/cluster-01-overlay k8s/$env/common-overlay"); do
+    kustomize build --load_restrictor none $path | yq r  -d'*'  -j - metadata | (grep hmcts.github.com/prod-automated || true ) | grep -v ${!env_white_list}
+    if [ $? -eq 0 ]
+    then
+      echo "Non whitelisted HelmReleases found with hmcts.github.com/prod-automated annotation in $path" && exit 1
+    fi
+  done
 done


### PR DESCRIPTION
- With kustomize , you cannot check automation on files, instead it needs to be checked on effective kustomize build result. 
- By default all workloads are forced to have automation, Teams will be given an option to opt out of automation with `hmcts.github.com/prod-automated` annotation after having an exceptional approval. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
