### PR TITLE
DTSPO-4182 AAT Divorce Flux v2 migration - Image Automation

### DIFF
--- a/apps/divorce/automation/kustomization.yaml
+++ b/apps/divorce/automation/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../div-fps/image-repo.yaml
+  - ../div-fps/image-policy.yaml
+  - ../div-dgs/image-repo.yaml
+  - ../div-dgs/image-policy.yaml
+  - ../div-dn/image-repo.yaml
+  - ../div-dn/image-policy.yaml
+  - ../div-da/image-repo.yaml
+  - ../div-da/image-policy.yaml
+  - ../div-rfe/image-repo.yaml
+  - ../div-rfe/image-policy.yaml
+  - ../div-cms/image-repo.yaml
+  - ../div-cms/image-policy.yaml
+  - ../div-cfs/image-repo.yaml
+  - ../div-cfs/image-policy.yaml
+  - ../div-cos/image-repo.yaml
+  - ../div-cos/image-policy.yaml
+  - ../div-emca/image-repo.yaml
+  - ../div-emca/image-policy.yaml
+  - ../div-pfe/image-repo.yaml
+  - ../div-pfe/image-policy.yaml

--- a/apps/flux-system/automation/kustomization.yaml
+++ b/apps/flux-system/automation/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../cpo/automation
   - ../../ctsc/automation
   - ../../dg/automation
+  - ../../divorce/automation
   - ../../idam/automation
 
 patches:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Added Flux v2 image automation for Divorce AAT. 
Note Flux v2 image policies and repo already created in a [previous PR](https://github.com/hmcts/cnp-flux-config/pull/10887/files)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
