### PR TITLE
Updated Civil config for perftest, ithc and demo

### DIFF
--- a/k8s/namespaces/civil/civil-service/demo.yaml
+++ b/k8s/namespaces/civil/civil-service/demo.yaml
@@ -7,3 +7,6 @@ spec:
     java:
       environment:
         TESTING_SUPPORT_ENABLED: true
+        FEIGN_CLIENT_CONFIG_REMOTERUNTIMESERVICE_URL: http://fake-url
+        FEIGN_CLIENT_CONFIG_REMOTEEXTERNALTASKSERVICE_URL: http://fake-url
+        FEIGN_CLIENT_CONFIG_REMOTEREPOSITORYSERVICE_URL: http://fake-url

--- a/k8s/namespaces/civil/civil-service/ithc.yaml
+++ b/k8s/namespaces/civil/civil-service/ithc.yaml
@@ -7,3 +7,6 @@ spec:
     java:
       environment:
         TESTING_SUPPORT_ENABLED: true
+        FEIGN_CLIENT_CONFIG_REMOTERUNTIMESERVICE_URL: http://fake-url
+        FEIGN_CLIENT_CONFIG_REMOTEEXTERNALTASKSERVICE_URL: http://fake-url
+        FEIGN_CLIENT_CONFIG_REMOTEREPOSITORYSERVICE_URL: http://fake-url

--- a/k8s/namespaces/civil/civil-service/perftest.yaml
+++ b/k8s/namespaces/civil/civil-service/perftest.yaml
@@ -7,3 +7,6 @@ spec:
     java:
       environment:
         TESTING_SUPPORT_ENABLED: true
+        FEIGN_CLIENT_CONFIG_REMOTERUNTIMESERVICE_URL: http://fake-url
+        FEIGN_CLIENT_CONFIG_REMOTEEXTERNALTASKSERVICE_URL: http://fake-url
+        FEIGN_CLIENT_CONFIG_REMOTEREPOSITORYSERVICE_URL: http://fake-url


### PR DESCRIPTION
### Change description ###

Temporarily pointed Civil Service on perftest, ithc and demo to fake Camunda URL so it doesn't consume events triggered by Civil Damages Service.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
