### PR TITLE
Revert "RPET-991: release new parameter to ACA API call"

### DIFF
--- a/k8s/prod/common/divorce/div-cos.yaml
+++ b/k8s/prod/common/divorce/div-cos.yaml
@@ -41,7 +41,7 @@ spec:
         FEATURE_BAILIFF_JOURNEY: true
         PBA_USING_CASE_TYPE: false
         FEATURE_OBJECT_TO_COSTS: true
-        FEATURE_USE_USER_TOKEN: true
+        FEATURE_USE_USER_TOKEN: false
         DOCUMENT_GENERATOR_SERVICE_API_BASEURL: "http://div-dgs-java.divorce"
         SCHEDULER_SEND_UPDATED_CASES_TO_ROBOTICS_ENABLED: true
         DATAEXTRACTION_STATUS_DA_EMAILTO: StokeCTSC4.Auto@justice.gov.uk


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#9769

We don't want to merge it, but it's opened in case we would have to roll back release.