### PR TITLE
align aat to prod

### DIFF
--- a/k8s/aat/common/ccd/definition-store-api.yaml
+++ b/k8s/aat/common/ccd/definition-store-api.yaml
@@ -18,7 +18,7 @@ spec:
     path: stable/ccd-definition-store-api
   values:
     java:
-      replicas: 2
+      replicas: 4
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-143c75a-20210728104758
       memoryRequests: "1024Mi"
@@ -32,7 +32,7 @@ spec:
         DEFINITION_STORE_DB_NAME: ccd_definition_store
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v11-aat.postgres.database.azure.com
         DUMMY_RESTART_VAR: 2
-        DEFINITION_STORE_TX_TIMEOUT_DEFAULT: 120
+        DEFINITION_STORE_TX_TIMEOUT_DEFAULT: 40
     global:
       environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-1716


### Change description ###
On aat, 2 x scale out def store api, 25% scaling down connection pool (was already so), reduce TX timeout to 40 secs


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
