### PR TITLE
Add Reconciliation API Key secret to test config

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
@@ -34,7 +34,6 @@ spec:
               test-subscription-key: TEST_SUBSCRIPTION_KEY
               storage-account-secondary-key: TEST_STORAGE_ACCOUNT_KEY
               storage-account-name: TEST_STORAGE_ACCOUNT_NAME
-              # Reconciliation API Key
               reconciliation-api-key: TEST_RECONCILIATION_API_KEY
         environment:
           TEST_URL: "http://reform-scan-blob-router-aat.service.core-compute-aat.internal"

--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
@@ -34,6 +34,8 @@ spec:
               test-subscription-key: TEST_SUBSCRIPTION_KEY
               storage-account-secondary-key: TEST_STORAGE_ACCOUNT_KEY
               storage-account-name: TEST_STORAGE_ACCOUNT_NAME
+              # Reconciliation API Key
+              reconciliation-api-key: TEST_RECONCILIATION_API_KEY
         environment:
           TEST_URL: "http://reform-scan-blob-router-aat.service.core-compute-aat.internal"
           SLACK_CHANNEL: "bsp-test-notices"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1360


### Change description ###
Reconciliation API Key secret is used in functional tests in https://github.com/hmcts/blob-router-service/pull/624

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
