### PR TITLE
duplicate definition of 'em:helmrelease/em-hrs-ingestor'

### DIFF
--- a/k8s/prod/cluster-01-overlay/em/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/em/kustomization.yaml
@@ -3,8 +3,5 @@ kind: Kustomization
 namespace: em
 bases:
 - ../../../namespaces/em/em-icp/em-icp.yaml
-- ../../../namespaces/em/em-hrs-ingestor/em-hrs-ingestor.yaml
 patchesStrategicMerge:
 - ../../../namespaces/em/em-icp/prod.yaml
-- ../../../namespaces/em/em-hrs-ingestor/prod.yaml
-- ../../../namespaces/em/em-hrs-ingestor/prod-1.yaml


### PR DESCRIPTION
duplicate definition of 'em:helmrelease/em-hrs-ingestor' (generated by k8s/prod/common-overlay/.flux.yaml and by k8s/prod/cluster-01-overlay/.flux.yaml)"

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
