### PR TITLE
Dtspo 2564 update retention time from 10 days to 30 days

### DIFF
--- a/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -41,7 +41,6 @@ spec:
         prometheus: true
         prometheusOperator: true
         time: true
-    retention: 30d
 
     prometheus:
       additionalServiceMonitors:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -41,6 +41,7 @@ spec:
         prometheus: true
         prometheusOperator: true
         time: true
+    retention: 30d
 
     prometheus:
       additionalServiceMonitors:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kube-prometheus-stack
   namespace: monitoring
 spec:
+  retention: 30d
   values:
     prometheus:
       ingress:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -10,7 +10,7 @@ spec:
       ingress:
         hosts:
           - prometheus-00.sandbox.platform.hmcts.net
-      prometheusSpec: 
+      prometheusSpec:
         retention: 30d
     alertmanager:
       ingress:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-00/kube-prometheus-stack.yaml
@@ -5,12 +5,13 @@ metadata:
   name: kube-prometheus-stack
   namespace: monitoring
 spec:
-  retention: 30d
   values:
     prometheus:
       ingress:
         hosts:
           - prometheus-00.sandbox.platform.hmcts.net
+      prometheusSpec: 
+        retention: 30d
     alertmanager:
       ingress:
         hosts:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
@@ -5,12 +5,13 @@ metadata:
   name: kube-prometheus-stack
   namespace: monitoring
 spec:
-  retention: 30d
   values:
     prometheus:
       ingress:
         hosts:
           - prometheus-01.sandbox.platform.hmcts.net
+      prometheusSpec: 
+        retention: 30d
     alertmanager:
       ingress:
         hosts:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
@@ -5,6 +5,7 @@ metadata:
   name: kube-prometheus-stack
   namespace: monitoring
 spec:
+  retention: 30d
   values:
     prometheus:
       ingress:

--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/sandbox/cluster-01/kube-prometheus-stack.yaml
@@ -10,7 +10,7 @@ spec:
       ingress:
         hosts:
           - prometheus-01.sandbox.platform.hmcts.net
-      prometheusSpec: 
+      prometheusSpec:
         retention: 30d
     alertmanager:
       ingress:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-2564

### Change description ###

Updated patch files for sandbox environment to change the retention time from 10 days to 30 days for Prometheus metrics.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
