### PR TITLE
DTSPO-4182 Ethos AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/ethos/ecm-consumer.yaml
+++ b/k8s/aat/common/ethos/ecm-consumer.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ecm-consumer
   namespace: ethos
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: ecm-consumer
   rollback:

--- a/k8s/aat/common/ethos/repl-docmosis-service.yaml
+++ b/k8s/aat/common/ethos/repl-docmosis-service.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: repl-docmosis-service
   namespace: ethos
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: repl-docmosis-service
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 image automation PR - #11361

Removed flux v1 image annotation from Ethos AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
