### PR TITLE
 Turning back on multi-draft after bug check

### DIFF
--- a/k8s/demo/common/sscs/sscs-tribunals-frontend.yaml
+++ b/k8s/demo/common/sscs/sscs-tribunals-frontend.yaml
@@ -29,7 +29,7 @@ spec:
         FT_ANTENNA_WEBCHAT: "true"
         FT_ALLOW_UC_HEARING_OPTIONS: "true"
         MEDIA_FILES_ALLOWED_ENABLED: "true"
-        MULTIPLE_DRAFTS_ENABLED: "false"
+        MULTIPLE_DRAFTS_ENABLED: "true"
         TEST_PROPERTY: "true"
         PCQ_URL: https://pcq.demo.platform.hmcts.net
         PCQ_ENABLED: "true"


### PR DESCRIPTION
Turning multi-draft back on to align with PROD after bug check completed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
