### PR TITLE
DTSBPS-620: stop wa in demo, aat and prod

### DIFF
--- a/k8s/aat/common/ctsc/work-allocation.yaml
+++ b/k8s/aat/common/ctsc/work-allocation.yaml
@@ -18,7 +18,7 @@ spec:
     path: stable/ctsc-work-allocation
   values:
     java:
-      replicas: 2
+      replicas: 0
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ctsc/work-allocation:prod-784dc7cb
       environment:

--- a/k8s/demo/common/ctsc/work-allocation.yaml
+++ b/k8s/demo/common/ctsc/work-allocation.yaml
@@ -18,7 +18,7 @@ spec:
     path: stable/ctsc-work-allocation
   values:
     java:
-      replicas: 2
+      replicas: 0
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ctsc/work-allocation:pr-427-b8691861
       environment:

--- a/k8s/prod/common/ctsc/work-allocation.yaml
+++ b/k8s/prod/common/ctsc/work-allocation.yaml
@@ -18,7 +18,7 @@ spec:
     path: stable/ctsc-work-allocation
   values:
     java:
-      replicas: 2
+      replicas: 0
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ctsc/work-allocation:prod-784dc7cb
       environment:


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSBPS-620


### Change description ###
8x8 will be replaced by Antenna on 19th. So the WA task poller needs to stopped as the queue needs to be cleaned in demo, aat, and prod environment.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
