### PR TITLE
Add additional packageRule due to error with two registryUrls

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,12 @@
     {
       "datasources": ["helm"],
       "managers": ["regex"],
-      "registryUrls": ["https://hmctspublic.azurecr.io/helm/v1/repo/","https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/"]
+      "registryUrls": ["https://hmctspublic.azurecr.io/helm/v1/repo/"]
+    },
+    {
+      "datasources": ["helm"],
+      "managers": ["regex"],
+      "registryUrls": ["https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/"]
     }
   ]
 }


### PR DESCRIPTION
### Change description ###
Add additional packageRule due to error with two registryUrls
`WARN: Excess registryUrls found for datasource lookup - using first configured only`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
