### PR TITLE
RDM-11956 Extend allowed list of document domains to include em-hrs-a…

### DIFF
--- a/k8s/prod/common/ccd/data-store-api.yaml
+++ b/k8s/prod/common/ccd/data-store-api.yaml
@@ -27,7 +27,7 @@ spec:
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-617aef96
       environment:
         IDAM_USER_URL: "https://hmcts-access.service.gov.uk"
-        CCD_DM_DOMAIN: ^https?://(?:api-gateway\.dm\.reform\.hmcts\.net|dm-store-prod\.service\.core-compute-prod\.internal(?::\d+)?)
+        CCD_DOCUMENT_URL_PATTERN: ^https?://(((?:api-gateway\.dm\.reform\.hmcts\.net|dm-store-prod\.service\.core-compute-prod\.internal(?::\d+)?)\/documents\/[A-Za-z0-9-]+(?:\/binary)?)|(em-hrs-api-prod\.service\.core-compute-prod\.internal(?::\d+)?\/hearing-recordings\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/segments\/[0-9]))
         CCD_DEFAULTPRINTURL: "https://return-case-doc.ccd.platform.hmcts.net/jurisdictions/:jid/case-types/:ctid/cases/:cid"
         HTTP_CLIENT_MAX_CLIENT_PER_ROUTE: 40
         DEFINITION_CACHE_LATEST_VERSION_TTL_SEC: 30


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-11956


### Change description ###
Extend allowed list of document domains to include em-hrs-api


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
