### PR TITLE
Allow reminder service from midnight for nightly tests

### DIFF
--- a/k8s/aat/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/aat/common/sscs/sscs-tya-notif.yaml
@@ -26,6 +26,8 @@ spec:
         JOB_SCHEDULER_DB_NAME: notification
         JOB_SCHEDULER_DB_HOST: sscs-tya-notif-postgres-v11-db-aat.postgres.database.azure.com
         SSCS_TRACK_YOUR_APPEAL_LINK: https://track-appeal.aat.platform.hmcts.net/trackyourappeal/appeal_id
+        HOURS_START_TIME: 0
+        HOURS_END_TIME: 17
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
Nightly tests are not passing because we do not allow reminders to be sent out of hours. This should fix this. 