### PR TITLE
testing mic exception deployment via flux

### DIFF
--- a/k8s/sandbox/cluster-01/mic-exception.yaml
+++ b/k8s/sandbox/cluster-01/mic-exception.yaml
@@ -1,0 +1,9 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzurePodIdentityException
+metadata:
+  name: mic-exception
+  namespace: admin
+spec:
+  podLabels:
+    app: mic
+    component: mic


### PR DESCRIPTION
Adding an exception required for the AAD POd Identity Mic controller to function correctly as described in the following guide:

https://docs.microsoft.com/en-us/azure/aks/use-managed-identity#limitations﻿
