### PR TITLE
SSCS-9362 - Secure doc store in demo

### DIFF
--- a/k8s/demo/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/demo/common/sscs/sscs-tya-notif.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: sscs
   annotations:
     flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
+    flux.weave.works/tag.java: glob:pr-1714-*
 spec:
   releaseName: sscs-tya-notif
   rollback:
@@ -20,7 +20,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-ac3802b-20210709121005
+      image: hmctspublic.azurecr.io/sscs/tya-notif:pr-1714-f511073-20210707204630
       environment:
         JOB_SCHEDULER_DB_USERNAME: "notification@sscs-tya-notif-postgres-v11-db-demo"
         JOB_SCHEDULER_DB_NAME: "notification"
@@ -28,6 +28,7 @@ spec:
         COVID_19_NOTIFICATION_FEATURE: false
         PDF_SERVICE_HEALTH_URL: https://docmosis.demo.platform.hmcts.net/rs/status
         PDF_SERVICE_BASE_URL: https://docmosis.demo.platform.hmcts.net/rs/render
+        SECURE_DOC_STORE_FEATURE: true
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
SSCS-9362 - Secure doc store in demo

sets SECURE_DOC_STORE_FEATURE in notifications on
puts https://github.com/hmcts/sscs-track-your-appeal-notifications/pull/1714 in demo