### PR TITLE
Add environment variable to Blob router

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
@@ -23,3 +23,4 @@ spec:
       environment:
         STORAGE_BLOB_PROCESSING_DELAY_IN_MINUTES: 0
         CRIME_ENABLED: true
+        DELETE_DUMMY_VAR: true


### PR DESCRIPTION
### Change description ###
`reform-scan-blob-router` Helm releases are in a failed state. 
Trying to fix by adding a new environment variable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
