### PR TITLE
SIDM-n/a - feat(idam): autorelease exclusions

### DIFF
--- a/tests/flux-automation.sh
+++ b/tests/flux-automation.sh
@@ -19,6 +19,9 @@ exclusions=(
   k8s/aat/common/idam/idam-api.yaml
   k8s/aat/common/idam/idam-web-admin.yaml
   k8s/aat/common/idam/idam-web-public.yaml
+  k8s/prod/common/idam/idam-api.yaml
+  k8s/prod/common/idam/idam-web-admin.yaml
+  k8s/prod/common/idam/idam-web-public.yaml
 )
 
 [ -z "$_github_head_sha" ] && echo "Github head sha missing. Not on a PR" && exit 0


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-n/a

### Change description ###

feat(idam): autorelease exclusions

Allows IDAM to set autorelease false before production go live to facilitate running CICD ahead of release so that time is not wasted during the release window.

```
...
2.1 Go Live: AAT=aat-2.1, Prod=prod-2.1 (both built from the same pipeline/commit).
2.2 Development: AAT=aat-2.1, Prod=prod-2.1.
2.2 Regression Testing (GoLive -2 weeks): AAT=aat-2.2, Prod=prod-2.1.
2.2 Go Live (during the day): AAT=aat-2.2, Prod=prod-2.1 (**prod autorelease=false**).
2.2 Go Live: AAT=aat-2.2, Prod=prod-2.2 (both built from the same pipeline/commit). (**prod autorelease=true**).
...
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```