### PR TITLE
update to use guthub chart source (AAT & PRD)

### DIFF
--- a/k8s/aat/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/aat/common/money-claims/cmc-citizen-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-citizen-frontend
-    version: 3.3.12
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-citizen-frontend
   values:
     nodejs:
       replicas: 2

--- a/k8s/aat/common/money-claims/cmc-legal-frontend.yaml
+++ b/k8s/aat/common/money-claims/cmc-legal-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-legal-frontend
-    version: 1.2.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-legal-frontend
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-citizen-frontend
-    version: 3.3.14
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-citizen-frontend
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
@@ -20,7 +20,7 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-2851-3a8fda4
+      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-2851-3a8fda48
       ingressHost: moneyclaims.demo.platform.hmcts.net
       environment:
         FEATURE_TESTING_SUPPORT: true

--- a/k8s/demo/common/money-claims/cmc-legal-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-legal-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-legal-frontend
-    version: 1.2.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-legal-frontend
   values:
     nodejs:
       replicas: 2

--- a/k8s/prod/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/prod/common/money-claims/cmc-citizen-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-citizen-frontend
-    version: 3.3.13
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-citizen-frontend
   values:
     nodejs:
       replicas: 4

--- a/k8s/prod/common/money-claims/cmc-legal-frontend.yaml
+++ b/k8s/prod/common/money-claims/cmc-legal-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-legal-frontend
-    version: 1.2.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-legal-frontend
   values:
     nodejs:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-8855
https://tools.hmcts.net/jira/browse/ROC-8857

### Change description ###

> As part of upgrading base helm charts to latest version, i have updated the flux config to use guthub chart source

Tested in demo environment via https://github.com/hmcts/cnp-flux-config/pull/8365

https://hmcts-reform.slack.com/files/T1L0WSW9F/F018A7PQBNC?origin_team=T1L0WSW9F

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
