### PR TITLE
Allow FPRL to access CCD vault

### DIFF
--- a/k8s/aat/common/family-private-law/identity.yaml
+++ b/k8s/aat/common/family-private-law/identity.yaml
@@ -9,7 +9,6 @@ spec:
   clientID: "73b1dbde-e66e-48d8-886e-439d9db3c14f"
 
 ---
-
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentityBinding
 metadata:

--- a/k8s/preview/common-overlay/family-private-law/kustomization.yaml
+++ b/k8s/preview/common-overlay/family-private-law/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: family-private-law
 bases:
 - ../../../namespaces/family-private-law/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+- ../../../aat/common/ccd/identity.yaml
+- ../../../aat/common/xui/identity.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io


### PR DESCRIPTION
When pods starting in preview getting error:
```
 for pod: family-private-law/fprl-ccd-definitions-pr-2-ccd-case-mgmt-web-5b684f4cb9-grn5h
  Warning  FailedMount  31m  kubelet  MountVolume.SetUp failed for volume "vault-ccd" : rpc error: code = Unknown desc = error mounting secret time="2021-06-28T08:08:05Z" level=fatal msg="[error] : failed to get keyvaultClient: failed to get key vault token: nmi response failed with status code: 404"
```
