### PR TITLE
impr: use the github repo as chart source

### DIFF
--- a/k8s/namespaces/bsp/bulk-scan-orchestrator/bulk-scan-orchestrator.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-orchestrator/bulk-scan-orchestrator.yaml
@@ -6,9 +6,9 @@ spec:
   releaseName: bulk-scan-orchestrator
   timeout: 600
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: bulk-scan-orchestrator
-    version: 0.3.8
+    git: git@github.com:hmcts/hmcts-charts
+    path: stable/bulk-scan-orchestrator
+    ref: master
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/bsp/bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   releaseName: bulk-scan-payment-processor
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: bulk-scan-payment-processor
-    version: 0.2.3
+    git: git@github.com:hmcts/hmcts-charts
+    path: stable/bulk-scan-payment-processor
+    ref: master
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/bsp/bulk-scan-processor/bulk-scan-processor.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-processor/bulk-scan-processor.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   releaseName: bulk-scan-processor
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: bulk-scan-processor
-    version: 0.3.6
+    git: git@github.com:hmcts/hmcts-charts
+    path: stable/bulk-scan-processor
+    ref: master
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
@@ -9,9 +9,9 @@ spec:
   releaseName: reform-scan-blob-router
   timeout: 600
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: reform-scan-blob-router
-    version: 0.2.4
+    git: git@github.com:hmcts/hmcts-charts
+    path: stable/reform-scan-blob-router
+    ref: master
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/reform-scan/reform-scan-notification-service/reform-scan-notification-service.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-notification-service/reform-scan-notification-service.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   releaseName: reform-scan-notification-service
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: reform-scan-notification-service
-    version: 0.1.5
+    git: git@github.com:hmcts/hmcts-charts
+    path: stable/reform-scan-notification-service
+    ref: master
   values:
     java:
       replicas: 2


### PR DESCRIPTION
* it replaces the repository, and makes the version maintenance easier
* the charts come from: https://github.com/hmcts/hmcts-charts/tree/master/stable


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
