### PR TITLE
Moving kustomize common config as a patch

### DIFF
--- a/apps/aac/base/kustomization.yaml
+++ b/apps/aac/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: aac
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/aac/base/kustomize.yaml
+++ b/apps/aac/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: aac
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/aac/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "aac"
       TEAM_NOTIFICATION_CHANNEL: "ccd-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/admin/base/kustomization.yaml
+++ b/apps/admin/base/kustomization.yaml
@@ -7,8 +7,3 @@ resources:
   - ../csi-secret-store-provider-v0.0.8
   - ../env-injector/env-injector.yaml
   - ../aad-pod-id
-
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/admin/base/kustomize.yaml
+++ b/apps/admin/base/kustomize.yaml
@@ -4,42 +4,9 @@ metadata:
   name: admin
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/admin/${ENVIRONMENT}/${CLUSTER}
-  patches:
-    - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
-        kind: HelmRelease
-        metadata:
-          name: test-helmrelease
-        spec:
-          interval: 5m
-          install:
-            remediation:
-              retries: 3
-          upgrade:
-            remediation:
-              retries: 3
-              remediateLastFailure: true
-          values:
-            global:
-              environment: ${KEYVAULT_ENVIRONMENT:-prod}
-              tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-              enableKeyVaults: true
-      target:
-        kind: HelmRelease
   postBuild:
     substitute:
       NAMESPACE: "admin"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      ENVIRONMENT: "${ENVIRONMENT}"
-      CLUSTER: "\"${CLUSTER}\""
-      CLUSTER_PATH: "${ENVIRONMENT}/${CLUSTER}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/adoption/base/kustomization.yaml
+++ b/apps/adoption/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: adoption
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/adoption/base/kustomize.yaml
+++ b/apps/adoption/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: adoption
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/adoption/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "adoption"
       TEAM_NOTIFICATION_CHANNEL: "fpla_adoption_tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/am/base/kustomization.yaml
+++ b/apps/am/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: am
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/am/base/kustomize.yaml
+++ b/apps/am/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: am
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/am/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "am"
       TEAM_NOTIFICATION_CHANNEL: "am-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/artifactory/base/kustomization.yaml
+++ b/apps/artifactory/base/kustomization.yaml
@@ -4,8 +4,3 @@ resources:
   - ../../base
   - ../artifactory/artifactory.yaml
   - ../artifactory/ingress.yaml
-
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/artifactory/base/kustomize.yaml
+++ b/apps/artifactory/base/kustomize.yaml
@@ -4,17 +4,9 @@ metadata:
   name: artifactory
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/artifactory/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "artifactory"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/backstage/base/kustomization.yaml
+++ b/apps/backstage/base/kustomization.yaml
@@ -4,7 +4,3 @@ resources:
   - ../../base
   - ../backstage/backstage.yaml
   - ../backstage/backstage-helmrepo.yaml
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/backstage/base/kustomize.yaml
+++ b/apps/backstage/base/kustomize.yaml
@@ -4,17 +4,9 @@ metadata:
   name: backstage
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/backstage/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "backstage"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/bar/base/kustomization.yaml
+++ b/apps/bar/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: bar
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/bar/base/kustomize.yaml
+++ b/apps/bar/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: bar
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/bar/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "bar"
       TEAM_NOTIFICATION_CHANNEL: "bar-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/base/kustomize.yaml
+++ b/apps/base/kustomize.yaml
@@ -1,0 +1,42 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: sample-kustomize
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-config
+    namespace: flux-system
+  validation: none
+  patches:
+    - patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        kind: HelmRelease
+        metadata:
+          name: test-helmrelease
+        spec:
+          interval: 5m
+          install:
+            remediation:
+              retries: 3
+          upgrade:
+            remediation:
+              retries: 3
+              remediateLastFailure: true
+          values:
+            global:
+              environment: ${KEYVAULT_ENVIRONMENT:-prod}
+              tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+              enableKeyVaults: true
+      target:
+        kind: HelmRelease
+  postBuild:
+    substitute:
+      ENVIRONMENT: "${ENVIRONMENT}"
+      CLUSTER: "\"${CLUSTER}\""
+      CLUSTER_PATH: "${ENVIRONMENT}/${CLUSTER}"
+      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
+      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/bsp/base/kustomization.yaml
+++ b/apps/bsp/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: bsp
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/bsp/base/kustomize.yaml
+++ b/apps/bsp/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: bsp
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/bsp/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "bsp"
       TEAM_NOTIFICATION_CHANNEL: "bsp-build-notices"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/camunda/base/kustomization.yaml
