### PR TITLE
chore: remove mailing on aat blob-router

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
@@ -21,7 +21,6 @@ spec:
         CREATE_RECONCILIATION_DETAILED_REPORT_CRON: "* */5 * * * *"
         CREATE_RECONCILIATION_DETAILED_REPORT_ENABLED: "true"
         PCQ_ENABLED: "true"
-        SMTP_HOST: smtp.office365.com
       testsConfig:
         serviceAccountName: tests-service-account
         keyVaults:


### PR DESCRIPTION
### Change description ###

Remove the mail config for AAT, which was used for test purposes. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
