### PR TITLE
Bump bulk-scan-orchestrator 0.3.4 -> 0.3.5

### DIFF
--- a/k8s/namespaces/bsp/bulk-scan-orchestrator/bulk-scan-orchestrator.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-orchestrator/bulk-scan-orchestrator.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-orchestrator
-    version: 0.3.4
+    version: 0.3.5
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Removes no longer used env vars. Reference: hmcts/bulk-scan-orchestrator#1119

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
