### PR TITLE
Sandbox: remove neuvector

### DIFF
--- a/k8s/sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-00-overlay/kustomization.yaml
@@ -8,7 +8,6 @@ bases:
   - ../../namespaces/admin/traefik
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
-  #- ../../namespaces/neuvector
   - ../../namespaces/monitoring
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/monitoring/kuberhealthy
@@ -29,10 +28,6 @@ patchesStrategicMerge:
 
   #traefik patch
   - ../../namespaces/admin/traefik/patches/sandbox/cluster-00/traefik.yaml
-
-  # neuvector patch
-  #- ../../namespaces/neuvector/patches/sandbox/neuvector.yaml
-  #- ../../namespaces/neuvector/patches/sandbox/cluster-00/neuvector.yaml
 
   #kured patch
   - ../../namespaces/kured/patches/sandbox/cluster-00/kured.yaml

--- a/k8s/sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-00-overlay/kustomization.yaml
@@ -8,7 +8,7 @@ bases:
   - ../../namespaces/admin/traefik
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
-  - ../../namespaces/neuvector
+  #- ../../namespaces/neuvector
   - ../../namespaces/monitoring
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/monitoring/kuberhealthy
@@ -31,8 +31,8 @@ patchesStrategicMerge:
   - ../../namespaces/admin/traefik/patches/sandbox/cluster-00/traefik.yaml
 
   # neuvector patch
-  - ../../namespaces/neuvector/patches/sandbox/neuvector.yaml
-  - ../../namespaces/neuvector/patches/sandbox/cluster-00/neuvector.yaml
+  #- ../../namespaces/neuvector/patches/sandbox/neuvector.yaml
+  #- ../../namespaces/neuvector/patches/sandbox/cluster-00/neuvector.yaml
 
   #kured patch
   - ../../namespaces/kured/patches/sandbox/cluster-00/kured.yaml

--- a/k8s/sandbox/cluster-01-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-01-overlay/kustomization.yaml
@@ -10,7 +10,7 @@ bases:
   - ../../namespaces/kured
   - ../../namespaces/monitoring
   - ../../namespaces/monitoring/kuberhealthy
-  - ../../namespaces/neuvector
+  #- ../../namespaces/neuvector
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/knode-system
@@ -29,8 +29,8 @@ patchesStrategicMerge:
   - ../../namespaces/admin/kube-slack/patches/sandbox/cluster-01/kube-slack.yaml
 
   # neuvector patch
-  - ../../namespaces/neuvector/patches/sandbox/neuvector.yaml
-  - ../../namespaces/neuvector/patches/sandbox/cluster-01/neuvector.yaml
+  #- ../../namespaces/neuvector/patches/sandbox/neuvector.yaml
+  #- ../../namespaces/neuvector/patches/sandbox/cluster-01/neuvector.yaml
 
   #traefik patches
   - ../../namespaces/admin/traefik/patches/sandbox/cluster-01/traefik.yaml

--- a/k8s/sandbox/cluster-01-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-01-overlay/kustomization.yaml
@@ -10,7 +10,6 @@ bases:
   - ../../namespaces/kured
   - ../../namespaces/monitoring
   - ../../namespaces/monitoring/kuberhealthy
-  #- ../../namespaces/neuvector
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/knode-system
@@ -27,10 +26,6 @@ patchesStrategicMerge:
 
   #kube-slack patches
   - ../../namespaces/admin/kube-slack/patches/sandbox/cluster-01/kube-slack.yaml
-
-  # neuvector patch
-  #- ../../namespaces/neuvector/patches/sandbox/neuvector.yaml
-  #- ../../namespaces/neuvector/patches/sandbox/cluster-01/neuvector.yaml
 
   #traefik patches
   - ../../namespaces/admin/traefik/patches/sandbox/cluster-01/traefik.yaml

--- a/k8s/sandbox/common/neuvector/identity.yaml
+++ b/k8s/sandbox/common/neuvector/identity.yaml
@@ -16,4 +16,4 @@ metadata:
   namespace: neuvector
 spec:
   azureIdentity: neuvector
-  selector: nv
+  selector: neuvector

--- a/k8s/sandbox/common/neuvector/identity.yaml
+++ b/k8s/sandbox/common/neuvector/identity.yaml
@@ -16,4 +16,4 @@ metadata:
   namespace: neuvector
 spec:
   azureIdentity: neuvector
-  selector: neuvector
+  selector: nv

--- a/k8s/sandbox/common/neuvector/namespace.yaml
+++ b/k8s/sandbox/common/neuvector/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: neuvector
+---


### PR DESCRIPTION
Was needed to test neuvector previously, but need to remove it now as it's clashing with Azure DevOps test build for changes to the neuvector chart. Have changed the selector over within the chart instead.

 PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
