### PR TITLE
DTSPO-4182 Money-Claims AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/money-claims/claim-store.yaml
+++ b/k8s/aat/common/money-claims/claim-store.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: cmc-claim-store
   namespace: money-claims
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: cmc-claim-store
   rollback:

--- a/k8s/aat/common/money-claims/cmc-citizen-frontend.yaml
+++ b/k8s/aat/common/money-claims/cmc-citizen-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend
   namespace: money-claims
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: cmc-citizen-frontend
   rollback:

--- a/k8s/aat/common/money-claims/cmc-legal-frontend.yaml
+++ b/k8s/aat/common/money-claims/cmc-legal-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: cmc-legal-frontend
   namespace: money-claims
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: cmc-legal-frontend
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11397

Removed flux v1 image annotation from Money-Claims AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
