### PR TITLE
SSCS-7852 - Tech debt – Change chart source for all helm releases to GitHub (prod)

### DIFF
--- a/k8s/prod/common/sscs/sscs-bulk-scan.yaml
+++ b/k8s/prod/common/sscs/sscs-bulk-scan.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: sscs-bulk-scan
-    version: 0.0.11
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-bulk-scan
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/sscs/sscs-ccd-callback-orchestrator.yaml
+++ b/k8s/prod/common/sscs/sscs-ccd-callback-orchestrator.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: sscs-ccd-callback-orchestrator
-    version: 0.0.11
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-ccd-callback-orchestrator
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/sscs/sscs-cor-frontend.yaml
+++ b/k8s/prod/common/sscs/sscs-cor-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: sscs-cor-frontend
-    version: 0.1.17
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-cor-frontend
   values:
     nodejs:
       replicas: 2

--- a/k8s/prod/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/prod/common/sscs/sscs-evidence-share.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: sscs-evidence-share
-    version: 0.0.20
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-evidence-share
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/sscs/sscs-tribunals-api.yaml
+++ b/k8s/prod/common/sscs/sscs-tribunals-api.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: sscs-tribunals-api
-    version: 0.0.21
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-tribunals-api
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/prod/common/sscs/sscs-tya-notif.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: sscs-tya-notif
-    version: 0.0.19
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2


### PR DESCRIPTION
SSCS-7852 - Tech debt – Change chart source for all helm releases to GitHub (prod)