### PR TITLE
IDAM Release 5.1.1: autodeployment on for idam-web-public

### DIFF
--- a/k8s/prod/common/idam/idam-web-public.yaml
+++ b/k8s/prod/common/idam/idam-web-public.yaml
@@ -5,7 +5,7 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    fluxcd.io/automated: "false"
+    fluxcd.io/automated: "true"
     filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: idam-web-public


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/projects/SIDM/versions/36415

### Change description ###
Enable autodeployment for idam-web-public to deploy content updates for OCMC.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
