### PR TITLE
add em kustomization to non prod envs and fix up prod schedules

### DIFF
--- a/k8s/aat/cluster-01-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-01-overlay/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
   - am
   - rd
   - pcq
+  - em
   - ../../namespaces/admin/flux
   - ../../namespaces/admin/fluxcloud
   - ../../namespaces/admin/flux-helm-operator

--- a/k8s/demo/cluster-00-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-00-overlay/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
   - am
   - rd
   - pcq
+  - em
   - ../../namespaces/admin/external-dns
   - ../../namespaces/admin/external-dns-public
   - ../../namespaces/admin/flux

--- a/k8s/demo/cluster-01-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-01-overlay/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 bases:
   - ccd
   - rd
+  - em
   - ../../namespaces/admin/external-dns
   - ../../namespaces/admin/external-dns-public
   - ../../namespaces/admin/flux

--- a/k8s/namespaces/em/em-hrs-ingestor/prod-0.yaml
+++ b/k8s/namespaces/em/em-hrs-ingestor/prod-0.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 21-23 * * *"
-      # Run every hour during the evening 9pm through 7am
+      schedule: "0 0-6,21-23 * * *"
+      # Run every hour, during the evening 9pm through 6am

--- a/k8s/namespaces/em/em-hrs-ingestor/prod-1.yaml
+++ b/k8s/namespaces/em/em-hrs-ingestor/prod-1.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   values:
     job:
-      schedule: "30 0-6,21-23 * * *"
+      schedule: "30 0-5,21-23 * * *"
       # Run every hour at 30 mins past, during the evening 9pm through 6am

--- a/k8s/namespaces/em/em-hrs-ingestor/prod-1.yaml
+++ b/k8s/namespaces/em/em-hrs-ingestor/prod-1.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   values:
     job:
-      schedule: "30 0-6 * * *"
-      # Run every hour at 30 mins past,  during the evening 9pm through 7am
+      schedule: "30 0-6,21-23 * * *"
+      # Run every hour at 30 mins past, during the evening 9pm through 6am

--- a/k8s/namespaces/em/em-hrs-ingestor/schedule-cluster-0.yaml
+++ b/k8s/namespaces/em/em-hrs-ingestor/schedule-cluster-0.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 * * * *"
-      # Run every hour, on the hour
+      schedule: "0/20 * * * *"
+      # Run every 20 mins from the hour

--- a/k8s/namespaces/em/em-hrs-ingestor/schedule-cluster-1.yaml
+++ b/k8s/namespaces/em/em-hrs-ingestor/schedule-cluster-1.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   values:
     job:
-      schedule: "30 * * * *"
-      # Run every hour, on the half hour
+      schedule: "10/20 * * * *"
+      # Run every 20 mins, from 10 minutes past the hour

--- a/k8s/perftest/cluster-00-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-00-overlay/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
   - ccd
   - am
   - rd
+  - em
   - ../../namespaces/admin/flux
   - ../../namespaces/admin/fluxcloud
   - ../../namespaces/admin/flux-helm-operator

--- a/k8s/perftest/cluster-01-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-01-overlay/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
   - ccd
   - am
   - rd
+  - em
   - ../../namespaces/admin/flux
   - ../../namespaces/admin/fluxcloud
   - ../../namespaces/admin/flux-helm-operator

--- a/k8s/prod/cluster-00-overlay/em/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/em/kustomization.yaml
@@ -6,4 +6,5 @@ bases:
 - ../../../namespaces/em/em-hrs-ingestor/em-hrs-ingestor.yaml
 patchesStrategicMerge:
 - ../../../namespaces/em/em-icp/prod.yaml
+- ../../../namespaces/em/em-hrs-ingestor/prod-common.yaml
 - ../../../namespaces/em/em-hrs-ingestor/prod-0.yaml


### PR DESCRIPTION
### Change description ###
add em kustomization to non prod envs (as per prod)
add common prod kustomization to prod 0
fix up prod scheduling to be desired values
make non prod scheduling every 10 mins throughout the day



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