+++ b/apps/camunda/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: camunda
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/camunda/base/kustomize.yaml
+++ b/apps/camunda/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: camunda
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/camunda/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "camunda"
       TEAM_NOTIFICATION_CHANNEL: "platops-build-notices"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/catalog/base/kustomization.yaml
+++ b/apps/catalog/base/kustomization.yaml
@@ -4,7 +4,3 @@ resources:
   - ../../base
   - ../svc-cat/svc-cat.yaml
 namespace: catalog
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/catalog/base/kustomize.yaml
+++ b/apps/catalog/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: catalog
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/catalog/base
   postBuild:
     substitute:
       NAMESPACE: "catalog"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/ccd/base/kustomization.yaml
+++ b/apps/ccd/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: ccd
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/ccd/base/kustomize.yaml
+++ b/apps/ccd/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: ccd
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/ccd/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "ccd"
       TEAM_NOTIFICATION_CHANNEL: "ccd-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/chart-tests/base/kustomization.yaml
+++ b/apps/chart-tests/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: chart-tests
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/chart-tests/base/kustomize.yaml
+++ b/apps/chart-tests/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: chart-tests
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/chart-tests/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "chart-tests"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/civil/base/kustomization.yaml
+++ b/apps/civil/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: civil
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/civil/base/kustomize.yaml
+++ b/apps/civil/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: civil
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/civil/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "civil"
       TEAM_NOTIFICATION_CHANNEL: "civil_contact"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/cnp/base/kustomization.yaml
+++ b/apps/cnp/base/kustomization.yaml
@@ -5,7 +5,3 @@ resources:
   - ../plum-frontend/plum-frontend.yaml
   - ../plum-recipe-backend/plum-recipe-backend.yaml
 namespace: cnp
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/cnp/base/kustomize.yaml
+++ b/apps/cnp/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: cnp
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/cnp/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "cnp"
       TEAM_NOTIFICATION_CHANNEL: "platops-build-notices"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/coh/base/kustomization.yaml
+++ b/apps/coh/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: coh
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/coh/base/kustomize.yaml
+++ b/apps/coh/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: coh
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/coh/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "coh"
       TEAM_NOTIFICATION_CHANNEL: "coh-pipeline"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/cpo/base/kustomization.yaml
+++ b/apps/cpo/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: cpo
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/cpo/base/kustomize.yaml
+++ b/apps/cpo/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: cpo
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/cpo/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "cpo"
       TEAM_NOTIFICATION_CHANNEL: "ccd-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/ctsc/base/kustomization.yaml
+++ b/apps/ctsc/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: ctsc
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/ctsc/base/kustomize.yaml
+++ b/apps/ctsc/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: ctsc
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/ctsc/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "ctsc"
       TEAM_NOTIFICATION_CHANNEL: "ctsc-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/dg/base/kustomization.yaml
+++ b/apps/dg/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: dg
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/dg/base/kustomize.yaml
+++ b/apps/dg/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: dg
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/dg/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "dg"
       TEAM_NOTIFICATION_CHANNEL: "dts-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/divorce/base/kustomization.yaml
+++ b/apps/divorce/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: divorce
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/divorce/base/kustomize.yaml
+++ b/apps/divorce/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: divorce
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/divorce/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "divorce"
       TEAM_NOTIFICATION_CHANNEL: "div-dev"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/dm-store/base/kustomization.yaml
