### PR TITLE
Revert "CHG5005207: Latest idam-web-public image to Prod"

### DIFF
--- a/k8s/prod/common/idam/idam-web-public.yaml
+++ b/k8s/prod/common/idam/idam-web-public.yaml
@@ -18,7 +18,7 @@ spec:
     version: 0.2.10
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-a97fae2-20210723140900
+      image: hmctspublic.azurecr.io/idam/web-public:prod-93f29b5-20210722155406
       ingressHost: hmcts-access.service.gov.uk
       aadIdentityName: idam
       useInterpodAntiAffinity: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#10757

Backing out the CHG as one of the 2 Production AKS clusters (prod-aks-01) is not applying any flux config changes at the moment.