### PR TITLE
Bump blob-router-service 0.1.7 -> 0.1.8

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-blob-router
-    version: 0.1.7
+    version: 0.1.8
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Removes no longer used configuration: hmcts/blob-router-service#646

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
