### PR TITLE
DTSBPS-386 Remove ctsc-web-forms-ui from Jenkin view

### DIFF
--- a/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/cftptl/cluster-00/jenkins.yaml
@@ -142,7 +142,7 @@ spec:
                     title: AM
                 - buildMonitor:
                     includeRegex: >-
-                      HMCTS_.*CTSC\/.+\/master
+                      ^HMCTS_.*CTSC.*\/(ctsc-shared-infrastructure|ctsc-work-.*)\/master
                     name: CTSC
                     recurse: true
                     title: CTSC


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-386


### Change description ###
Remove the unused project from jenking view
*ctsc-web-forms-ui *


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