+++ b/apps/dm-store/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: dm-store
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/dm-store/base/kustomize.yaml
+++ b/apps/dm-store/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: dm-store
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/dm-store/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "dm-store"
       TEAM_NOTIFICATION_CHANNEL: "em-dev-chat"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/docmosis/base/kustomization.yaml
+++ b/apps/docmosis/base/kustomization.yaml
@@ -4,7 +4,3 @@ resources:
   - ../../base
   - ../docmosis/docmosis.yaml
 namespace: docmosis
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/docmosis/base/kustomize.yaml
+++ b/apps/docmosis/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: docmosis
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/docmosis/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "docmosis"
       TEAM_NOTIFICATION_CHANNEL: "docmosis-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/em/base/kustomization.yaml
+++ b/apps/em/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: em
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/em/base/kustomize.yaml
+++ b/apps/em/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: em
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/em/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "em"
       TEAM_NOTIFICATION_CHANNEL: "em-dev-chat"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/etcd/base/kustomization.yaml
+++ b/apps/etcd/base/kustomization.yaml
@@ -5,7 +5,3 @@ resources:
   - ../etcd/etcd.yaml
   - ../etcd/etcd-helmrepo.yaml
 namespace: etcd
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/etcd/base/kustomize.yaml
+++ b/apps/etcd/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: etcd
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/etcd/base
   postBuild:
     substitute:
       NAMESPACE: "etcd"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/ethos/base/kustomization.yaml
+++ b/apps/ethos/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: ethos
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/ethos/base/kustomize.yaml
+++ b/apps/ethos/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: ethos
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/ethos/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "ethos"
       TEAM_NOTIFICATION_CHANNEL: "ethos-repl-service"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/fact/base/kustomization.yaml
+++ b/apps/fact/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: fact
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/fact/base/kustomize.yaml
+++ b/apps/fact/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: fact
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/fact/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "fact"
       TEAM_NOTIFICATION_CHANNEL: "fact-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/family-private-law/base/kustomization.yaml
+++ b/apps/family-private-law/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: family-private-law
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/family-private-law/base/kustomize.yaml
+++ b/apps/family-private-law/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: family-private-law
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/family-private-law/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "family-private-law"
       TEAM_NOTIFICATION_CHANNEL: "fprl-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/family-public-law/base/kustomization.yaml
+++ b/apps/family-public-law/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: family-public-law
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/family-public-law/base/kustomize.yaml
+++ b/apps/family-public-law/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: family-public-law
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/family-public-law/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "family-public-law"
       TEAM_NOTIFICATION_CHANNEL: "fpla-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/fees-pay/base/kustomization.yaml
+++ b/apps/fees-pay/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: fees-pay
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/fees-pay/base/kustomize.yaml
+++ b/apps/fees-pay/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: fees-pay
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/fees-pay/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "fees-pay"
       TEAM_NOTIFICATION_CHANNEL: "cc-payments-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/financial-remedy/base/kustomization.yaml
+++ b/apps/financial-remedy/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: financial-remedy
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/financial-remedy/base/kustomize.yaml
+++ b/apps/financial-remedy/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: financial-remedy
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/financial-remedy/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "financial-remedy"
       TEAM_NOTIFICATION_CHANNEL: "finrem-dev"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/hmc/base/kustomization.yaml
+++ b/apps/hmc/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: hmc
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/hmc/base/kustomize.yaml
+++ b/apps/hmc/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: hmc
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/hmc/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "hmc"
       TEAM_NOTIFICATION_CHANNEL: "ccd-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/ia/base/kustomization.yaml
+++ b/apps/ia/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: ia
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/ia/base/kustomize.yaml
+++ b/apps/ia/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: ia
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/ia/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "ia"
       TEAM_NOTIFICATION_CHANNEL: "ia-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/idam-sprod/base/kustomization.yaml
