### PR TITLE
Disable autodeployment for idam-web-public in AAT

### DIFF
--- a/k8s/aat/common/idam/idam-web-public.yaml
+++ b/k8s/aat/common/idam/idam-web-public.yaml
@@ -5,7 +5,7 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
+    flux.weave.works/automated: "false"
     flux.weave.works/tag.java: glob:aat-*
 spec:
   releaseName: idam-web-public


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-5480


### Change description ###
Turning off auto deployment for idam-web-public in AAT as per:
https://tools.hmcts.net/confluence/display/SISM/5.2.1+Release+Run-Book+-+AAT#


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
