### PR TITLE
DTSPO-4182 IA AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/ia/aip-frontend.yaml
+++ b/k8s/aat/common/ia/aip-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ia-aip-frontend
   namespace: ia
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: ia-aip-frontend
   rollback:

--- a/k8s/aat/common/ia/home-office-mock-api.yaml
+++ b/k8s/aat/common/ia/home-office-mock-api.yaml
@@ -4,10 +4,6 @@ kind: HelmRelease
 metadata:
   name: ia-home-office-mock-api
   namespace: ia
-  annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
 spec:
   releaseName: ia-home-office-mock-api
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11382

Removed flux v1 image annotation from IA AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.

![image](https://user-images.githubusercontent.com/22701260/131816383-e2c2bce7-f2bc-4319-ac7b-1eba04890048.png)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