+++ b/apps/idam-sprod/base/kustomization.yaml
@@ -6,7 +6,3 @@ resources:
   - ../idam-web-admin/idam-web-admin.yaml
   - ../idam-web-public/idam-web-public.yaml
 namespace: idam-sprod
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/idam-sprod/base/kustomize.yaml
+++ b/apps/idam-sprod/base/kustomize.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 metadata:
   name: idam-sprod
   namespace: flux-system
+  annotations:
+    hmcts.github.com/kustomize-defaults: disabled
 spec:
   interval: 1m0s
   prune: true

--- a/apps/idam/base/kustomization.yaml
+++ b/apps/idam/base/kustomization.yaml
@@ -6,7 +6,3 @@ resources:
   - ../idam-web-admin/idam-web-admin.yaml
   - ../idam-web-public/idam-web-public.yaml
 namespace: idam
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/idam/base/kustomize.yaml
+++ b/apps/idam/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: idam
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/idam/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "idam"
       TEAM_NOTIFICATION_CHANNEL: "idam_tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/jenkins/base/kustomization.yaml
+++ b/apps/jenkins/base/kustomization.yaml
@@ -7,8 +7,3 @@ resources:
   - ../jenkins/logging.yaml
   - ../jenkins/disk.yaml
   - ../jenkins/identity.yaml
-
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/jenkins/base/kustomize.yaml
+++ b/apps/jenkins/base/kustomize.yaml
@@ -4,17 +4,9 @@ metadata:
   name: jenkins
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/jenkins/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "jenkins"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/kube-system/base/kustomize.yaml
+++ b/apps/kube-system/base/kustomize.yaml
@@ -4,11 +4,4 @@ metadata:
   name: kube-system
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/kube-system/base

--- a/apps/kured/base/kustomization.yaml
+++ b/apps/kured/base/kustomization.yaml
@@ -4,8 +4,3 @@ resources:
   - ../../base
   - ../kured/kured-helmrepo.yaml
   - ../kured/kured.yaml
-
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/kured/base/kustomize.yaml
+++ b/apps/kured/base/kustomize.yaml
@@ -4,17 +4,9 @@ metadata:
   name: kured
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/kured/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "kured"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/money-claims/base/kustomization.yaml
+++ b/apps/money-claims/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: money-claims
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/money-claims/base/kustomize.yaml
+++ b/apps/money-claims/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: money-claims
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/money-claims/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "money-claims"
       TEAM_NOTIFICATION_CHANNEL: "cmc-tech-notification"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/monitoring/base/kustomization.yaml
+++ b/apps/monitoring/base/kustomization.yaml
@@ -4,8 +4,3 @@ resources:
   - ../../base
   - ../node-problem-detector
   - ../kube-prometheus-stack
-
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/monitoring/base/kustomize.yaml
+++ b/apps/monitoring/base/kustomize.yaml
@@ -4,20 +4,9 @@ metadata:
   name: monitoring
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/monitoring/${ENVIRONMENT}/${CLUSTER}
   postBuild:
     substitute:
       NAMESPACE: "monitoring"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      ENVIRONMENT: "${ENVIRONMENT}"
-      CLUSTER: "\"${CLUSTER}\""
-      CLUSTER_PATH: "${ENVIRONMENT}/${CLUSTER}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/nfdiv/base/kustomization.yaml
+++ b/apps/nfdiv/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: nfdiv
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/nfdiv/base/kustomize.yaml
+++ b/apps/nfdiv/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: nfdiv
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/nfdiv/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "nfdiv"
       TEAM_NOTIFICATION_CHANNEL: "nfdiv-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/osba/base/kustomization.yaml
+++ b/apps/osba/base/kustomization.yaml
@@ -4,7 +4,3 @@ resources:
   - ../../base
   - ../osba/osba.yaml
 namespace: osba
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/osba/base/kustomize.yaml
+++ b/apps/osba/base/kustomize.yaml
@@ -4,13 +4,6 @@ metadata:
   name: osba
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/osba/${ENVIRONMENT}
   postBuild:
     substitute:

