### PR TITLE
Remove AI key from chart properties from FR services

### DIFF
--- a/k8s/aat/common/financial-remedy/finrem-ns.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-ns.yaml
@@ -27,7 +27,6 @@ spec:
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      applicationInsightsInstrumentKey: "97f6a0e1-6be6-44b0-97bf-d03852b7791f"
       image: hmctspublic.azurecr.io/finrem/ns:prod-114753d5
     global:
       environment: aat

--- a/k8s/demo/common/financial-remedy/finrem-ns.yaml
+++ b/k8s/demo/common/financial-remedy/finrem-ns.yaml
@@ -27,7 +27,6 @@ spec:
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      applicationInsightsInstrumentKey: "8acedaf6-c503-4433-a94c-f3b104247f3b"
       image: hmctspublic.azurecr.io/finrem/ns:prod-114753d5
     global:
       environment: demo

--- a/k8s/prod/common/financial-remedy/finrem-ns.yaml
+++ b/k8s/prod/common/financial-remedy/finrem-ns.yaml
@@ -27,7 +27,6 @@ spec:
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      applicationInsightsInstrumentKey: "eb08d1ca-cf60-4744-854d-b0e6a94b99e2"
       image: hmctspublic.azurecr.io/finrem/ns:prod-114753d5
       environment:
         SWAGGER_ENABLED: false


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

Removes AI key from chart properties from FR services which is no longer supported in newer version of helm charts. Value will be loaded from secrets instead.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
