### PR TITLE
DTSPO-4182 Bar and BSP Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/bar/bar-app.yaml
+++ b/k8s/aat/common/bar/bar-app.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: bar-api
   namespace: bar
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: bar-api
   rollback:

--- a/k8s/aat/common/bar/bar-web.yaml
+++ b/k8s/aat/common/bar/bar-web.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: bar-web
   namespace: bar
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.nodejs: glob:prod-*
 spec:
   releaseName: bar-web
   rollback:

--- a/k8s/aat/common/bsp/bulk-scan-sample-app.yaml
+++ b/k8s/aat/common/bsp/bulk-scan-sample-app.yaml
@@ -4,16 +4,6 @@ kind: HelmRelease
 metadata:
   name: bulk-scan-sample-app
   namespace: bsp
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/smoke: java.smoketests.image
-    filter.fluxcd.io/smoke: glob:prod-*
-    repository.fluxcd.io/functional: java.functionaltests.image
-    filter.fluxcd.io/functional: glob:prod-*
 spec:
   releaseName: bulk-scan-sample-app
   rollback:

--- a/k8s/namespaces/bsp/bulk-scan-orchestrator/aat.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-orchestrator/aat.yaml
@@ -2,11 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator
-  annotations:
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/bsp/bulk-scan-payment-processor/aat.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-payment-processor/aat.yaml
@@ -3,14 +3,6 @@ kind: HelmRelease
 metadata:
   name: bulk-scan-payment-processor
   namespace: bsp
-  annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/bsp/bulk-scan-processor/aat.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-processor/aat.yaml
@@ -2,14 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor
-  annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###

Follow up to Flux V2 migration PR - https://github.com/hmcts/cnp-flux-config/pull/11242

Removed flux v1 image annotation from am AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.

![image](https://user-images.githubusercontent.com/22701260/130927287-b5ff5337-e28c-419f-ade7-aa6b324aa0e4.png)

![image](https://user-images.githubusercontent.com/22701260/130927389-21a68b05-a421-42e2-b7be-014750d41b56.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
