### PR TITLE
DTSPO-4182 CTSC AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/ctsc/work-allocation.yaml
+++ b/k8s/aat/common/ctsc/work-allocation.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ctsc-work-allocation
   namespace: ctsc
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: ctsc-work-allocation
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - https://github.com/hmcts/cnp-flux-config/pull/11320

Removed flux v1 image annotation from CTSC AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
