### PR TITLE
updated retention time to 30 days for aat environment

### DIFF
--- a/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-00/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/patches/aat/cluster-00/kube-prometheus-stack.yaml
@@ -10,6 +10,8 @@ spec:
       ingress:
         hosts:
           - prometheus-00.aat.platform.hmcts.net
+      prometheusSpec:
+        retention: 30d
 
     alertmanager:
       ingress:


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-2564

### Change description ###

Updated patch file for aat environment to change the retention time from 10 days to 30 days for Prometheus metrics.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
