### PR TITLE
RDCC-2690 - remove whitelisting for probate_backend since release called off

### DIFF
--- a/k8s/namespaces/rd/rd-professional-api/prod.yaml
+++ b/k8s/namespaces/rd/rd-professional-api/prod.yaml
@@ -9,4 +9,4 @@ spec:
         DELETE_ORG: true
         IDAM_URL: https://idam-api.platform.hmcts.net
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
-        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,xui_webapp,finrem_payment_service,finrem_case_orchestration,fpl_case_service,iac,aac_manage_case_assignment,divorce_frontend,probate_backend
+        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,xui_webapp,finrem_payment_service,finrem_case_orchestration,fpl_case_service,iac,aac_manage_case_assignment,divorce_frontend


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-2690


### Change description ###
RDCC-2690 - remove whitelisting for probate_backend since release called off


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
