### PR TITLE
Remove batch jobs to fix high number of pods on AAT-01 cluster

### DIFF
--- a/k8s/aat/cluster-00-overlay/am/kustomization.yaml
+++ b/k8s/aat/cluster-00-overlay/am/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: am
 bases:
-- ../../../namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
+# - ../../../namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
 - ../../../namespaces/am/am-judicial-booking-batch-service/am-judicial-booking-batch-service.yaml
-- ../../../namespaces/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
+# - ../../../namespaces/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
 patchesStrategicMerge:
-- ../../../namespaces/am/am-role-assignment-batch-service/aat-00.yaml
+# - ../../../namespaces/am/am-role-assignment-batch-service/aat-00.yaml
 - ../../../namespaces/am/am-judicial-booking-batch-service/aat-00.yaml
-- ../../../namespaces/am/am-role-assignment-refresh-batch/aat-00.yaml
+# - ../../../namespaces/am/am-role-assignment-refresh-batch/aat-00.yaml

--- a/k8s/aat/cluster-01-overlay/am/kustomization.yaml
+++ b/k8s/aat/cluster-01-overlay/am/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: am
 bases:
-- ../../../namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
+# - ../../../namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
 - ../../../namespaces/am/am-judicial-booking-batch-service/am-judicial-booking-batch-service.yaml
-- ../../../namespaces/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
+# - ../../../namespaces/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
 patchesStrategicMerge:
-- ../../../namespaces/am/am-role-assignment-batch-service/aat-01.yaml
+# - ../../../namespaces/am/am-role-assignment-batch-service/aat-01.yaml
 - ../../../namespaces/am/am-judicial-booking-batch-service/aat-01.yaml
-- ../../../namespaces/am/am-role-assignment-refresh-batch/aat-01.yaml
+# - ../../../namespaces/am/am-role-assignment-refresh-batch/aat-01.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
NA


### Change description ###
There are high number of pods in pending for AM batch jobs. Removing them temporarily to add them back.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
