### PR TITLE
Update neuvector release to 1.1.3 on sandbox and ithc

### DIFF
--- a/k8s/namespaces/neuvector/patches/ithc/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/ithc/neuvector.yaml
@@ -5,6 +5,10 @@ metadata:
   name: neuvector
   namespace: neuvector
 spec:
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: neuvector-azure-keyvault
+    version: 1.1.3
   values:
     keyvault:
       name: cftapps-ithc

--- a/k8s/namespaces/neuvector/patches/sandbox/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/sandbox/neuvector.yaml
@@ -5,6 +5,10 @@ metadata:
   name: neuvector
   namespace: neuvector
 spec:
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: neuvector-azure-keyvault
+    version: 1.1.3
   values:
     keyvault:
       name: cftapps-sbox


### PR DESCRIPTION
Previously tested on sandbox as part of chart change PR. 1.1.3 release includes added delay for backup to load before our configuration script https://github.com/hmcts/chart-neuvector/releases/tag/1.1.3

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
