### PR TITLE
DTSPO-4182 FPL AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/family-private-law/fprl-cos.yaml
+++ b/k8s/aat/common/family-private-law/fprl-cos.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: fprl-cos
   namespace: family-private-law
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: fprl-cos
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 image automation PR - #11367

Removed flux v1 image annotation from FPL AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
