### PR TITLE
Pointing home-office-integration-api to point to mock api instead of PRP1

### DIFF
--- a/k8s/namespaces/ia/ia-home-office-integration-api/aat.yaml
+++ b/k8s/namespaces/ia/ia-home-office-integration-api/aat.yaml
@@ -6,4 +6,4 @@ spec:
   values:
     java:
       environment:
-        HOME_OFFICE_ENDPOINT: "https://cts-challenge.prp1.np.immigration-api.homeoffice.gov.uk"
+        HOME_OFFICE_ENDPOINT: "http://ia-home-office-mock-api-aat.service.core-compute-aat.internal"


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Pointing home-office-integration-api to point to mock api instead of PRP1


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
