### PR TITLE
Remove Azure AD group dcd_group_devops_v2

### DIFF
--- a/k8s/namespaces/jenkins/jenkins.yaml
+++ b/k8s/namespaces/jenkins/jenkins.yaml
@@ -128,7 +128,6 @@ spec:
               authorizationStrategy:
                 globalMatrix:
                   permissions:
-                    - "Overall/Administer:300e771f-856c-45cc-b899-40d78281e9c1"
                     - "Overall/Administer:e7ea2042-4ced-45dd-8ae3-e051c6551789"
                     - "Overall/Administer:3830f73c-22c0-436c-893d-e1869d2bc551" # platform engineering in RPE899 tenant
                     - "Overall/SystemRead:authenticated"


### PR DESCRIPTION
### Change description ###
Remove Azure AD group:- dcd_group_devops_v2 as DTS Platform Operations group will be used

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
