### PR TITLE
Remove additional objectid for old group dcd_group_devops_v2

### DIFF
--- a/k8s/namespaces/neuvector/patches/aat/cluster-00/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/aat/cluster-00/neuvector.yaml
@@ -59,7 +59,6 @@ spec:
               Default_Role: reader
               Role_Groups:
                 admin:
-                  - 300e771f-856c-45cc-b899-40d78281e9c1
                   - e7ea2042-4ced-45dd-8ae3-e051c6551789
             sysinitcfg.yaml: |
               New_Service_Policy_Mode: Discover

--- a/k8s/namespaces/neuvector/patches/aat/cluster-01/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/aat/cluster-01/neuvector.yaml
@@ -45,7 +45,6 @@ spec:
               Default_Role: reader
               Role_Groups:
                 admin:
-                  - 300e771f-856c-45cc-b899-40d78281e9c1
                   - e7ea2042-4ced-45dd-8ae3-e051c6551789
             sysinitcfg.yaml: |
               New_Service_Policy_Mode: Discover


### PR DESCRIPTION
### Change description ###
Remove additional objectid for old group dcd_group_devops_v2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
