### PR TITLE
disabling deprecation check on Jenkins chart

### DIFF
--- a/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/mgmt-sandbox/cluster-00/jenkins.yaml
@@ -10,6 +10,7 @@ spec:
     name: jenkins
     version: 3.2.1
   values:
+    checkDeprecation: false
     controller:
       javaOpts: >-
         -XX:InitialRAMPercentage=30.0


### PR DESCRIPTION
Disabling as chart is validating against having `master:` values( will remove it when migrating to prod Jenkins as its not possible with current kustomize) 
https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/templates/deprecation.yaml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