--- a/apps/pact-broker/base/kustomization.yaml
+++ b/apps/pact-broker/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - ../pact-broker/pact-broker.yaml
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/pact-broker/base/kustomize.yaml
+++ b/apps/pact-broker/base/kustomize.yaml
@@ -4,17 +4,9 @@ metadata:
   name: pact-broker
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/pact-broker/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "pact-broker"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/pcq/base/kustomization.yaml
+++ b/apps/pcq/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: pcq
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/pcq/base/kustomize.yaml
+++ b/apps/pcq/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: pcq
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/pcq/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "pcq"
       TEAM_NOTIFICATION_CHANNEL: "pcq-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/probate/base/kustomization.yaml
+++ b/apps/probate/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: probate
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/probate/base/kustomize.yaml
+++ b/apps/probate/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: probate
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/probate/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "probate"
       TEAM_NOTIFICATION_CHANNEL: "probate-jenkins"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/rd/base/kustomization.yaml
+++ b/apps/rd/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: rd
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/rd/base/kustomize.yaml
+++ b/apps/rd/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: rd
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/rd/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "rd"
       TEAM_NOTIFICATION_CHANNEL: "rd-master-builds"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/reform-scan/base/kustomization.yaml
+++ b/apps/reform-scan/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: reform-scan
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/reform-scan/base/kustomize.yaml
+++ b/apps/reform-scan/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: reform-scan
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/reform-scan/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "reform-scan"
       TEAM_NOTIFICATION_CHANNEL: "bsp-build-notices"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/response/base/kustomization.yaml
+++ b/apps/response/base/kustomization.yaml
@@ -4,7 +4,3 @@ resources:
   - ../../base
   - ../response/response-api.yaml
   - ../response/response-frontend.yaml
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/response/base/kustomize.yaml
+++ b/apps/response/base/kustomize.yaml
@@ -4,16 +4,8 @@ metadata:
   name: response
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/response/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "response"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/rpe/base/kustomization.yaml
+++ b/apps/rpe/base/kustomization.yaml
@@ -5,7 +5,3 @@ resources:
   - ../draft-store-service/draft-store-service.yaml
   - ../rpe-service-auth-provider/rpe-service-auth-provider.yaml
 namespace: rpe
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/rpe/base/kustomize.yaml
+++ b/apps/rpe/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: rpe
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/rpe/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "rpe"
       TEAM_NOTIFICATION_CHANNEL: "platops-build-notices"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/rpe/sbox/base/kustomization.yaml
+++ b/apps/rpe/sbox/base/kustomization.yaml
@@ -8,7 +8,3 @@ resources:
 namespace: rpe
 patchesStrategicMerge:
   - ../../draft-store-service/sbox.yaml
-patches:  #Adding patch here as we don't use namespace base in here
-  - path: ../../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/slack-help-bot/base/kustomization.yaml
+++ b/apps/slack-help-bot/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - ../slack-help-bot/slack-help-bot.yaml
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/slack-help-bot/base/kustomize.yaml
+++ b/apps/slack-help-bot/base/kustomize.yaml
@@ -4,16 +4,8 @@ metadata:
   name: slack-help-bot
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/slack-help-bot/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "slack-help-bot"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/sscs/base/kustomization.yaml
+++ b/apps/sscs/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: sscs
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/sscs/base/kustomize.yaml
+++ b/apps/sscs/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: sscs
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/sscs/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "sscs"
       TEAM_NOTIFICATION_CHANNEL: "sscs-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/vsts/base/kustomization.yaml
+++ b/apps/vsts/base/kustomization.yaml
@@ -3,8 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - ../vsts/agent.yaml
-
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/vsts/base/kustomize.yaml
+++ b/apps/vsts/base/kustomize.yaml
@@ -4,18 +4,9 @@ metadata:
   name: vsts
   namespace: flux-system
 spec:
-  interval: 5m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/vsts/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "vsts"
       TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
       ENV_INJECTOR: "disabled"
-      CLUSTER_PATH: "${ENVIRONMENT}/${CLUSTER}"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"

