### PR TITLE
FR: Toggle on Respondent Solicitor Journey

### DIFF
--- a/k8s/prod/common/financial-remedy/finrem-cos.yaml
+++ b/k8s/prod/common/financial-remedy/finrem-cos.yaml
@@ -29,7 +29,7 @@ spec:
         ASSIGNED_TO_JUDGE_DEFAULT_EMAIL: newApplication@justice.gov.uk
         BSP_SERVICES_ALLOWED_TO_UPDATE: bulk_scan_orchestrator
         BSP_SERVICES_ALLOWED_TO_VALIDATE: bulk_scan_processor
-        FEATURE_RESPONDENT_JOURNEY: false
+        FEATURE_RESPONDENT_JOURNEY: true
         FEATURE_SEND_TO_FRC: true
     global:
       environment: prod


### PR DESCRIPTION
Reverting the revert of hmcts/cnp-flux-config#8841 so we can toggle on Resp Sol Journey in FR