### PR TITLE
enable scanning for blob router in perftest

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/perftest.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/perftest.yaml
@@ -10,4 +10,3 @@ spec:
         HANDLE_REJECTED_FILES_CRON: "0 0 7 * * *"
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"
         TASK_SCAN_DELAY: 300000
-        SCHEDULING_TASK_SCAN_ENABLED: false


### PR DESCRIPTION



### Change description ###
enable scanning for blob router in perftest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
