### PR TITLE
Fix for ithc error on missing bar namespace

### DIFF
--- a/k8s/ithc/common-overlay/bar/kustomization.yaml
+++ b/k8s/ithc/common-overlay/bar/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: bar
+bases:
+- ../../../namespaces/bar

--- a/k8s/ithc/common-overlay/kustomization.yaml
+++ b/k8s/ithc/common-overlay/kustomization.yaml
@@ -21,6 +21,7 @@ bases:
   - camunda
   - aac
   - fact
+  - bar
 patches:
   - path: ../ithc-helmrelease.yaml
     target:


### PR DESCRIPTION
Error from server (NotFound): error when creating \"STDIN\": namespaces \"bar\" not found"
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
