### PR TITLE
New idam tagging and deployment strategy

### DIFF
--- a/k8s/aat/common/idam/idam-api.yaml
+++ b/k8s/aat/common/idam/idam-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: idam
   annotations:
     flux.weave.works/automated: "false"
-    flux.weave.works/tag.java: glob:aat-*
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-api
   rollback:

--- a/k8s/aat/common/idam/idam-web-admin.yaml
+++ b/k8s/aat/common/idam/idam-web-admin.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: idam
   annotations:
     flux.weave.works/automated: "false"
-    flux.weave.works/tag.java: glob:aat-*
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-admin
   rollback:

--- a/k8s/aat/common/idam/idam-web-public.yaml
+++ b/k8s/aat/common/idam/idam-web-public.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: idam
   annotations:
     flux.weave.works/automated: "false"
-    flux.weave.works/tag.java: glob:aat-*
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-public
   rollback:

--- a/k8s/demo/common/idam/idam-api.yaml
+++ b/k8s/demo/common/idam/idam-api.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-api
   namespace: idam
   annotations:
-    fluxcd.io/automated: "false"
-    filter.fluxcd.io/java: glob:prod-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-api
   rollback:

--- a/k8s/demo/common/idam/idam-api.yaml
+++ b/k8s/demo/common/idam/idam-api.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-api
   namespace: idam
   annotations:
-    fluxcd.io/automated: "true"
-    filter.fluxcd.io/java: glob:demo-*
+    fluxcd.io/automated: "false"
+    filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: idam-api
   rollback:

--- a/k8s/demo/common/idam/idam-web-admin.yaml
+++ b/k8s/demo/common/idam/idam-web-admin.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-admin
   namespace: idam
   annotations:
-    fluxcd.io/automated: "true"
-    filter.fluxcd.io/java: glob:demo-*
+    fluxcd.io/automated: "false"
+    filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: idam-web-admin
   rollback:

--- a/k8s/demo/common/idam/idam-web-admin.yaml
+++ b/k8s/demo/common/idam/idam-web-admin.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-admin
   namespace: idam
   annotations:
-    fluxcd.io/automated: "false"
-    filter.fluxcd.io/java: glob:prod-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-admin
   rollback:

--- a/k8s/demo/common/idam/idam-web-public.yaml
+++ b/k8s/demo/common/idam/idam-web-public.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    fluxcd.io/automated: "true"
-    filter.fluxcd.io/java: glob:demo-*
+    fluxcd.io/automated: "false"
+    filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: idam-web-public
   rollback:

--- a/k8s/demo/common/idam/idam-web-public.yaml
+++ b/k8s/demo/common/idam/idam-web-public.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    fluxcd.io/automated: "false"
-    filter.fluxcd.io/java: glob:prod-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-public
   rollback:

--- a/k8s/ithc/common/idam/idam-api.yaml
+++ b/k8s/ithc/common/idam/idam-api.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-api
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:ithc-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-api
   rollback:

--- a/k8s/ithc/common/idam/idam-web-admin.yaml
+++ b/k8s/ithc/common/idam/idam-web-admin.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-admin
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:ithc-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-admin
   rollback:

--- a/k8s/ithc/common/idam/idam-web-public.yaml
+++ b/k8s/ithc/common/idam/idam-web-public.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:ithc-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-public
   rollback:

--- a/k8s/perftest/cluster-00/idam/idam-api.yaml
+++ b/k8s/perftest/cluster-00/idam/idam-api.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-api
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:perftest-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-api
   rollback:

--- a/k8s/perftest/cluster-01/idam/idam-api.yaml
+++ b/k8s/perftest/cluster-01/idam/idam-api.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-api
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:perftest-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-api
   rollback:

--- a/k8s/perftest/common/idam/idam-web-admin.yaml
+++ b/k8s/perftest/common/idam/idam-web-admin.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-admin
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:perftest-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-admin
   rollback:

--- a/k8s/perftest/common/idam/idam-web-public.yaml
+++ b/k8s/perftest/common/idam/idam-web-public.yaml
@@ -5,8 +5,8 @@ metadata:
   name: idam-web-public
   namespace: idam
   annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:perftest-*
+    flux.weave.works/automated: "false"
+    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: idam-web-public
   rollback:


### PR DESCRIPTION
Deploy prod or preview tags to environments.
Stop creating perftest, ithc, demo and aat tags