### PR TITLE
Sandbox aad-pod-identity

### DIFF
--- a/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
@@ -6,8 +6,13 @@ metadata:
     k8s-app: aad-pod-id
   name: aad-pod-identity
   namespace: admin
+  annotations:
+    fluxcd.io/automated: "false"
 spec:
   releaseName: aad-pod-identity
+  rollback:
+    enable: true
+    retry: true
   chart:
     repository: https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts
     name: aad-pod-identity

--- a/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
@@ -19,3 +19,4 @@ spec:
     version: 1.6.2
   values:
     forceNameSpaced: true
+    installCRDs: true

--- a/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
@@ -6,8 +6,6 @@ metadata:
     k8s-app: aad-pod-id
   name: aad-pod-identity
   namespace: admin
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   releaseName: aad-pod-identity
   rollback:

--- a/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
+++ b/k8s/namespaces/admin/aad-pod-identity/aad-pod-identity.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     repository: https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts
     name: aad-pod-identity
-    version: 1.6.2
+    version: 2.0.1
   values:
     forceNameSpaced: true
     installCRDs: true


### PR DESCRIPTION
Chart version is actually 2.0.1 for app v 1.6.2, so needing fixing.
Also enabled rollbacks and install of CRDs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
