### PR TITLE
fix chart naming as helm operator v2 doesnt support dot

### DIFF
--- a/apps/catalog/svc-cat/svc-cat.yaml
+++ b/apps/catalog/svc-cat/svc-cat.yaml
@@ -25,7 +25,7 @@ spec:
           memory: 300Mi
   chart:
     spec:
-      chart: catalog-v0.2
+      chart: catalog
       version: 0.2.2
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
