### PR TITLE
Neuvector 1.1.3 applied for perftest and aat

### DIFF
--- a/k8s/namespaces/neuvector/patches/aat/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/aat/neuvector.yaml
@@ -5,6 +5,10 @@ metadata:
   name: neuvector
   namespace: neuvector
 spec:
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: neuvector-azure-keyvault
+    version: 1.1.3
   values:
     keyvault:
       name: cftapps-stg

--- a/k8s/namespaces/neuvector/patches/perftest/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/perftest/neuvector.yaml
@@ -5,6 +5,10 @@ metadata:
   name: neuvector
   namespace: neuvector
 spec:
+  chart:
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    name: neuvector-azure-keyvault
+    version: 1.1.3
   values:
     keyvault:
       name: cftapps-test


### PR DESCRIPTION
1.1.3 Adds in delay before neuvector configuration script is loaded, to avoid clash with backup load. Tested on sbox and ithc.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
