### PR TITLE
Adding apps to common kustomization

### DIFF
--- a/k8s/aat/common-overlay/wa/kustomization.yaml
+++ b/k8s/aat/common-overlay/wa/kustomization.yaml
@@ -3,9 +3,6 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
-- ../../../namespaces/wa/wa-standalone-task-bpmn/wa-standalone-task-bpmn.yaml
-- ../../../namespaces/wa/wa-case-event-handler/wa-case-event-handler.yaml
 patchesStrategicMerge:
 - ../../../namespaces/wa/wa-proto-frontend/aat.yaml
 - ../../../namespaces/wa/wa-task-management-api/aat.yaml
-

--- a/k8s/demo/common-overlay/wa/kustomization.yaml
+++ b/k8s/demo/common-overlay/wa/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
-- ../../../namespaces/wa/wa-case-event-handler/wa-case-event-handler.yaml
 patchesStrategicMerge:
 - ../../../namespaces/wa/wa-proto-frontend/demo.yaml
 

--- a/k8s/namespaces/wa/kustomization.yaml
+++ b/k8s/namespaces/wa/kustomization.yaml
@@ -7,4 +7,6 @@ bases:
 - wa-task-management-api/wa-task-management-api.yaml
 - wa-task-configuration-api/wa-task-configuration-api.yaml
 - wa-proto-frontend/wa-proto-frontend.yaml
+- wa-case-event-handler/wa-case-event-handler.yaml
+- wa-standalone-task-bpmn/wa-standalone-task-bpmn.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.


### PR DESCRIPTION
Adding standalong-task-bpmn and case-event-handler to common kustomization and removing from the AAT/Demo common-overlay since we want the apps to be deployed everywhere. 