### PR TITLE
feature(TA-159): Add nightly Divorce builds to the Divorce build monitor

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -118,7 +118,7 @@ spec:
                     title: INTESTACY Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      HMCTS_DIV/(?!div-ansible|div-case-progression-service|div-feature-toggle-client|div-frontend-boilerplate).+\/master
+                      ^HMCTS_.*DIV.*\/(?!div-ansible|div-case-progression-service|div-feature-toggle-client|div-frontend-boilerplate).+\/master
                     name: DIV
                     recurse: true
                     title: Divorce Dashboard


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/TA-159

### Change description ###

Add all nightly Divorce builds to the Divorce build monitor by using the same Regex format as other services.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
