### PR TITLE
DTSPO-22 Fix AzurePodIdentityException for addons

### DIFF
--- a/k8s/aat/cluster-00-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-00-overlay/kustomization.yaml
@@ -21,6 +21,7 @@ bases:
   - ../../namespaces/admin/keda
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/aat/cluster-01-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-01-overlay/kustomization.yaml
@@ -21,6 +21,7 @@ bases:
   - ../../namespaces/admin/keda
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/cftptl/cluster-00-overlay/kustomization.yaml
+++ b/k8s/cftptl/cluster-00-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/pact-broker
   - ../../namespaces/artifactory
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
   - ../../namespaces/backstage

--- a/k8s/demo/cluster-00-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-00-overlay/kustomization.yaml
@@ -20,6 +20,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
   - ../../namespaces/admin/traefik-auth

--- a/k8s/demo/cluster-01-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-01-overlay/kustomization.yaml
@@ -19,6 +19,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
   - ../../namespaces/admin/traefik-auth

--- a/k8s/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-00-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/admin/env-injector
   - ../../namespaces/knode-system
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/ithc/cluster-01-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-01-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/admin/env-injector
   - ../../namespaces/knode-system
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/ldata/cluster-00-overlay/kustomization.yaml
+++ b/k8s/ldata/cluster-00-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/kube-system/container-azm-ms-agentconfig

--- a/k8s/ldata/cluster-01-overlay/kustomization.yaml
+++ b/k8s/ldata/cluster-01-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/kube-system/container-azm-ms-agentconfig

--- a/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/pact-broker
   - ../../namespaces/artifactory
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/backstage
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig

--- a/k8s/namespaces/kube-system/aad-pod-id/kustomization.yaml
+++ b/k8s/namespaces/kube-system/aad-pod-id/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: kube-system
+kind: Kustomization
+resources:
+  - mic-exception.yaml

--- a/k8s/namespaces/kube-system/aad-pod-id/mic-exception.yaml
+++ b/k8s/namespaces/kube-system/aad-pod-id/mic-exception.yaml
@@ -1,8 +1,7 @@
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzurePodIdentityException
 metadata:
-  name: mic-exception
+  name: aks-addon-exception
 spec:
   podLabels:
-    app: mic
-    component: mic
+    kubernetes.azure.com/managedby: aks

--- a/k8s/perftest/cluster-00-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-00-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider-v0.0.8
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/perftest/cluster-01-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-01-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider-v0.0.8
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 patchesStrategicMerge:

--- a/k8s/preview/cluster-00-overlay/kustomization.yaml
+++ b/k8s/preview/cluster-00-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/preview/cluster-01-overlay/kustomization.yaml
+++ b/k8s/preview/cluster-01-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/knode-system
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/kustomization.yaml
@@ -20,6 +20,7 @@ bases:
   - ../../namespaces/admin/keda
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/kustomization.yaml
@@ -20,6 +20,7 @@ bases:
   - ../../namespaces/admin/keda
   - ../../namespaces/monitoring/dynatrace
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-00-overlay/kustomization.yaml
@@ -13,6 +13,7 @@ bases:
   - ../../namespaces/monitoring/kuberhealthy
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/admin/csi-secret-store-provider-v0.0.8
   - ../../namespaces/kube-system/container-azm-ms-agentconfig
 

--- a/k8s/sandbox/cluster-01-overlay/kustomization.yaml
+++ b/k8s/sandbox/cluster-01-overlay/kustomization.yaml
@@ -12,6 +12,7 @@ bases:
   - ../../namespaces/monitoring/kuberhealthy
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
+  - ../../namespaces/kube-system/aad-pod-id
   - ../../namespaces/knode-system
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/admin/csi-secret-store-provider


### PR DESCRIPTION
A file intended for the kube-system namespace was in the admin kustomization, kustomize overrides any namespace overrides so moved it to a different kustomization