### PR TITLE
feat(SIDM-4960-sso): IDAM sso: add non-prod config

### DIFF
--- a/k8s/aat/common/idam/idam-api.yaml
+++ b/k8s/aat/common/idam/idam-api.yaml
@@ -41,6 +41,12 @@ spec:
         SSL_TRUST_DNS_0: C=UK,ST=London,L=London,O=Amido,CN=*.service.core-compute-idam-aat2.internal,emailAddress=devops@amido.com
         SSL_TRUST_HOSTNAMES_0: forgerock-idm.service.core-compute-idam-aat2.internal
         SSL_TRUST_HOSTNAMES_1: forgerock-am.service.core-compute-idam-aat2.internal
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/demo/common/idam/idam-api.yaml
+++ b/k8s/demo/common/idam/idam-api.yaml
@@ -41,6 +41,12 @@ spec:
         SSL_TRUST_DNS_0: C=UK,ST=London,L=London,O=Amido,CN=*.service.core-compute-idam-demo.internal,emailAddress=devops@amido.com
         SSL_TRUST_HOSTNAMES_0: forgerock-idm.service.core-compute-idam-demo.internal
         SSL_TRUST_HOSTNAMES_1: forgerock-am.service.core-compute-idam-demo.internal
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/ithc/common/idam/idam-api.yaml
+++ b/k8s/ithc/common/idam/idam-api.yaml
@@ -31,6 +31,12 @@ spec:
         STRATEGIC_ADMIN_URL: https://idam-web-admin.ithc.platform.hmcts.net
         STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.ithc.platform.hmcts.net
         STRATEGIC_API_URL: https://idam-api.ithc.platform.hmcts.net
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: ithc
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/perftest/common/idam/idam-api.yaml
+++ b/k8s/perftest/common/idam/idam-api.yaml
@@ -32,6 +32,12 @@ spec:
         STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.perftest.platform.hmcts.net
         STRATEGIC_API_URL: https://idam-api.perftest.platform.hmcts.net
         DUMMY_ENV_VAR_TO_TRIGGER_POD_RESTART: 27022020_01
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/preview/common/idam/idam-api.yaml
+++ b/k8s/preview/common/idam/idam-api.yaml
@@ -39,6 +39,12 @@ spec:
         STRATEGIC_ADMIN_URL: https://idam-web-admin.service.core-compute-preview.internal
         STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.service.core-compute-preview.internal
         STRATEGIC_API_URL: https://idam-api.service.core-compute-preview.internal
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: preview
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/sandbox/common/idam-sprod/idam-api.yaml
+++ b/k8s/sandbox/common/idam-sprod/idam-api.yaml
@@ -41,6 +41,12 @@ spec:
         SSL_TRUST_DNS_1: C=None,ST=None,L=None,OU=None,O=OpenDJ Self-Signed Certificate,CN=openidm-localhost
         SSL_TRUST_HOSTNAMES_0: forgerock-idm.service.core-compute-idam-sprod.internal
         SSL_TRUST_HOSTNAMES_1: forgerock-am.service.core-compute-idam-sprod.internal
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: sprod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/k8s/sandbox/common/idam/idam-api.yaml
+++ b/k8s/sandbox/common/idam/idam-api.yaml
@@ -40,6 +40,12 @@ spec:
         SSL_TRUST_DNS_1: C=None,ST=None,L=None,OU=None,O=OpenDJ Self-Signed Certificate,CN=openidm-localhost
         SSL_TRUST_HOSTNAMES_0: forgerock-idm.service.core-compute-idam-sandbox.internal
         SSL_TRUST_HOSTNAMES_1: forgerock-am.service.core-compute-idam-sandbox.internal
+        STRATEGIC_SSO_PROVIDERS_0_providerName: azure
+        STRATEGIC_SSO_PROVIDERS_0_userinfoEndpoint: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_0_uniqueIdClaim: oid
+        STRATEGIC_SSO_PROVIDERS_0_roles_0: judiciary
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeName: groups
+        STRATEGIC_SSO_PROVIDERS_0_requiredAttributes_0_attributeValue: 7d960c29-7bbe-4762-b9dc-f54d425ee284
     global:
       environment: sandbox
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-4960


### Change description ###
For SSO we decided to use the PROD conf as default values and then update flux values for non-prod environments.

Follows this PR https://github.com/hmcts/idam-api/pull/750/files


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
