### PR TITLE
Updated neuvector in all non-prod

### DIFF
--- a/k8s/namespaces/neuvector/neuvector.yaml
+++ b/k8s/namespaces/neuvector/neuvector.yaml
@@ -68,7 +68,7 @@ spec:
       - '{"config":{"name":"Mta","criteria":[{"key": "address", "value": "mta.reform.hmcts.net", "op": "="}]}}'
       - '{"config":{"name":"Idam","criteria":[{"key": "address", "value": "idam-api.platform.hmcts.net", "op": "="}]}}'
     neuvector:
-      tag: 3.2.2
+      tag: 4.0.1
       resources:
         requests:
           cpu: "100m"

--- a/k8s/namespaces/neuvector/patches/aat/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/aat/neuvector.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: neuvector
 spec:
   values:
-    neuvector:
-      tag: 4.0.1
     keyvault:
       name: cftapps-stg
       resourcegroup: core-infra-stg-rg

--- a/k8s/namespaces/neuvector/patches/prod/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/prod/neuvector.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: neuvector
 spec:
   values:
+    neuvector:
+      tag: 3.2.2
     keyvault:
       name: cft-apps-prod
       resourcegroup: core-infra-prod-rg


### PR DESCRIPTION
As neuvector 4.0.1 is stable on AAT we are deploying it to all non-prod envs with a separate CR to go for prod.﻿
