### PR TITLE
rpet-63 altering the deployment demo looks up for div-cos application

### DIFF
--- a/k8s/demo/common/divorce/div-cos.yaml
+++ b/k8s/demo/common/divorce/div-cos.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: divorce
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:pr-1154-*
+    flux.weave.works/tag.java: glob:pr-1130-*
 spec:
   releaseName: div-cos
   rollback:


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPET-63

This PR is redirection the DEMO environment to PR-1130 developed for the RPET-63

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
