### PR TITLE
remove docassembly from em jenkins dashboard

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -185,7 +185,7 @@ spec:
                 - buildMonitor:
                     includeRegex: >-
                       ^HMCTS_.*(EM).*\/(em-ccd-orchestrator|em-native-pdf-annotator-app|em-annotation-api|em
-                      -stitching-api|dg-docassembly-api|document-management-store-app)|em-hrs-api\/master
+                      -stitching-api|document-management-store-app)|em-hrs-api\/master
                     name: Evidence
                     recurse: true
                     title: Evidence Management


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3327

### Change description ###
remove docassembly from em jenkins dashboard, as its ownership has been transferred to DTS


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
