### PR TITLE
Revert "RDM-3079-10937"

### DIFF
--- a/k8s/demo/common/ccd/data-store-api.yaml
+++ b/k8s/demo/common/ccd/data-store-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ccd
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:pr-1396-*
+    flux.weave.works/tag.java: glob:pr-1350-*
 spec:
   releaseName: ccd-data-store-api
   rollback:
@@ -20,7 +20,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-1396-754f83f4
+      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-1350-5cf88503
       environment:
         DEFINITION_CACHE_LATEST_VERSION_TTL_SEC: 30
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net

--- a/k8s/demo/common/ccd/definition-store-api.yaml
+++ b/k8s/demo/common/ccd/definition-store-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ccd
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:pr-958-*
+    flux.weave.works/tag.java: glob:pr-931-*
 spec:
   releaseName: ccd-definition-store-api
   rollback:
@@ -20,7 +20,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-958-4acc98ef
+      image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-931-6a31fb0c
       environment:
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#8533

The definition-store-api pods failed to start on the Demo cluster due to FlyWay issues.