### PR TITLE
Bump `bulk-scan-payment-processor` 0.2.2 -> 0.2.3

### DIFF
--- a/k8s/namespaces/bsp/bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-payment-processor
-    version: 0.2.2
+    version: 0.2.3
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Enables use of staging queue for aat functional tests on main pipeline run on jenkins platform. reference: hmcts/bulk-scan-payment-processor#274

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
