### PR TITLE
Bump `bulk-scan-processor` 0.3.5 -> 0.3.6

### DIFF
--- a/k8s/namespaces/bsp/bulk-scan-processor/bulk-scan-processor.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-processor/bulk-scan-processor.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: bulk-scan-processor
-    version: 0.3.5
+    version: 0.3.6
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Removes unused config: hmcts/bulk-scan-processor#1517

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
