### PR TITLE
Bumped blob-router version

### DIFF
--- a/k8s/aat/common/reform-scan/blob-router.yaml
+++ b/k8s/aat/common/reform-scan/blob-router.yaml
@@ -22,7 +22,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/demo/cluster-00/reform-scan/blob-router.yaml
+++ b/k8s/demo/cluster-00/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/reform-scan/blob-router.yaml
+++ b/k8s/perftest/common/reform-scan/blob-router.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/reform-scan/blob-router.yaml
+++ b/k8s/prod/common/reform-scan/blob-router.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.1.0
+    version: 0.1.1
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1367


### Change description ###
Bumped blob-router version to 0.1.1
https://github.com/hmcts/blob-router-service/pull/598

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
