### PR TITLE
DTSPO-1943 - Add crbs for cleanup, with patches for differing groups - prod

### DIFF
--- a/k8s/cftptl/cluster-00-overlay/kustomization.yaml
+++ b/k8s/cftptl/cluster-00-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/jenkins
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
@@ -67,3 +68,9 @@ patchesJson6902:
       name: kube-prometheus-stack
       namespace: monitoring
     path: ../../namespaces/jenkins/additional-service-monitors.yaml
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      labelSelector: role-type=developer
+    path: ../../namespaces/all-namespaces/reader-clusterrole/cftptl.yaml

--- a/k8s/ldata/cluster-00-overlay/kustomization.yaml
+++ b/k8s/ldata/cluster-00-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
@@ -43,3 +44,9 @@ patchesStrategicMerge:
 
   # Dynatrace patch
   - ../../namespaces/monitoring/dynatrace/patches/ldata/oneagent.yaml
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      labelSelector: role-type=developer
+    path: ../../namespaces/all-namespaces/reader-clusterrole/ldata.yaml

--- a/k8s/ldata/cluster-01-overlay/kustomization.yaml
+++ b/k8s/ldata/cluster-01-overlay/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
   - ../../namespaces/admin/kube-slack
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
@@ -43,3 +44,9 @@ patchesStrategicMerge:
 
   # Dynatrace patch
   - ../../namespaces/monitoring/dynatrace/patches/ldata/oneagent.yaml
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      labelSelector: role-type=developer
+    path: ../../namespaces/all-namespaces/reader-clusterrole/ldata.yaml

--- a/k8s/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/kustomization.yaml
@@ -10,6 +10,7 @@ bases:
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector

--- a/k8s/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/kustomization.yaml
@@ -69,9 +69,7 @@ patches:
     target:
       kind: HelmRelease
       annotationSelector: hmcts.github.com/prod-automated == enabled
-
-patches:
-  - target:
+  - path: ../../namespaces/all-namespaces/reader-clusterrole/prod.yaml
+    target:
       kind: ClusterRoleBinding
       labelSelector: role-type=developer
-    path: ../../namespaces/all-namespaces/reader-clusterrole/prod.yaml

--- a/k8s/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/kustomization.yaml
@@ -68,3 +68,9 @@ patches:
     target:
       kind: HelmRelease
       annotationSelector: hmcts.github.com/prod-automated == enabled
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      labelSelector: role-type=developer
+    path: ../../namespaces/all-namespaces/reader-clusterrole/prod.yaml

--- a/k8s/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/kustomization.yaml
@@ -10,6 +10,7 @@ bases:
   - ../../namespaces/admin/keyvault-flexvol
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/admin/traefik
+  - ../../namespaces/all-namespaces/reader-clusterrole.yaml
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector

--- a/k8s/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/kustomization.yaml
@@ -69,9 +69,7 @@ patches:
     target:
       kind: HelmRelease
       annotationSelector: hmcts.github.com/prod-automated == enabled
-
-patches:
-  - target:
+  - path: ../../namespaces/all-namespaces/reader-clusterrole/prod.yaml
+    target:
       kind: ClusterRoleBinding
       labelSelector: role-type=developer
-    path: ../../namespaces/all-namespaces/reader-clusterrole/prod.yaml

--- a/k8s/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/kustomization.yaml
@@ -68,3 +68,9 @@ patches:
     target:
       kind: HelmRelease
       annotationSelector: hmcts.github.com/prod-automated == enabled
+
+patches:
+  - target:
+      kind: ClusterRoleBinding
+      labelSelector: role-type=developer
+    path: ../../namespaces/all-namespaces/reader-clusterrole/prod.yaml


### PR DESCRIPTION
Adds crb for ldata, cftptl and prod clusters into flux - as these are to be cleaned up from the pipeline. 
Using kustomize patch as the groups are different for these clusters - patches can be viewed here https://github.com/hmcts/cnp-flux-config/tree/master/k8s/namespaces/all-namespaces/reader-clusterrole

https://tools.hmcts.net/jira/browse/DTSPO-1943
Tested locally and groups checked.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
