### PR TITLE
fix : Pod restart to enable Unspec roles in demo(RDCC-2329)

### DIFF
--- a/k8s/namespaces/rd/rd-professional-api/demo.yaml
+++ b/k8s/namespaces/rd/rd-professional-api/demo.yaml
@@ -2,15 +2,10 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: rd-professional-api
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:pr-949-*
-    hmcts.github.com/prod-automated: disabled
 spec:
   values:
     java:
       environment:
-        DELETE_ORG: true
+        DELETE_ORG: false
         ACTIVE_ORG_EXT: true
         PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,xui_webapp,finrem_payment_service,finrem_case_orchestration,fpl_case_service,iac,aac_manage_case_assignment,divorce_frontend,unspec_service,nfdiv_cos,am_org_role_mapping_service
-      image: hmctspublic.azurecr.io/rd/professional-api:pr-949-785b3138


### PR DESCRIPTION
### JIRA link (if applicable) ###
RDCC-2329


### Change description ###
The change will restart the Demo pods so that Unspec roles will be enabled in Demo Env


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
