### PR TITLE
chore(idam): add dummy env var to trigger pod restart

### DIFF
--- a/k8s/perftest/common/idam/idam-api.yaml
+++ b/k8s/perftest/common/idam/idam-api.yaml
@@ -31,6 +31,7 @@ spec:
         STRATEGIC_ADMIN_URL: https://idam-web-admin.perftest.platform.hmcts.net
         STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.perftest.platform.hmcts.net
         STRATEGIC_API_URL: https://idam-api.perftest.platform.hmcts.net
+        DUMMY_ENV_VAR_TO_TRIGGER_POD_RESTART: 27022020_01
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/perftest/common/idam/idam-web-admin.yaml
+++ b/k8s/perftest/common/idam/idam-web-admin.yaml
@@ -25,6 +25,7 @@ spec:
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.perftest.platform.hmcts.net
         STRATEGIC_PUBLIC_URL: https://idam-web-public.perftest.platform.hmcts.net
+        DUMMY_ENV_VAR_TO_TRIGGER_POD_RESTART: 27022020_01
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/perftest/common/idam/idam-web-public.yaml
+++ b/k8s/perftest/common/idam/idam-web-public.yaml
@@ -24,6 +24,7 @@ spec:
       aadIdentityName: idam
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.perftest.platform.hmcts.net
+        DUMMY_ENV_VAR_TO_TRIGGER_POD_RESTART: 27022020_01
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Change description ###

added a dummy env var to trigger a pod restart as our pipeline does not tag images correctly. changing the value will trigger a pod restart as we don't have permission to do this on the aks cluster.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
