### PR TITLE
Changing to sleep mode for Jenkins sidecar

### DIFF
--- a/k8s/namespaces/jenkins/jenkins.yaml
+++ b/k8s/namespaces/jenkins/jenkins.yaml
@@ -422,6 +422,10 @@ spec:
           env:
             - name: REQ_TIMEOUT
               value: "60"
+            - name: METHOD
+              value: "SLEEP"
+            - name: SLEEP_TIME
+              value: "300"
       ingress:
         enabled: true
         labels: {}


### PR DESCRIPTION
Currently having issues with using WATCH mode where it suddenly stops working as described in https://github.com/kiwigrid/k8s-sidecar/issues/85. 

Drawback is deletion of config maps won't work - which is not a case we need to be worried.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
