### PR TITLE
Sandbox - add flux-helm-repositories secret to admin

### DIFF
--- a/k8s/sandbox/common-overlay/admin/kustomization.yaml
+++ b/k8s/sandbox/common-overlay/admin/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: admin
 bases:
 - ../../../namespaces/admin/helm-operator
+- ../../../namespaces/admin/helm-operator/sealed-secrets/sandbox/flux-helm-repositories.yaml
 - https://raw.githubusercontent.com/fluxcd/helm-operator/1.2.0/deploy/crds.yaml
 patchesJson6902:
 - target:


### PR DESCRIPTION
flux-helm-repositories was installed as part of old helm-op, so does need included in admin
Whereas flux-git-deploy secret is deployed in flux release.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
