### PR TITLE
correct image to one with a green tick

### DIFF
--- a/k8s/demo/common/sscs/sscs-bulk-scan.yaml
+++ b/k8s/demo/common/sscs/sscs-bulk-scan.yaml
@@ -20,7 +20,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/bulk-scan:pr-871-935ab12d
+      image: hmctspublic.azurecr.io/sscs/bulk-scan:pr-871-c9e140f9
       environment:
     global:
       environment: demo


### PR DESCRIPTION
correct image to one with a green tick
Builds are failing this morning, so use an image that has its build passing.