### PR TITLE
Disabling 8X8 Web-chat

### DIFF
--- a/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
@@ -25,7 +25,6 @@ spec:
       environment:
         FEATURE_TESTING_SUPPORT: true
         FEATURE_RETURN_ERROR_TO_USER: true
-        FEATURE_WEB_CHAT: false
         PCQ_URL: https://pcq.demo.platform.hmcts.net
     global:
       environment: demo


### PR DESCRIPTION
### Change description ###
Updating the cmc-citizen-frontend.yaml to disable the 8X8 web-chat for testing the Antenna web-chat.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
