### PR TITLE
RPET-491: all other services

### DIFF
--- a/k8s/aat/common/divorce/div-cms.yaml
+++ b/k8s/aat/common/divorce/div-cms.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-cms
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-cms
   values:
     java:
       replicas: 2

--- a/k8s/aat/common/divorce/div-da.yaml
+++ b/k8s/aat/common/divorce/div-da.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-da
-    version: 1.1.6
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-da
   values:
     nodejs:
       replicas: 2

--- a/k8s/aat/common/divorce/div-dgs.yaml
+++ b/k8s/aat/common/divorce/div-dgs.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dgs
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dgs
   values:
     java:
       replicas: 2

--- a/k8s/aat/common/divorce/div-dn.yaml
+++ b/k8s/aat/common/divorce/div-dn.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dn
-    version: 1.2.4
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dn
   values:
     nodejs:
       replicas: 2

--- a/k8s/aat/common/divorce/div-emca.yaml
+++ b/k8s/aat/common/divorce/div-emca.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-emca
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-emca
   values:
     java:
       replicas: 2

--- a/k8s/aat/common/divorce/div-fps.yaml
+++ b/k8s/aat/common/divorce/div-fps.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-fps
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-fps
   values:
     java:
       replicas: 2

--- a/k8s/aat/common/divorce/div-hm.yaml
+++ b/k8s/aat/common/divorce/div-hm.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-hm
-    version: 1.1.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-hm
   values:
     nodejs:
       replicas: 2

--- a/k8s/aat/common/divorce/div-pfe.yaml
+++ b/k8s/aat/common/divorce/div-pfe.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-pfe
-    version: 1.1.14
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-pfe
   values:
     nodejs:
       replicas: 2

--- a/k8s/aat/common/divorce/div-rfe.yaml
+++ b/k8s/aat/common/divorce/div-rfe.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-rfe
-    version: 1.1.7
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-rfe
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/divorce/div-cms.yaml
+++ b/k8s/demo/common/divorce/div-cms.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-cms
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-cms
   values:
     java:
       replicas: 2

--- a/k8s/demo/common/divorce/div-da.yaml
+++ b/k8s/demo/common/divorce/div-da.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-da
-    version: 1.1.6
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-da
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/divorce/div-dgs.yaml
+++ b/k8s/demo/common/divorce/div-dgs.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dgs
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dgs
   values:
     java:
       replicas: 2

--- a/k8s/demo/common/divorce/div-dn.yaml
+++ b/k8s/demo/common/divorce/div-dn.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dn
-    version: 1.2.4
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dn
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/divorce/div-emca.yaml
+++ b/k8s/demo/common/divorce/div-emca.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-emca
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-emca
   values:
     java:
       replicas: 2

--- a/k8s/demo/common/divorce/div-fps.yaml
+++ b/k8s/demo/common/divorce/div-fps.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-fps
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-fps
   values:
     java:
       replicas: 2

--- a/k8s/demo/common/divorce/div-pfe.yaml
+++ b/k8s/demo/common/divorce/div-pfe.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-pfe
-    version: 1.1.11
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-pfe
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/divorce/div-rfe.yaml
+++ b/k8s/demo/common/divorce/div-rfe.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-rfe
-    version: 1.1.6
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-rfe
   values:
     nodejs:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-cms.yaml
+++ b/k8s/ithc/common/divorce/div-cms.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-cms
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-cms
   values:
     java:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-da.yaml
+++ b/k8s/ithc/common/divorce/div-da.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-da
-    version: 1.1.6
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-da
   values:
     nodejs:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-dgs.yaml
+++ b/k8s/ithc/common/divorce/div-dgs.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dgs
-    version: 1.2.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dgs
   values:
     java:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-dn.yaml
+++ b/k8s/ithc/common/divorce/div-dn.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dn
-    version: 1.2.4
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dn
   values:
     nodejs:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-emca.yaml
