### PR TITLE
RDM-9752: aat - Reverted Elasticsearch request timeout to 6sec for data-store-api

### DIFF
--- a/k8s/aat/common/ccd/data-store-api.yaml
+++ b/k8s/aat/common/ccd/data-store-api.yaml
@@ -24,7 +24,6 @@ spec:
       environment:
         CCD_DM_DOMAIN: ^https?://(?:api-gateway\.preprod\.dm\.reform\.hmcts\.net|dm-store-aat\.service\.core-compute-aat\.internal(?::\d+)?)
         CCD_CONDITIONAL_APIS_CASE_ASSIGNED_USER_AND_ROLES_ENABLED: false
-        ELASTIC_SEARCH_REQUEST_TIMEOUT: 25000
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-9752

### Change description ###

Reverted Elasticsearch request timeout to 6sec for data-store-api in aat env

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
