### PR TITLE
RPET-491: changing to GitHub as the chart source for all of our HelmRelease

### DIFF
--- a/k8s/aat/common/divorce/div-cfs.yaml
+++ b/k8s/aat/common/divorce/div-cfs.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-cfs
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-cfs
   values:
     java:
       replicas: 2


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/RPET-491