### PR TITLE
DTSPO-4182 Adoption Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/adoption/adoption-backend.yaml
+++ b/k8s/aat/common/adoption/adoption-backend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: adoption-backend
   namespace: adoption
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: adoption-backend
   rollback:

--- a/k8s/aat/common/adoption/adoption-frontend.yaml
+++ b/k8s/aat/common/adoption/adoption-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: adoption-frontend
   namespace: adoption
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: adoption-frontend
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Removed image annotation from adoption AAT after image policies and repositories changes have applied in the mgmt cluster.

![image](https://user-images.githubusercontent.com/22701260/130472466-23d790b6-57cb-43f0-9b83-3f271108b78e.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
