### PR TITLE
DTSPO-4182 AM Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
+++ b/k8s/namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
@@ -2,9 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service
-  annotations:
-    hmcts.github.com/global-defaults: enabled
-    hmcts.github.com/prod-automated: enabled
 spec:
   releaseName: am-role-assignment-batch-service
   chart:

--- a/k8s/namespaces/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
+++ b/k8s/namespaces/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
@@ -2,9 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch
-  annotations:
-    hmcts.github.com/global-defaults: enabled
-    hmcts.github.com/prod-automated: enabled
 spec:
   releaseName: am-role-assignment-refresh-batch
   chart:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Removed image annotation from am AAT after image policies and repositories changes have applied in the mgmt cluster.

![image](https://user-images.githubusercontent.com/22701260/130629351-f1775187-7e2e-41e5-a929-6dbaf0da3edc.png)

![image](https://user-images.githubusercontent.com/22701260/130629534-8546ba9d-bfd0-46f0-bb5a-0d18a0094de8.png)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
