### PR TITLE
Updated config to forceNamespace for aad-pod-id-mic

### DIFF
--- a/k8s/namespaces/admin/aad-pod-id/patches/aad-pod-id.yaml
+++ b/k8s/namespaces/admin/aad-pod-id/patches/aad-pod-id.yaml
@@ -10,3 +10,16 @@ spec:
         env:
         - name: FORCENAMESPACED
           value: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mic
+spec:
+  template:
+    spec:
+      containers:
+      - name: mic
+        env:
+        - name: FORCENAMESPACED
+          value: "true"


### PR DESCRIPTION
i had to add the "FORCENAMESPACED: true" env to MIC deployment too, otherwise the azureassignedidentity resource would get created in the default namespace instead of the coresponding namespace

quick guide: https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.namespaced.md