### PR TITLE
add CAMUNDA_MAX_RESULTS env var to the prod patch to target 1000 task…

### DIFF
--- a/k8s/namespaces/wa/wa-task-batch-configuration/prod-00.yaml
+++ b/k8s/namespaces/wa/wa-task-batch-configuration/prod-00.yaml
@@ -8,6 +8,7 @@ spec:
       schedule: "0 */2 * * *"
       environment:
         JOB_NAME: CONFIGURATION
+        CAMUNDA_MAX_RESULTS: "1000"
     global:
       environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
set max result to 1000 in Prod because in AAT the default is 10 tasks to reduce idam request calls. 