### PR TITLE
Test imageautomation on sbox Jenkins

### DIFF
--- a/apps/flux-system/automation-sbox/hmctsprivate-image-repo.yaml
+++ b/apps/flux-system/automation-sbox/hmctsprivate-image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImageRepository
+metadata:
+  name: default
+spec:
+  interval: 5m0s
+  secretRef:
+    name: hmctsprivate-creds

--- a/apps/flux-system/automation-sbox/hmctspublic-image-repo.yaml
+++ b/apps/flux-system/automation-sbox/hmctspublic-image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImageRepository
+metadata:
+  name: default
+spec:
+  interval: 5m0s
+  secretRef:
+    name: hmctspublic-creds

--- a/apps/flux-system/automation-sbox/kustomization.yaml
+++ b/apps/flux-system/automation-sbox/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+resources:
+  - registry-credential-sync/hmctspublic/kustomize.yaml
+  - registry-credential-sync/hmctsprivate/kustomize.yaml
+  # - ../../backstage/automation
+  # - ../../cnp/automation
+  # - ../../slack-help-bot/automation
+  # - ../../rpe/automation
+  # - ../../docmosis/automation
+  # - ../../sscs/automation
+  # - ../../aac/automation
+
+patches:
+  - path: hmctspublic-image-repo.yaml
+    target:
+      kind: ImageRepository
+      annotationSelector: hmcts.github.com/image-registry != hmctsprivate
+  - path: hmctsprivate-image-repo.yaml
+    target:
+      kind: ImageRepository
+      annotationSelector: hmcts.github.com/image-registry == hmctsprivate
+  - path: prod-image-policy.yaml
+    target:
+      kind: ImagePolicy
+      annotationSelector: hmcts.github.com/prod-automated != disabled

--- a/apps/flux-system/automation-sbox/prod-image-policy.yaml
+++ b/apps/flux-system/automation-sbox/prod-image-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImagePolicy
+metadata:
+  name: default
+spec:
+  filterTags:
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/flux-system/automation-sbox/registry-credential-sync/base/config-patches.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/base/config-patches.yaml
@@ -1,0 +1,9 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: credentials-sync  # name must match the stub-resource in az-identity.yaml
+  namespace: flux-system
+spec:
+  clientID: ce9eec6d-fda0-442a-9ec7-67799f31723e
+  resourceID: /subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftsbox-intsvc-mi
+  type: 0  # user-managed identity

--- a/apps/flux-system/automation-sbox/registry-credential-sync/base/kustomization.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/fluxcd/flux2/manifests/integrations/registry-credentials-sync/azure?ref=main
+patchesStrategicMerge:
+  - config-patches.yaml

--- a/apps/flux-system/automation-sbox/registry-credential-sync/hmctsprivate/config-patches.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/hmctsprivate/config-patches.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: credentials-sync
+data:
+  ACR_NAME: hmctsprivate
+  KUBE_SECRET: hmctsprivate-creds   # does not yet exist -- will be created in the same Namespace
+  SYNC_PERIOD: "3600"    # ACR tokens expire every 3 hours; refresh faster than that

--- a/apps/flux-system/automation-sbox/registry-credential-sync/hmctsprivate/kustomization.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/hmctsprivate/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+namePrefix: hmctsprivate-
+resources:
+  - ../base
+patchesStrategicMerge:
+  - config-patches.yaml

--- a/apps/flux-system/automation-sbox/registry-credential-sync/hmctsprivate/kustomize.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/hmctsprivate/kustomize.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: hmctsprivate-credentials-sync
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-config
+    namespace: flux-system
+  validation: none
+  path: ./apps/flux-system/automation/registry-credential-sync/hmctsprivate

--- a/apps/flux-system/automation-sbox/registry-credential-sync/hmctspublic/config-patches.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/hmctspublic/config-patches.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: credentials-sync
+data:
+  ACR_NAME: hmctspublic
+  KUBE_SECRET: hmctspublic-creds   # does not yet exist -- will be created in the same Namespace
+  SYNC_PERIOD: "3600"    # ACR tokens expire every 3 hours; refresh faster than that

--- a/apps/flux-system/automation-sbox/registry-credential-sync/hmctspublic/kustomization.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/hmctspublic/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system
+namePrefix: hmctspublic-
+resources:
+  - ../base
+patchesStrategicMerge:
+  - config-patches.yaml

--- a/apps/flux-system/automation-sbox/registry-credential-sync/hmctspublic/kustomize.yaml
+++ b/apps/flux-system/automation-sbox/registry-credential-sync/hmctspublic/kustomize.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: hmctspublic-credentials-sync
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-config
+    namespace: flux-system
+  validation: none
+  path: ./apps/flux-system/automation/registry-credential-sync/hmctspublic

--- a/apps/flux-system/sbox-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/sbox-intsvc/base/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.yaml
+  - ../../base/image-automation-components.yaml
+  # - ../../base/image-update-automation.yaml
+  # - ../../automation-sbox


### PR DESCRIPTION
### Change description ###
Test imageautomation on sbox Jenkins
- Some kustomize is commented out, required as kustomize will fail due to missing initial components - will PR these at a later stage once base/image-automation-components.yaml is deployed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
