### PR TITLE
[WIP]RPET-491: Add HelmRelease that should refer to the charts automatically publish…

### DIFF
--- a/k8s/namespaces/divorce/namespace.yaml
+++ b/k8s/namespaces/divorce/namespace.yaml
@@ -5,3 +5,8 @@ metadata:
   labels:
     slackChannel: div-dev
     hmcts.github.com/envInjector: enabled
+spec:
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/divorce


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPET-491


### Change description ###

Currently, we need to upgrade our flux files for every new version of our helm charts.

There is a solution, however, to make this manual (and error-prone) process redundant, which is to make flux use GitHub charts instead of ACR.

It seems to be a relatively easy fix with a quite high value.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
