### PR TITLE
feature(ROC-8266): Add cmc-performance-test to the CMC build monitor

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -160,7 +160,7 @@ spec:
                     title: ETHOS
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend|cmc-legal-rep-frontend|cmc-claim-store|cmc-shared-infrastructure)\/master
+                      ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend|cmc-legal-rep-frontend|cmc-claim-store|cmc-shared-infrastructure|cmc-performance-test)\/master
                     name: CMC
                     recurse: true
                     title: CMC


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-8266

### Change description ###

This change adds the results from **cmc-performance-test** `master` pipeline to the CMC dashboard, for a more complete picture of what parts of CMC have been successful / failed to build.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
