### PR TITLE
DTSPO-4182 Fees-Pay AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/fees-pay/ccpay-bubble-frontend.yaml
+++ b/k8s/aat/common/fees-pay/ccpay-bubble-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend
   namespace: fees-pay
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: ccpay-bubble-frontend
   rollback:

--- a/k8s/aat/common/fees-pay/ccpay-bulkscanning-app.yaml
+++ b/k8s/aat/common/fees-pay/ccpay-bulkscanning-app.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api
   namespace: fees-pay
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: ccpay-bulkscanning-api
   rollback:

--- a/k8s/aat/common/fees-pay/ccpay-payment-app.yaml
+++ b/k8s/aat/common/fees-pay/ccpay-payment-app.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ccpay-payment-app
   namespace: fees-pay
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: ccpay-payment-api
   rollback:

--- a/k8s/aat/common/fees-pay/fees-register-api.yaml
+++ b/k8s/aat/common/fees-pay/fees-register-api.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: fees-register-api
   namespace: fees-pay
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: fees-register-api
   rollback:

--- a/k8s/aat/common/fees-pay/fees-register-frontend.yaml
+++ b/k8s/aat/common/fees-pay/fees-register-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: fees-register-frontend
   namespace: fees-pay
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: fees-register-frontend
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182

### Change description ###
Follow up to Flux V2 image automation PR - #11372

Removed flux v1 image annotation from Fees-Pay AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
