### PR TITLE
DTSPO-1943 Adding developer clusterrolebindings into flux for pipeline cleanup

### DIFF
--- a/k8s/aat/cluster-00-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-00-overlay/kustomization.yaml
@@ -13,6 +13,7 @@ bases:
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/monitoring/kuberhealthy
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector

--- a/k8s/aat/cluster-01-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-01-overlay/kustomization.yaml
@@ -12,6 +12,7 @@ bases:
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/monitoring/kuberhealthy
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector

--- a/k8s/demo/cluster-00-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-00-overlay/kustomization.yaml
@@ -11,6 +11,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/monitoring/kube-prometheus-stack

--- a/k8s/demo/cluster-01-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-01-overlay/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/monitoring/kube-prometheus-stack

--- a/k8s/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-00-overlay/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/monitoring/kube-prometheus-stack

--- a/k8s/ithc/cluster-01-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-01-overlay/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/monitoring/kube-prometheus-stack

--- a/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
@@ -74,7 +74,7 @@ patchesJson6902:
     path: ../../namespaces/jenkins/additional-service-monitors.yaml
 
 patches:
-- target:
-    kind: ClusterRoleBinding
-    labelSelector: role-type=developer
-  path: ../../namespaces/all-namespaces/reader-clusterrole/mgmt-sandbox.yaml
+  - target:
+      kind: ClusterRoleBinding
+      labelSelector: role-type=developer
+    path: ../../namespaces/all-namespaces/reader-clusterrole/mgmt-sandbox.yaml

--- a/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
+++ b/k8s/mgmt-sandbox/cluster-00-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/jenkins
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
@@ -71,3 +72,9 @@ patchesJson6902:
       name: kube-prometheus-stack
       namespace: monitoring
     path: ../../namespaces/jenkins/additional-service-monitors.yaml
+
+patches:
+- target:
+    kind: ClusterRoleBinding
+    labelSelector: role-type=developer
+  path: ../../namespaces/all-namespaces/reader-clusterrole/mgmt-sandbox.yaml

--- a/k8s/namespaces/all-namespaces/edit-clusterrole.yaml
+++ b/k8s/namespaces/all-namespaces/edit-clusterrole.yaml
@@ -1,4 +1,4 @@
-# For use with Preview environment
+# For use with Preview and Sandbox environments
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -15,7 +15,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: developer-edit-custom-resources
+  name: developer-write-custom-resources
 rules:
 - apiGroups: ['keda.k8s.io']
   resources: ['scaledobjects']
@@ -33,11 +33,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: developer-edit-custom-resources
+  name: developer-write-custom-resources
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: developer-edit-custom-resources
+  name: developer-write-custom-resources
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/k8s/namespaces/all-namespaces/reader-clusterrole.yaml
+++ b/k8s/namespaces/all-namespaces/reader-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: developer-read
+  labels:
+    role-type: developer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -14,7 +16,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: developer-view-custom-resources
+  name: developer-read-custom-resources
 rules:
 - apiGroups: ['keda.k8s.io']
   resources: ['scaledobjects']
@@ -32,11 +34,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: developer-view-custom-resources
+  name: developer-read-custom-resources
+  labels:
+    role-type: developer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: developer-view-custom-resources
+  name: developer-read-custom-resources
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/k8s/namespaces/all-namespaces/reader-clusterrole/cftptl.yaml
+++ b/k8s/namespaces/all-namespaces/reader-clusterrole/cftptl.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: ClusterRoleBinding
+metadata:
+  name: developer-read
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: 'e8f7ee45-1843-4ddb-bc7e-bdd102300533'

--- a/k8s/namespaces/all-namespaces/reader-clusterrole/ldata.yaml
+++ b/k8s/namespaces/all-namespaces/reader-clusterrole/ldata.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: ClusterRoleBinding
+metadata:
+  name: developer-read
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: '7c7c42d7-0356-42e8-863a-84ec944ed03a'

--- a/k8s/namespaces/all-namespaces/reader-clusterrole/mgmt-sandbox.yaml
+++ b/k8s/namespaces/all-namespaces/reader-clusterrole/mgmt-sandbox.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: ClusterRoleBinding
+metadata:
+  name: developer-read
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: '7b8ece8b-ad4f-4a5c-aede-b1cee61a574b'

--- a/k8s/namespaces/all-namespaces/reader-clusterrole/prod.yaml
+++ b/k8s/namespaces/all-namespaces/reader-clusterrole/prod.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: ClusterRoleBinding
+metadata:
+  name: developer-read
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: '3cc118af-56e7-4169-b99f-052432d5a81d'

--- a/k8s/perftest/cluster-00-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-00-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector

--- a/k8s/perftest/cluster-01-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-01-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector

--- a/k8s/preview/cluster-00-overlay/kustomization.yaml
+++ b/k8s/preview/cluster-00-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/external-dns
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/edit-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/osba

--- a/k8s/preview/cluster-01-overlay/kustomization.yaml
+++ b/k8s/preview/cluster-01-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/external-dns
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/edit-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/osba


### PR DESCRIPTION
As part of https://tools.hmcts.net/jira/browse/DTSPO-1943
Clusterrole and clusterrolebindings for DTS CFT developers group are being added into flux config
Renamed an edit one to avoid a clash in preview.
This is to allow these to be removed from the cluster deployment pipeline (nb: admin cr/crb staying in pipeline).
(already added to sandbox in a previous pr)
Some envs to be done in a separate pr because of group differences (prod,mgmt,ldata)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
