### PR TITLE
move prom operator out of stable - sandbox only

### DIFF
--- a/k8s/namespaces/monitoring/kube-prometheus-stack/flux-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/flux-alerts-rules.yaml
@@ -1,0 +1,55 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-flux-alert-rules
+  namespace: monitoring
+spec:
+  "groups":
+  - "name": "flux"
+    "rules":
+    - "alert": "FluxSyncErrors"
+      "annotations":
+        "message": "Flux sync errors, likely has infrastructure issues or duplicate manifests"
+      "expr": |
+        delta(flux_daemon_sync_duration_seconds_count{success='true'}[6m]) < 1
+      "for": "5m"
+      "labels":
+        "severity": "critical"
+    - "alert": "FluxManifestError"
+      "annotations":
+        "message": "Error applying {{ $value }} manifests"
+      "expr": |
+        flux_daemon_sync_manifests{success='false'} > 0
+      "for": "5m"
+      "labels":
+        "severity": "critical"
+  - "name": "FluxHelmOperator"
+    "rules":
+    - "alert": "HelmOperatorLowThroughput"
+      "annotations":
+        "message": "{{ $value }} Helm releases in queue for too long"
+      "expr": |
+        flux_helm_operator_release_queue_length_count > 0
+      "for": "30m"
+      "labels":
+        "severity": "critical"
+    - "alert": "HelmReleaseRolledBack"
+      "annotations":
+        "message": "A helm release {{ $labels.release_name }} has been rolled back "
+      "expr": |
+        flux_helm_operator_release_condition_info{condition="RolledBack"} == 1
+      "for": "10m"
+      "labels":
+        "severity": "warning"
+    - "alert": "HelmReleaseError"
+      "annotations":
+        "message": "A Helm Release {{ $labels.release_name }} has failed to deploy"
+      "expr": |
+        flux_helm_operator_release_condition_info{condition="Released"} == -1
+      "for": "15m"
+      "labels":
+        "severity": "critical"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+  annotations:
+    flux.weave.works/automated: "false"
+    flux.weave.works/ignore: "false"
+spec:
+  releaseName: kube-prometheus-stack
+  forceUpgrade: true
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    repository: https://prometheus-community.github.io/helm-charts
+    name: kube-prometheus-stack
+    version: 11.0.0
+  valueFileSecrets:
+    - name: "prometheus-values"
+  values:
+    defaultRules:
+      create: true
+      rules:
+        alertmanager: false
+        etcd: true
+        general: true
+        k8s: true
+        kubeApiserver: true
+        kubePrometheusNodeAlerting: true
+        kubePrometheusNodeRecording: true
+        kubernetesAbsent: true
+        kubernetesApps: true
+        kubernetesResources: true
+        kubernetesStorage: true
+        kubernetesSystem: true
+        kubeScheduler: true
+        network: true
+        node: true
+        prometheus: true
+        prometheusOperator: true
+        time: true
+
+    prometheus:
+      additionalServiceMonitors:
+        - name: "flux-monitor"
+          selector:
+            matchLabels:
+              app: flux
+          namespaceSelector:
+            matchNames:
+              - admin
+          endpoints:
+            - targetPort: 3030
+          path: /metrics
+      additionalPodMonitors:
+        - name: "nodelocaldns"
+          selector:
+            matchLabels:
+              k8s-app: node-local-dns
+          namespaceSelector:
+            matchNames:
+              - kube-system
+          podMetricsEndpoints:
+            - port: metrics
+              path: /metrics
+        - name: "node-problem-monitor"
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: node-problem-detector
+          namespaceSelector:
+            matchNames:
+              - monitoring
+          podMetricsEndpoints:
+            - port: exporter
+              path: /metrics
+      ingress:
+        enabled: true
+
+    kubelet:
+      serviceMonitor:
+        https: false
+
+    alertmanager:
+      ingress:
+        enabled: true
+      config:
+        global:
+          resolve_timeout: "5m"
+        route:
+          receiver: slack_alerting # default receiver
+          group_by:
+            - alertname
+            - cluster
+            - service
+          group_wait: "30s"
+          group_interval: "5m"
+          repeat_interval: "2h"
+          routes:
+            - match_re:
+                alertname: KubeletDown|KubeControllerManagerDown|KubeSchedulerDown
+              receiver: "null"
+            - match:
+                severity: critical
+              receiver: slack_critical
+        # Mute any warning-level notifications if the same alert is already critical.
+        inhibit_rules:
+          - source_match:
+              severity: "critical"
+            target_match:
+              severity: "warning"
+            equal: ["alertname", "cluster", "service"]
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"
+
+    grafana:
+      enabled: false
+      plugins:
+        - grafana-kubernetes-app
+        - camptocamp-prometheus-alertmanager-datasource
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: traefik
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+            - name: "default"
+              orgId: 1
+              folder: ""
+              type: file
+              disableDeletion: false
+              editable: true
+              options:
+                path: /var/lib/grafana/dashboards/default
+      dashboards:
+        default:
+          kubernetes-pod-monitoring:
+            gnetId: 9144
+            revision: 2
+            datasource: Prometheus
+          Kubernetes-Deployment-Statefulset-Daemonset-metrics:
+            gnetId: 8588
+            revision: 1
+            datasource: Prometheus
+          Cluster-Monitoring-for-Kubernetes:
+            gnetId: 10000
+            revision: 1
+            datasource: Prometheus
+          Cluster-cost:
+            gnetId: 8670
+            revision: 5
+            datasource: Prometheus
+          Cluster-Dashboard:
+            gnetId: 11358
+            revision: 1
+          Jenkins:
+            gnetId: 9964
+            revision: 1
+            datasource: Prometheus
+          NodeLocalDNS:
+            url: https://raw.githubusercontent.com/hmcts/prometheus-monitoring/master/grafana/dashboards/nodelocaldns.json
+          CoreDNS-Cluster:
+            url: https://raw.githubusercontent.com/hmcts/prometheus-monitoring/master/grafana/dashboards/coredns_cluster.json
+          FluxPerf:
+            url: https://raw.githubusercontent.com/hmcts/prometheus-monitoring/master/grafana/dashboards/flux-performance.json
+          AppHealth:
+            url: https://raw.githubusercontent.com/hmcts/prometheus-monitoring/master/grafana/dashboards/app_health.json
+          Kuberhealthy:
+            url: https://raw.githubusercontent.com/hmcts/prometheus-monitoring/master/grafana/dashboards/kuberhealthy.json
+          AdminApps:
+            url: https://raw.githubusercontent.com/hmcts/prometheus-monitoring/master/grafana/dashboards/admin_health.json

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/kustomization.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kube-prometheus-stack.yaml
+  - nodelocaldns-alerts-rules.yaml
+  - flux-alerts-rules.yaml

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,79 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups":
+  - "name": "nodelocaldns"
+    "rules":
+    - "alert": "NodeLocalDNSDown"
+      "annotations":
+        "message": "NodeLocalDNS has disappeared from Prometheus target discovery."
+      "expr": |
+        absent(up{container="node-cache",name!="node-local-dns-metrics"} == 1)
+      "for": "15m"
+      "labels":
+        "severity": "critical"
+    - "alert": "NodeLocalDNSLatencyHigh"
+      "annotations":
+        "message": "NodeLocalDNS has 99th percentile latency of {{ $value }} seconds for server {{ $labels.server }} zone {{ $labels.zone }} ."
+      "expr": |
+        histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{container="node-cache",name!="node-local-dns-metrics"}[5m])) by(server, zone, le)) > 4
+      "for": "10m"
+      "labels":
+        "severity": "critical"
+    - "alert": "NodeLocalDNSErrorsHigh"
+      "annotations":
+        "message": "NodeLocalDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests."
+      "expr": |
+        sum(rate(coredns_dns_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics",rcode="SERVFAIL"}[5m]))
+          /
+        sum(rate(coredns_dns_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics"}[5m])) > 0.03
+      "for": "10m"
+      "labels":
+        "severity": "critical"
+    - "alert": "NodeLocalDNSErrorsHigh"
+      "annotations":
+        "message": "NodeLocalDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of requests."
+      "expr": |
+        sum(rate(coredns_dns_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics",rcode="SERVFAIL"}[5m]))
+          /
+        sum(rate(coredns_dns_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics"}[5m])) > 0.01
+      "for": "10m"
+      "labels":
+        "severity": "warning"
+  - "name": "coredns_forward"
+    "rules":
+    - "alert": "NodeLocalDNSForwardLatencyHigh"
+      "annotations":
+        "message": "NodeLocalDNS has 99th percentile latency of {{ $value }} seconds forwarding requests to {{ $labels.to }}."
+      "expr": |
+        histogram_quantile(0.99, sum(rate(coredns_forward_request_duration_seconds_bucket{container="node-cache",name!="node-local-dns-metrics"}[5m])) by(to, le)) > 4
+      "for": "10m"
+      "labels":
+        "severity": "critical"
+    - "alert": "NodeLocalDNSForwardErrorsHigh"
+      "annotations":
+        "message": "NodeLocalDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}."
+      "expr": |
+        sum(rate(coredns_forward_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics",rcode="SERVFAIL"}[5m]))
+          /
+        sum(rate(coredns_forward_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics"}[5m])) > 0.03
+      "for": "10m"
+      "labels":
+        "severity": "critical"
+    - "alert": "NodeLocalDNSForwardErrorsHigh"
+      "annotations":
+        "message": "NodeLocalDNS is returning SERVFAIL for {{ $value | humanizePercentage }} of forward requests to {{ $labels.to }}."
+      "expr": |
+        sum(rate(coredns_dns_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics",rcode="SERVFAIL"}[5m]))
+          /
+        sum(rate(coredns_dns_response_rcode_count_total{container="node-cache",name!="node-local-dns-metrics"}[5m])) > 0.01
+      "for": "10m"
+      "labels":
+        "severity": "warning"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-00.aat.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-00.aat.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'AAT-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'AAT-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-01/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-01.aat.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-01.aat.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'AAT-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'AAT-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-01/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/cftptl/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/cftptl/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-ptl.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-ptl.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting-prod
+                title: 'CFTPTL - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical-prod
+                title: 'CFTPTL - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"
+
+    grafana:
+      enabled: true
+      ingress:
+        hosts:
+          - grafana-ptl.platform.hmcts.net
+      additionalDataSources:
+        - name: prometheus-aat-00
+          type: prometheus
+          url: http://prometheus-00.aat.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-aat-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-00.aat.platform.hmcts.net
+          access: proxy
+        - name: prometheus-aat-01
+          type: prometheus
+          url: http://prometheus-01.aat.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-aat-01
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-01.aat.platform.hmcts.net
+          access: proxy
+        - name: prometheus-perftest-00
+          type: prometheus
+          url: http://prometheus-00.perftest.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-perftest-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-00.perftest.platform.hmcts.net
+          access: proxy
+        - name: prometheus-perftest-01
+          type: prometheus
+          url: http://prometheus-01.perftest.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-perftest-01
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-01.perftest.platform.hmcts.net
+          access: proxy
+        - name: prometheus-ithc-00
+          type: prometheus
+          url: http://prometheus-00.ithc.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-ithc-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-00.ithc.platform.hmcts.net
+          access: proxy
+        - name: prometheus-ithc-01
+          type: prometheus
+          url: http://prometheus-01.ithc.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-ithc-01
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-01.ithc.platform.hmcts.net
+          access: proxy
+        - name: prometheus-demo-00
+          type: prometheus
+          url: https://prometheus-00.demo.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-demo-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: https://alertmanager-00.demo.platform.hmcts.net
+          access: proxy
+        - name: prometheus-prod-00
+          type: prometheus
+          url: http://prometheus-00.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-prod-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-00.platform.hmcts.net
+          access: proxy
+        - name: prometheus-prod-01
+          type: prometheus
+          url: http://prometheus-01.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-prod-01
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-01.platform.hmcts.net
+          access: proxy

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/cftptl/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/cftptl/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/cftptl/cluster-00/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/cftptl/cluster-00/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups": []

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/demo/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/demo/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        annotations:
+          kubernetes.io/ingress.class: traefik-private
+        hosts:
+          - prometheus-00.demo.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        annotations:
+          kubernetes.io/ingress.class: traefik-private
+        hosts:
+          - alertmanager-00.demo.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'Demo-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'Demo-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/demo/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/demo/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-00.ithc.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-00.ithc.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'ITHC-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'ITHC-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-01/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-01.ithc.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-01.ithc.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'ITHC-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'ITHC-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/ithc/cluster-01/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/mgmt-sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/mgmt-sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-mgmt-sbox.sandbox.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-mgmt-sbox.sandbox.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'CFTSBOX - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'CFTBOX - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"
+
+    grafana:
+      enabled: true
+      ingress:
+        hosts:
+          - grafana.sandbox.platform.hmcts.net
+      additionalDataSources:
+        - name: prometheus-00
+          type: prometheus
+          url: http://prometheus-00.sandbox.platform.hmcts.net
+          access: proxy
+        - name: prometheus-01
+          type: prometheus
+          url: http://prometheus-01.sandbox.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-00.sandbox.platform.hmcts.net
+          access: proxy
+        - name: alertmanager-01
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: http://alertmanager-01.sandbox.platform.hmcts.net
+          access: proxy

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/mgmt-sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/mgmt-sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/mgmt-sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/mgmt-sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups": []

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-00.perftest.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-00.perftest.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'Perftest-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'Perftest-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-01/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-01.perftest.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-01.perftest.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting
+                title: 'Perftest-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical
+                title: 'Perftest-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/perftest/cluster-01/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-00.dev.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-00.dev.platform.hmcts.net

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-00/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-00/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups": []

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-01/kube-prometheus-stack.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-01.dev.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-01.dev.platform.hmcts.net

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-01/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-01/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/preview/cluster-01/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups": []

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-00.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-00.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting-prod
+                title: 'Prod-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+                send_resolved: true
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical-prod
+                title: 'Prod-00 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+                send_resolved: true
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-01/kube-prometheus-stack.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-01.platform.hmcts.net
+
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-01.platform.hmcts.net
+      config:
+        receivers:
+          - name: "slack_alerting"
+            slack_configs:
+              - channel: prometheus-alerting-prod
+                title: 'Prod-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "slack_critical"
+            slack_configs:
+              - channel: prometheus-critical-prod
+                title: 'Prod-01 - {{ template "slack.default.title" . }}'
+                text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
+          - name: "null"

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/prod/cluster-01/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-00.sandbox.platform.hmcts.net
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-00.sandbox.platform.hmcts.net

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups": []

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: prom-operator
+  namespace: monitoring
+spec:
+  values:
+    prometheus:
+      ingress:
+        hosts:
+          - prometheus-01.sandbox.platform.hmcts.net
+    alertmanager:
+      ingress:
+        hosts:
+          - alertmanager-01.sandbox.platform.hmcts.net

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
-  name: prom-operator
+  name: kube-prometheus-stack
   namespace: monitoring
 spec:
   values:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/nodelocaldns-alerts-rules.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/nodelocaldns-alerts-rules.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: prometheus-operator
+    chart: prometheus-operator-8.3.0
+    release: prom-operator
+  name: prometheus-nodelocaldns-rules
+  namespace: monitoring
+spec:
+  "groups": []

--- a/k8s/sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-00-overlay/kustomization.yaml
@@ -33,7 +33,7 @@ patchesStrategicMerge:
   - ../../namespaces/kured/patches/sandbox/cluster-00/kured.yaml
 
   #prom-operator patch
-  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/prom-operator.yaml
+  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
 
   - ../../namespaces/admin/env-injector/patches/sandbox/cluster-00/env-injector.yaml

--- a/k8s/sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-00-overlay/kustomization.yaml
@@ -8,7 +8,7 @@ bases:
   - ../../namespaces/admin/traefik
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
-  - ../../namespaces/monitoring
+  - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/monitoring/kuberhealthy
   - ../../namespaces/admin/env-injector
@@ -33,8 +33,8 @@ patchesStrategicMerge:
   - ../../namespaces/kured/patches/sandbox/cluster-00/kured.yaml
 
   #prom-operator patch
-  - ../../namespaces/monitoring/patches/sandbox/cluster-00/prom-operator.yaml
-  - ../../namespaces/monitoring/patches/sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
+  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/prom-operator.yaml
+  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/nodelocaldns-alerts-rules.yaml
 
   - ../../namespaces/admin/env-injector/patches/sandbox/cluster-00/env-injector.yaml
 patches:

--- a/k8s/sandbox/cluster-01-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-01-overlay/kustomization.yaml
@@ -8,7 +8,7 @@ bases:
   - ../../namespaces/admin/traefik
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/kured
-  - ../../namespaces/monitoring
+  - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/kuberhealthy
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
@@ -34,8 +34,8 @@ patchesStrategicMerge:
   - ../../namespaces/kured/patches/sandbox/cluster-01/kured.yaml
 
   #prom-operator patch
-  - ../../namespaces/monitoring/patches/sandbox/cluster-01/prom-operator.yaml
-  - ../../namespaces/monitoring/patches/sandbox/cluster-01/nodelocaldns-alerts-rules.yaml
+  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/prom-operator.yaml
+  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/nodelocaldns-alerts-rules.yaml
 
   - ../../namespaces/admin/env-injector/patches/sandbox/cluster-01/env-injector.yaml
 

--- a/k8s/sandbox/cluster-01-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-01-overlay/kustomization.yaml
@@ -34,7 +34,7 @@ patchesStrategicMerge:
   - ../../namespaces/kured/patches/sandbox/cluster-01/kured.yaml
 
   #prom-operator patch
-  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/prom-operator.yaml
+  - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/nodelocaldns-alerts-rules.yaml
 
   - ../../namespaces/admin/env-injector/patches/sandbox/cluster-01/env-injector.yaml


### PR DESCRIPTION
Copied files from https://github.com/hmcts/cnp-flux-config/tree/master/k8s/namespaces/monitoring to a directory as it's currently not at right place, also its easy to rollout. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