--- a/apps/wa/base/kustomization.yaml
+++ b/apps/wa/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: wa
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/wa/base/kustomize.yaml
+++ b/apps/wa/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: wa
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/wa/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "wa"
       TEAM_NOTIFICATION_CHANNEL: "wa-tech"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/apps/xui/base/kustomization.yaml
+++ b/apps/xui/base/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: xui
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease

--- a/apps/xui/base/kustomize.yaml
+++ b/apps/xui/base/kustomize.yaml
@@ -4,17 +4,8 @@ metadata:
   name: xui
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/xui/${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "xui"
       TEAM_NOTIFICATION_CHANNEL: "xui-pipeline"
-      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "${KEYVAULT_ENVIRONMENT}"

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -9,3 +9,9 @@ resources:
 - ../../../apps/osba/base/kustomize.yaml
 - ../../../apps/catalog/base/kustomize.yaml
 - ../../../apps/etcd/base/kustomize.yaml
+
+patches:
+  - path: ../../../apps/base/kustomize.yaml
+    target:
+      kind: Kustomization
+      annotationSelector: hmcts.github.com/kustomize-defaults != disabled

--- a/clusters/ptl-intsvc/base/kustomization.yaml
+++ b/clusters/ptl-intsvc/base/kustomization.yaml
@@ -13,3 +13,9 @@ resources:
 - ../../../apps/jenkins/base/kustomize.yaml
 - ../../../apps/slack-help-bot/base/kustomize.yaml
 - ../../../apps/response/base/kustomize.yaml
+
+patches:
+  - path: ../../../apps/base/kustomize.yaml
+    target:
+      kind: Kustomization
+      annotationSelector: hmcts.github.com/kustomize-defaults != disabled

--- a/clusters/sbox-intsvc/base/kustomization.yaml
+++ b/clusters/sbox-intsvc/base/kustomization.yaml
@@ -11,3 +11,10 @@ resources:
 - ../../../apps/backstage/base/kustomize.yaml
 - ../../../apps/pact-broker/base/kustomize.yaml
 - ../../../apps/jenkins/base/kustomize.yaml
+
+
+patches:
+  - path: ../../../apps/base/kustomize.yaml
+    target:
+      kind: Kustomization
+      annotationSelector: hmcts.github.com/kustomize-defaults != disabled

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -11,3 +11,9 @@ resources:
 - ../../../apps/docmosis/base/kustomize.yaml
 - ../../../apps/idam/base/kustomize.yaml
 - ../../../apps/idam-sprod/base/kustomize.yaml
+
+patches:
+  - path: ../../../apps/base/kustomize.yaml
+    target:
+      kind: Kustomization
+      annotationSelector: hmcts.github.com/kustomize-defaults != disabled

--- a/migration/create-all-namespaces.sh
+++ b/migration/create-all-namespaces.sh
@@ -30,10 +30,6 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: $namespace
-patches:
-  - path: ../../base/helmrelease-default.yaml
-    target:
-      kind: HelmRelease
 EOF
 ) > "apps/$namespace/base/kustomization.yaml"
 
@@ -45,20 +41,11 @@ metadata:
   name: $namespace
   namespace: flux-system
 spec:
-  interval: 1m0s
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-config
-    namespace: flux-system
-  validation: none
   path: ./apps/$namespace/\${ENVIRONMENT}
   postBuild:
     substitute:
       NAMESPACE: "$namespace"
       TEAM_NOTIFICATION_CHANNEL: "${SLACK_CHANNEL}"
-      CLUSTER_FULL_NAME: "\${ENVIRONMENT}-\${CLUSTER}"
-      KEYVAULT_ENVIRONMENT: "\${KEYVAULT_ENVIRONMENT}"
 EOF
 ) > "apps/$namespace/base/kustomize.yaml"
 


### PR DESCRIPTION
Removes a lot of duplication in kustomize in every ns and adding HR patch to every namespace and sometimes even at env level.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
