### PR TITLE
Update sandbox docmosis image temporarily to check templates uploaded

### DIFF
--- a/k8s/namespaces/docmosis/docmosis/sandbox.yaml
+++ b/k8s/namespaces/docmosis/docmosis/sandbox.yaml
@@ -3,11 +3,11 @@ kind: HelmRelease
 metadata:
   name: docmosis
   annotations:
-    filter.fluxcd.io/chart-image: glob:sandbox-*
+    filter.fluxcd.io/chart-image: glob:prod-*
 spec:
   values:
     ingressHost: docmosis.sandbox.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:sandbox-129475
+    image: hmctsprivate.azurecr.io/docmosis:prod-129475
     environment:
       DOCMOSIS_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
       DOCMOSIS_TORNADO_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net


### PR DESCRIPTION
Before opening a new CR for switching docmosis prod to aks,
need to check that the fixed templates are uploaded and available in updated image.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
