### PR TITLE
Remove RD CRD API to resolve incorrect image warnings

### DIFF
--- a/k8s/aat/common-overlay/am/kustomization.yaml
+++ b/k8s/aat/common-overlay/am/kustomization.yaml
@@ -3,10 +3,10 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
-- ../../../namespaces/am/am-org-role-mapping-service/am-org-role-mapping-service.yaml
-- ../../../namespaces/am/am-role-assignment-service/am-role-assignment-service.yaml
+# - ../../../namespaces/am/am-org-role-mapping-service/am-org-role-mapping-service.yaml
+# - ../../../namespaces/am/am-role-assignment-service/am-role-assignment-service.yaml
 - ../../../namespaces/am/am-judicial-booking-service/am-judicial-booking-service.yaml
 patchesStrategicMerge:
-- ../../../namespaces/am/am-org-role-mapping-service/aat.yaml
+# - ../../../namespaces/am/am-org-role-mapping-service/aat.yaml
 - ../../../namespaces/am/am-judicial-booking-service/aat.yaml
-- ../../../namespaces/am/am-role-assignment-service/aat.yaml
+# - ../../../namespaces/am/am-role-assignment-service/aat.yaml

--- a/k8s/aat/common-overlay/rd/kustomization.yaml
+++ b/k8s/aat/common-overlay/rd/kustomization.yaml
@@ -3,11 +3,11 @@ kind: Kustomization
 namespace: rd
 bases:
 - ../../../namespaces/rd
-- ../../../namespaces/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
+# - ../../../namespaces/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
 - ../../../namespaces/rd/rd-location-ref-api/rd-location-ref-api.yaml
 - ../../../namespaces/rd/rd-judicial-api/rd-judicial-api.yaml
 patchesStrategicMerge:
-- ../../../namespaces/rd/rd-caseworker-ref-api/aat.yaml
+# - ../../../namespaces/rd/rd-caseworker-ref-api/aat.yaml
 - ../../../namespaces/rd/rd-judicial-api/aat.yaml
 - ../../../namespaces/rd/rd-location-ref-api/aat.yaml
 - ../../../namespaces/rd/rd-professional-api/aat.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
NA


### Change description ###
To resolve the following warnings:
Warning: AKS cluster aat-aks-00 is running rd/caseworker-ref-api:prod-4e8524e3 instead of rd/caseworker-ref-api:prod-4a7e5070 (2021-02-12T13:25:16.4910527Z).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
