### PR TITLE
update to use guthub chart source

### DIFF
--- a/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-citizen-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-citizen-frontend
-    version: 3.3.14
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-citizen-frontend
   values:
     nodejs:
       replicas: 2

--- a/k8s/demo/common/money-claims/cmc-legal-frontend.yaml
+++ b/k8s/demo/common/money-claims/cmc-legal-frontend.yaml
@@ -13,9 +13,9 @@ spec:
     enable: true
     retry: true
   chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-legal-frontend
-    version: 1.2.0
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-legal-frontend
   values:
     nodejs:
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ROC-8855
https://tools.hmcts.net/jira/browse/ROC-8857

### Change description ###

> As part of upgrading base helm charts to latest version, i have updated the flux config to use guthub chart source

https://hmcts-reform.slack.com/files/T1L0WSW9F/F018A7PQBNC?origin_team=T1L0WSW9F

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
