### PR TITLE
DTSPO-4182 Financial-Remedy AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/financial-remedy/finrem-cos.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-cos.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: finrem-cos
   namespace: financial-remedy
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:prod-*
 spec:
   releaseName: finrem-cos
   rollback:

--- a/k8s/aat/common/financial-remedy/finrem-dgcs.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-dgcs.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: finrem-dgcs
   namespace: financial-remedy
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:prod-*
 spec:
   releaseName: finrem-dgcs
   rollback:

--- a/k8s/aat/common/financial-remedy/finrem-emca.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-emca.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: finrem-emca
   namespace: financial-remedy
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:prod-*
 spec:
   releaseName: finrem-emca
   rollback:

--- a/k8s/aat/common/financial-remedy/finrem-ns.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-ns.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: finrem-ns
   namespace: financial-remedy
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: finrem-ns
   rollback:

--- a/k8s/aat/common/financial-remedy/finrem-ps.yaml
+++ b/k8s/aat/common/financial-remedy/finrem-ps.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: finrem-ps
   namespace: financial-remedy
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:prod-*
 spec:
   releaseName: finrem-ps
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###

Follow up to Flux V2 image automation PR - #11377

Removed flux v1 image annotation from Financial-Remedy AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
