### PR TITLE
Updated kustomize to deploy mic-exeption to all envs

### DIFF
--- a/k8s/aat/cluster-00-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-00-overlay/kustomization.yaml
@@ -22,7 +22,6 @@ bases:
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches

--- a/k8s/aat/cluster-01-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-01-overlay/kustomization.yaml
@@ -22,7 +22,6 @@ bases:
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches

--- a/k8s/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-00-overlay/kustomization.yaml
@@ -18,7 +18,6 @@ bases:
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches

--- a/k8s/ithc/cluster-01-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-01-overlay/kustomization.yaml
@@ -18,7 +18,6 @@ bases:
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches

--- a/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
@@ -19,7 +19,6 @@ bases:
   - ../../namespaces/backstage
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches

--- a/k8s/namespaces/admin/aad-pod-id/kustomization.yaml
+++ b/k8s/namespaces/admin/aad-pod-id/kustomization.yaml
@@ -5,5 +5,6 @@ commonLabels:
   k8s-app: aad-pod-id
 resources:
   - https://raw.githubusercontent.com/Azure/aad-pod-identity/v1.6.2/deploy/infra/deployment-rbac.yaml
+  - mic-exception.yaml
 patchesStrategicMerge:
   - patches/aad-pod-id.yaml

--- a/k8s/sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-00-overlay/kustomization.yaml
@@ -15,7 +15,6 @@ bases:
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider-v0.0.8
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches

--- a/k8s/sandbox/cluster-01-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-01-overlay/kustomization.yaml
@@ -16,7 +16,6 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
-  - ../../namespaces/admin/aad-pod-id/mic-exception.yaml
 
 patchesStrategicMerge:
   #flux patches


### PR DESCRIPTION
This is required as a prerequisite to deploying AKS clusters using managed identity. It will prevent the NMI from proxying the MIC when accessing the  Azure Metadata service.  ﻿
