### PR TITLE
Add environment variable to Bulk scan processor in AAT

### DIFF
--- a/k8s/namespaces/bsp/bulk-scan-processor/aat.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-processor/aat.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   values:
     java:
+      environment:
+        DUMMY_VAR_RESTART_PODS: "true"
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account


### PR DESCRIPTION
### Change description ###
Added a dummy environment variable to create new pods in AAT. 
AKS clusters aat-aks-00 and aat-aks-01 are not using the processor's latest image
```Warning: AKS cluster aat-aks-01 is running bulk-scan/processor:prod-eb6873e1 instead of bulk-scan/processor:prod-86766f69 (2020-09-01T09:05:18.00355Z).```
```Warning: AKS cluster aat-aks-00 is running bulk-scan/processor:prod-eb6873e1 instead of bulk-scan/processor:prod-86766f69 (2020-09-01T09:05:18.00355Z).```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
