### PR TITLE
Sandbox - add original rbac into admin

### DIFF
--- a/k8s/namespaces/admin/helm-operator/kustomization.yaml
+++ b/k8s/namespaces/admin/helm-operator/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/fluxcd/helm-operator/1.2.0/deploy/deployment.yaml
-  - helm-operator-service-account.yaml
-  - helm-operator-role-binding.yaml
-  - helm-operator-role.yaml
+  #- helm-operator-service-account.yaml
+  #- helm-operator-role-binding.yaml
+  #- helm-operator-role.yaml
 patches:
   - path: ../../../namespaces/admin/helm-operator/patches/helm-operator.yaml
     target:

--- a/k8s/sandbox/common-overlay/admin/kustomization.yaml
+++ b/k8s/sandbox/common-overlay/admin/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: admin
 bases:
 - ../../../namespaces/admin/helm-operator
 - https://raw.githubusercontent.com/fluxcd/helm-operator/1.2.0/deploy/crds.yaml
+- https://raw.githubusercontent.com/fluxcd/helm-operator/1.2.0/deploy/rbac.yaml


### PR DESCRIPTION
After revert, "system:serviceaccount:admin:helm-operator" cannot list resource "helmreleases" in API group "helm.fluxcd.io" at the cluster scope - as clusterrole was corrected to role for across namespaces.
Needed to be added back as had been changed from role to clusterrole for main one


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
