### PR TITLE
Civil namespace fix

### DIFF
--- a/k8s/aat/common-overlay/kustomization.yaml
+++ b/k8s/aat/common-overlay/kustomization.yaml
@@ -37,7 +37,6 @@ bases:
   - fact
   - nfdiv
   - cpo
-  - civil
 patches:
   - path: ../aat-helmrelease.yaml
     target:

--- a/k8s/aat/common-overlay/kustomization.yaml
+++ b/k8s/aat/common-overlay/kustomization.yaml
@@ -37,6 +37,7 @@ bases:
   - fact
   - nfdiv
   - cpo
+  - civil
 patches:
   - path: ../aat-helmrelease.yaml
     target:

--- a/k8s/demo/common-overlay/kustomization.yaml
+++ b/k8s/demo/common-overlay/kustomization.yaml
@@ -32,6 +32,7 @@ bases:
   - wa
   - nfdiv
   - cpo
+  - civil
 patches:
   - path: ../demo-helmrelease.yaml
     target:

--- a/k8s/preview/common-overlay/kustomization.yaml
+++ b/k8s/preview/common-overlay/kustomization.yaml
@@ -35,6 +35,7 @@ bases:
   - fact
   - nfdiv
   - cpo
+  - civil
 patches:
   - path: ../preview-helmrelease.yaml
     target:


### PR DESCRIPTION
Fix as there are currently errors in flux like 
Resource civil:azureidentity/civil, file: k8s/demo/common/civil/identity.yaml:
running kubectl: exit status 1, stderr: Error from server (NotFound): error when creating "STDIN": namespaces "civil" not found

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
