### PR TITLE
update dynatrace oneagent to 0.10.0

### DIFF
--- a/k8s/namespaces/monitoring/dynatrace/patches/perftest/oneagent.yaml
+++ b/k8s/namespaces/monitoring/dynatrace/patches/perftest/oneagent.yaml
@@ -5,6 +5,10 @@ metadata:
   name: oneagent-operator
   namespace: monitoring
 spec:
+  chart:
+    repository: https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/
+    name: dynatrace-oneagent-operator
+    version: 0.10.0
   values:
     oneagent:
       args:


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-2447

### Change description ###

update dynatrace oneagent in perftest env to use 0.10.0.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
