### PR TITLE
Removed the AM-PR dashboard and updated the AM dashboard

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -124,16 +124,10 @@ spec:
                     title: Divorce Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_.*AM.*\/(am-shared-infrastructure|am-judicial-booking-batch-service|am-judicial-booking-service|am-org-role-mapping-batch-service|am-org-role-mapping-service|am-role-assignment-batch-service|am-role-assignment-service)\/(master|demo)
+                      ^HMCTS_.*AM.*\/(am-shared-infrastructure|am-org-role-mapping-service|am-role-assignment-batch-service|am-role-assignment-service|am-performance-tests)\/master
                     name: AM
                     recurse: true
                     title: AM
-                - buildMonitor:
-                    includeRegex: >-
-                      .+\/(am-.*)\/(.*PR-.*)
-                    name: AM-PR
-                    recurse: true
-                    title: AM-PR
                 - buildMonitor:
                     includeRegex: >-
                       HMCTS_.*CTSC\/.+\/master


### PR DESCRIPTION

### Change description ###

 The AP-PR dashboard is not required and hence removed from the cnp config. There were couple of stale application need to be removed from main AM dashboard and add new one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
