### PR TITLE
Upgrade neuvector in Prod to 4.0.1

### DIFF
--- a/k8s/namespaces/neuvector/patches/prod/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/prod/neuvector.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: neuvector
 spec:
   values:
-    neuvector:
-      tag: 3.2.2
     keyvault:
       name: cft-apps-prod
       resourcegroup: core-infra-prod-rg


### PR DESCRIPTION
CHG5002678

Current deployed version 3.2.2 has a bug that prevents it from starting up randomly and it's also causing performance issues. 
Neuvector support team have suggested upgrading to 4.0.1. This version has been deployed to AAT for over a week and it proved to be stable﻿
