### PR TITLE
Update Jenkins VM Agent instance to match Prod

### DIFF
--- a/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
@@ -275,7 +275,7 @@ spec:
                         existingStorageAccountName: "hmctsjenkinssbox"
                         imageReference:
                           galleryImageDefinition: "jenkins-agent"
-                          galleryImageVersion: "2.2.3"
+                          galleryImageVersion: "2.2.4"
                           galleryName: "cnpimagegallery"
                           galleryResourceGroup: "cnp-image-gallery-rg"
                           gallerySubscriptionId: "bf308a5c-0624-4334-8ff8-8dca9fd43783"
@@ -287,7 +287,7 @@ spec:
                           mount /dev/sdb1 /opt/jenkins
                           chown -R jenkinsssh:jenkinsssh /opt/jenkins
                           set -e
-                          mv /tmp/jenkinsssh_id_rsa /home/jenkinsssh/.ssh/id_rsa
+                          cp /opt/jenkinsssh_id_rsa /home/jenkinsssh/.ssh/id_rsa
                           chown jenkinsssh:jenkinsssh /home/jenkinsssh/.ssh/id_rsa
                           chmod 0600 /home/jenkinsssh/.ssh/id_rsa
                           mkdir /opt/jenkins/.gradle && echo 'org.gradle.daemon=false' > /opt/jenkins/.gradle/gradle.properties


### PR DESCRIPTION
Jenkins VM Agent image was one version behind.

Had to also update the init script as the ssh key has been moved. ﻿

See PR for prod:

https://github.com/hmcts/cnp-flux-config/commit/8b00b8817fb24265311ae6347769a8716875d5d1