### PR TITLE
update refresh var

### DIFF
--- a/k8s/namespaces/em/em-hrs-api/em-hrs-api.yaml
+++ b/k8s/namespaces/em/em-hrs-api/em-hrs-api.yaml
@@ -16,4 +16,5 @@ spec:
       cpuLimits: "2000m"
       image: hmctspublic.azurecr.io/em/hrs-api:prod-53a1003a
       environment:
-        TEST: "REFRESH"
+        TEST: "REFRESHJun14"
+


### PR DESCRIPTION
### JIRA link (if applicable) ###

refresh prod as prod-aks-00APP  09:15
Warning: AKS cluster prod-aks-00 is running em/hrs-api:prod-923a0f43 instead of em/hrs-api:prod-53a1003a (2021-06-11T15:55:17.597482Z).

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
