### PR TITLE
Disabled IDAM network rule for neuvector

### DIFF
--- a/k8s/namespaces/neuvector/patches/prod/cluster-00/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/prod/cluster-00/neuvector.yaml
@@ -6,6 +6,24 @@ metadata:
   namespace: neuvector
 spec:
   values:
+    rules:
+      network:
+        - create: '{"insert":{"after":0,"rules":[{"id":1,"comment":"","from":"AllPods","to":"AzurePostgreSQL","ports":"tcp/5432","action":"allow","applications":["PostgreSQL","SSL","HTTP"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":1,"comment":"","from":"AllPods","to":"AzurePostgreSQL","ports":"tcp/5432","action":"allow","applications":["PostgreSQL","SSL","HTTP"],"disable":false}}'
+        - create: '{"insert":{"after":1,"rules":[{"id":2,"comment":"","from":"AllPods","to":"ApplicationInsights","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":2,"comment":"","from":"AllPods","to":"ApplicationInsights","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false}}'
+        - create: '{"insert":{"after":2,"rules":[{"id":3,"comment":"","from":"AllPods","to":"GovUkNotify","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":3,"comment":"","from":"AllPods","to":"GovUkNotify","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false}}'
+        - create: '{"insert":{"after":3,"rules":[{"id":4,"comment":"","from":"AllPods","to":"GovUkPay","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":4,"comment":"","from":"AllPods","to":"GovUkPay","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false}}'
+        - create: '{"insert":{"after":4,"rules":[{"id":5,"comment":"","from":"AllPods","to":"GovUkBankHolidays","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":5,"comment":"","from":"AllPods","to":"GovUkBankHolidays","ports":"tcp/443","action":"allow","applications":["SSL","HTTP"],"disable":false}}'
+        - create: '{"insert":{"after":5,"rules":[{"id":6,"comment":"","from":"AllPods","to":"ServiceBus","ports":"tcp/5671","action":"allow","applications":["SSL"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":6,"comment":"","from":"AllPods","to":"ServiceBus","ports":"tcp/5671","action":"allow","applications":["SSL"],"disable":false}}'
+        - create: '{"insert":{"after":6,"rules":[{"id":7,"comment":"","from":"AllPods","to":"Mta","ports":"tcp/25","action":"allow","applications":[],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":7,"comment":"","from":"AllPods","to":"Mta","ports":"tcp/25","action":"allow","applications":[],"disable":false}}'
+        - create: '{"insert":{"after":7,"rules":[{"id":8,"comment":"","from":"AllPods","to":"Idam","ports":"tcp/443","action":"allow","applications":["SSL"],"disable":false,"learned": false}]}}'
+          update: '{"config":{"id":8,"comment":"","from":"AllPods","to":"Idam","ports":"tcp/443","action":"allow","applications":["SSL"],"disable":true}}'
     redeploy: true
     neuvector:
       controller:


### PR DESCRIPTION
Workaround to resolve a performance issue. Further info below:

based on the latest troubleshooting during our remote session, there is a strong correlation between the number of free-fqdn-name logs entries (~250k per second) and the high CPU utilization.  The test where we forcefully deleted the enforcer on node "L", restored the CPU utilization to a lower expected level and ceased the free_fqdn_name errors.
Based on a quick review, the free_fqdn_name logline is caused by an unexpected request to delete the idam-api.platform.hmcts.net address entry from the enforcer.  This normally is called upon when no rules are referencing the address but in this case, rule 8 (user-created rule) does reference this address through address group definition Idam (address=idam-api.platform.hmtcs.net).
As an interim solution, we propose to disable rule #8 which makes use of the address group Idam and hope to cease the free_fqdn_name calls and therefore should stop the logging and reduce the CPU usage.

As every POD is under discover mode by disabling  the rule 8: "from(AllPods)->to(Idam) SSL tcp/443 action allow"  it will not impact any traffic, since all the connections covered by this rule will be learned again﻿
