### PR TITLE
Revert the  chart version to 2.0.29 and hard coded DB pointing 

### DIFF
--- a/k8s/demo/common/fees-pay/ccpay-payment-app.yaml
+++ b/k8s/demo/common/fees-pay/ccpay-payment-app.yaml
@@ -15,7 +15,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: payment-api
-    version: 2.0.33
+    version: 2.0.29
   values:
     java:
       replicas: 2
@@ -24,6 +24,8 @@ spec:
       imagePullPolicy: Always
       environment:
         DUMMY_RESTART_VAR: false
+        POSTGRES_HOST: payment-postgres-db-v11-{{ .Values.global.environment }}.postgres.database.azure.com
+        POSTGRES_USERNAME: payment@payment-postgres-db-v11-{{ .Values.global.environment }}
         PBA_CONFIG1_SERVICE_NAMES: PROBATE,CMC
         RETURNURL_ALLOWED_HOSTNAMES: hmcts.net,gov.uk
     global:


### PR DESCRIPTION
Revert back the chart version to 2.0.29  and hard cord the DB pointing to test the anteena changes

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
