### PR TITLE
Scales down indexer pod to 0 replicas as no request in for indexing …

### DIFF
--- a/k8s/namespaces/ccd/ccd-logstash-indexer/aat.yaml
+++ b/k8s/namespaces/ccd/ccd-logstash-indexer/aat.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   releaseName: ccd-logstash-indexer
   values:
-    replicas: 1
+    replicas: 0


### PR DESCRIPTION
…and pod enountering lots of 400 errors

### Change description ###

ES overloaded due to indexing 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
