### PR TITLE
Sandbox - helm operator config fix

### DIFF
--- a/k8s/namespaces/admin/helm-operator/patches/helm-operator.yaml
+++ b/k8s/namespaces/admin/helm-operator/patches/helm-operator.yaml
@@ -9,7 +9,6 @@ spec:
       - args:
         - --enabled-helm-versions=v3
         - --helm-repository-import=v3:/root/.helm/repository/repositories.yaml
-        - --kubeconfig=/root/.kube/config
         - --log-format=fmt
         - --git-timeout=1m
         - --git-poll-interval=1m


### PR DESCRIPTION
Based on docs, think I've included an unnecessary arg "--kubeconfig | Path to a kubeconfig. Only required if out-of-cluster."
PR is to remove it from sandbox config.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
