### PR TITLE
Add missing env var mapping for blob-router smoke tests in prod

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/prod.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/prod.yaml
@@ -40,6 +40,7 @@ spec:
               test-subscription-key: TEST_SUBSCRIPTION_KEY
               storage-account-secondary-key: TEST_STORAGE_ACCOUNT_KEY
               storage-account-name: TEST_STORAGE_ACCOUNT_NAME
+              reconciliation-api-key: TEST_RECONCILIATION_API_KEY
         environment:
           TEST_URL: "http://reform-scan-blob-router-prod.service.core-compute-prod.internal"
           SLACK_CHANNEL: "bsp-test-notices"


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
