### PR TITLE
chore: Allow case activity tracker to access aat ccd key vault from fpl namespace in preview env

### DIFF
--- a/k8s/preview/common-overlay/family-public-law/kustomization.yaml
+++ b/k8s/preview/common-overlay/family-public-law/kustomization.yaml
@@ -6,3 +6,4 @@ bases:
 - ../../../aat/common/family-public-law/identity.yaml
 - ../../../aat/common/aac/identity.yaml
 - ../../../aat/common/xui/identity.yaml
+- ../../../aat/common/ccd/identity.yaml


### PR DESCRIPTION
<img width="1422" alt="Screenshot 2021-05-26 at 11 32 19" src="https://user-images.githubusercontent.com/5861660/119645566-1113cb80-be16-11eb-8afd-27581b711472.png">
