### PR TITLE
  RDM-9053: Postgress 11 upgrade revert

### DIFF
--- a/k8s/demo/common/ccd/definition-store-api.yaml
+++ b/k8s/demo/common/ccd/definition-store-api.yaml
@@ -38,7 +38,7 @@ spec:
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v11-demo.postgres.database.azure.com
         DEFINITION_STORE_DB_USERNAME: ccd@ccd-definition-store-api-postgres-db-v11-demo
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp,aac_manage_case_assignment
-        DEFINITION_TEST_TEST: test
+        DEFINITION_TEST_TEST: test1
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
RDM-9053: Postgress 11 upgrade revert
    
          [RDM-9053] (https://tools.hmcts.net/jira/browse/RDM-9053).