### PR TITLE
Disabling the 8X8 web-chat in the demo env

### DIFF
--- a/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
@@ -25,7 +25,7 @@ spec:
       environment:
         FEATURE_TESTING_SUPPORT: true
         FEATURE_RETURN_ERROR_TO_USER: true
-        FEATURE_WEB_CHAT: true
+        FEATURE_WEB_CHAT: false
         PCQ_URL: https://pcq.demo.platform.hmcts.net
     global:
       environment: demo


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-8332
https://tools.hmcts.net/jira/browse/ROC-8396

### Change description ###

As part of antenna web-chat testing, i am disabling the current 8X8 web-chat in the demo environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