+++ b/k8s/ithc/common/divorce/div-emca.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-emca
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-emca
   values:
     java:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-fps.yaml
+++ b/k8s/ithc/common/divorce/div-fps.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-fps
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-fps
   values:
     java:
       replicas: 2

--- a/k8s/ithc/common/divorce/div-hm.yaml
+++ b/k8s/ithc/common/divorce/div-hm.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-hm
-    version: 1.1.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-hm
   values:
     nodejs:
       replicas: 2

--- a/k8s/perftest/common/divorce/div-cms.yaml
+++ b/k8s/perftest/common/divorce/div-cms.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-cms
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-cms
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/divorce/div-dgs.yaml
+++ b/k8s/perftest/common/divorce/div-dgs.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dgs
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dgs
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/divorce/div-emca.yaml
+++ b/k8s/perftest/common/divorce/div-emca.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-emca
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-emca
   values:
     java:
       replicas: 2

--- a/k8s/perftest/common/divorce/div-fps.yaml
+++ b/k8s/perftest/common/divorce/div-fps.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-fps
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-fps
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/divorce/div-cms.yaml
+++ b/k8s/prod/common/divorce/div-cms.yaml
@@ -14,9 +14,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-cms
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-cms
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/divorce/div-da.yaml
+++ b/k8s/prod/common/divorce/div-da.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-da
-    version: 1.1.6
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-da
   values:
     nodejs:
       replicas: 2

--- a/k8s/prod/common/divorce/div-dgs.yaml
+++ b/k8s/prod/common/divorce/div-dgs.yaml
@@ -14,9 +14,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dgs
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dgs
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/divorce/div-dn.yaml
+++ b/k8s/prod/common/divorce/div-dn.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-dn
-    version: 1.2.4
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-dn
   values:
     nodejs:
       replicas: 2

--- a/k8s/prod/common/divorce/div-emca.yaml
+++ b/k8s/prod/common/divorce/div-emca.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-emca
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-emca
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/divorce/div-fps.yaml
+++ b/k8s/prod/common/divorce/div-fps.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-fps
-    version: 1.2.1
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-fps
   values:
     java:
       replicas: 2

--- a/k8s/prod/common/divorce/div-hm.yaml
+++ b/k8s/prod/common/divorce/div-hm.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-hm
-    version: 1.1.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-hm
   values:
     nodejs:
       replicas: 2

--- a/k8s/prod/common/divorce/div-pfe.yaml
+++ b/k8s/prod/common/divorce/div-pfe.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-pfe
-    version: 1.1.14
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-pfe
   values:
     nodejs:
       replicas: 2

--- a/k8s/prod/common/divorce/div-rfe.yaml
+++ b/k8s/prod/common/divorce/div-rfe.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: div-rfe
-    version: 1.1.7
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/div-rfe
   values:
     nodejs:
       replicas: 2


### PR DESCRIPTION
Story:
https://tools.hmcts.net/jira/browse/RPET-491

```
Hi,

We are changing to GitHub as the chart source for all of our HelmRelease in cnp-flux-config. Example: https://github.com/hmcts/cnp-flux-config/blob/43cca1d6a18d2436b646ecbf7b58c6ae06056ae0/k8s/aat/common/rpe/draft-store-service.yaml#L24-L27

This is to fix the issue where you have to update the chart version in your repo and in cnp-flux-config, it stops them getting out of sync.

Please use the below syntax in your flux configurationchart:
    git: git@github.com:hmcts/hmcts-charts
    ref: master
    path: stable/plum-recipe-backend
The charts are automatically published by Jenkins to: https://github.com/hmcts/hmcts-charts
More information can be found here: https://hmcts.github.io/ways-of-working/new-component/gitops-flux.html#application-config-in-flux

We will continue to support ACR until 22nd August 2020 (1 Month). All the HelmRelease should be migrated to Github as the chart source untill then..

Any questions please raise to #cloud-native

Have a good day 

Platform Engineering
```