### PR TITLE
Update definition-store-api.yaml

### DIFF
--- a/k8s/perftest/common/ccd/definition-store-api.yaml
+++ b/k8s/perftest/common/ccd/definition-store-api.yaml
@@ -28,7 +28,7 @@ spec:
       environment:
         ELASTIC_SEARCH_FAIL_ON_IMPORT: false
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"
-        DEFINITION_STORE_DB_MAX_POOL_SIZE: 30
+        DEFINITION_STORE_DB_MAX_POOL_SIZE: 25
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v11-perftest.postgres.database.azure.com
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp,aac_manage_case_assignment,em_hrs_api
         DUMMY_VAR: true

--- a/k8s/perftest/common/ccd/definition-store-api.yaml
+++ b/k8s/perftest/common/ccd/definition-store-api.yaml
@@ -21,18 +21,18 @@ spec:
       replicas: 4
       autoscaling:
         enabled: false
-        minReplicas: 4
-        maxReplicas: 6
+        minReplicas: 3
+        maxReplicas: 4
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-143c75a-20210728104758
       environment:
         ELASTIC_SEARCH_FAIL_ON_IMPORT: false
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"
-        DEFINITION_STORE_DB_MAX_POOL_SIZE: 32
+        DEFINITION_STORE_DB_MAX_POOL_SIZE: 30
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v11-perftest.postgres.database.azure.com
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp,aac_manage_case_assignment,em_hrs_api
         DUMMY_VAR: true
-        DEFINITION_STORE_TX_TIMEOUT_DEFAULT: 120
+        DEFINITION_STORE_TX_TIMEOUT_DEFAULT: 30
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-1716


### Change description ###
max connections per pod from 32 to 25
transaction timeout 30 sec
autoscaling adjustment - not in effect already

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
