### PR TITLE
Disable Scheduling in send-letter-service

### DIFF
--- a/k8s/namespaces/rpe/rpe-send-letter-service/prod.yaml
+++ b/k8s/namespaces/rpe/rpe-send-letter-service/prod.yaml
@@ -12,3 +12,4 @@ spec:
         UPLOAD_SUMMARY_REPORT_ENABLED: true
         FILE_CLEANUP_ENABLED: false
         OLD_LETTER_CONTENT_CLEANUP_ENABLED: false
+        SCHEDULING_ENABLED: "false"


### PR DESCRIPTION
Upgrading the postresql db to v11. Need there to be no db updates whilst this is happening - only inserts.

Setting this value to false will mean new print letter jobs can still be persisted to the db, but none will be uploaded to Xerox

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
