### PR TITLE
Use correct rate limiter for github app

### DIFF
--- a/k8s/namespaces/jenkins/jenkins.yaml
+++ b/k8s/namespaces/jenkins/jenkins.yaml
@@ -96,6 +96,10 @@ spec:
               primaryView:
                 all:
                   name: all
+          rate-limiting: |
+            unclassified:
+              gitHubConfiguration:
+                apiRateLimitChecker: ThrottleOnOver
           auth: |
             jenkins:
               authorizationStrategy:


### PR DESCRIPTION
> Throttle at/near rate limit: Restrict GitHub API requests only when near or above rate limit. This strategy may be preferred over "Throttle for Normalize" if there are relatively few/infrequent queries to the GitHub API.

