### PR TITLE
Change PR link for `bulk-scan-orchestrator` in demo

### DIFF
--- a/k8s/demo/cluster-00/bsp/bulk-scan-orchestrator.yaml
+++ b/k8s/demo/cluster-00/bsp/bulk-scan-orchestrator.yaml
@@ -20,7 +20,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/bulk-scan/orchestrator:pr-1065-aae99c1a
+      image: hmctspublic.azurecr.io/bulk-scan/orchestrator:pr-1103-29e89041
       environment:
         ROOT_LOGGING_LEVEL: DEBUG
     global:

--- a/k8s/demo/cluster-00/bsp/bulk-scan-orchestrator.yaml
+++ b/k8s/demo/cluster-00/bsp/bulk-scan-orchestrator.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: bsp
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:pr-1065-*
+    flux.weave.works/tag.java: glob:pr-1103-*
 spec:
   releaseName: bulk-scan-orchestrator
   rollback:


### PR DESCRIPTION
### Change description ###

Switching deployment flag so manual activity in orchestrator can be verified against automated models

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
