### PR TITLE
Bump reform-scan-notification-service 0.1.4 -> 0.1.5

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-notification-service/reform-scan-notification-service.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-notification-service/reform-scan-notification-service.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: reform-scan-notification-service
-    version: 0.1.4
+    version: 0.1.5
   values:
     java:
       replicas: 2


### PR DESCRIPTION
### Change description ###

Removes unused configuration: hmcts/reform-scan-notification-service#247

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
