### PR TITLE
update wa azureidentity in aat

### DIFF
--- a/k8s/aat/common/wa/identity.yaml
+++ b/k8s/aat/common/wa/identity.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: wa
 spec:
   type: 0
-  ResourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/wa-aat-mi"
-  ClientID: "03ddf0d9-4c38-4189-b8b8-6c6090ebf4ee"
+  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/wa-aat-mi"
+  clientID: "03ddf0d9-4c38-4189-b8b8-6c6090ebf4ee"
 
 ---
 
@@ -16,5 +16,5 @@ metadata:
   name: wa-binding
   namespace: wa
 spec:
-  AzureIdentity: wa
-  Selector: wa
+  azureIdentity: wa
+  selector: wa


### PR DESCRIPTION
Wa identity was merged earlier, I just need to update the casing now to match the new version of aad-pod-identity.