### PR TITLE
DTSPO-4182 Divorce AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/divorce/div-cfs.yaml
+++ b/k8s/aat/common/divorce/div-cfs.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-cfs
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: div-cfs
   rollback:

--- a/k8s/aat/common/divorce/div-cms.yaml
+++ b/k8s/aat/common/divorce/div-cms.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-cms
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: div-cms
   rollback:

--- a/k8s/aat/common/divorce/div-cos.yaml
+++ b/k8s/aat/common/divorce/div-cos.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-cos
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: div-cos
   rollback:

--- a/k8s/aat/common/divorce/div-da.yaml
+++ b/k8s/aat/common/divorce/div-da.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-da
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: div-da
   rollback:

--- a/k8s/aat/common/divorce/div-dgs.yaml
+++ b/k8s/aat/common/divorce/div-dgs.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-dgs
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: div-dgs
   rollback:

--- a/k8s/aat/common/divorce/div-dn.yaml
+++ b/k8s/aat/common/divorce/div-dn.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-dn
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: div-dn
   rollback:

--- a/k8s/aat/common/divorce/div-emca.yaml
+++ b/k8s/aat/common/divorce/div-emca.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-emca
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: div-emca
   rollback:

--- a/k8s/aat/common/divorce/div-fps.yaml
+++ b/k8s/aat/common/divorce/div-fps.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-fps
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: div-fps
   rollback:

--- a/k8s/aat/common/divorce/div-pfe.yaml
+++ b/k8s/aat/common/divorce/div-pfe.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-pfe
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: div-pfe
   rollback:

--- a/k8s/aat/common/divorce/div-rfe.yaml
+++ b/k8s/aat/common/divorce/div-rfe.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: div-rfe
   namespace: divorce
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: div-rfe
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11329

Removed flux v1 image annotation from Divorce AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
