### PR TITLE
DTSPO-4182 Probate AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/common/probate/business-service.yaml
+++ b/k8s/aat/common/probate/business-service.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: probate-business-service
   namespace: probate
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: probate-business-service
   rollback:

--- a/k8s/aat/common/probate/orchestrator-service.yaml
+++ b/k8s/aat/common/probate/orchestrator-service.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: probate-orchestrator-service
   namespace: probate
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: probate-orchestrator-service
   rollback:

--- a/k8s/aat/common/probate/probate-back-office.yaml
+++ b/k8s/aat/common/probate/probate-back-office.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: probate-back-office
   namespace: probate
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:prod-*
 spec:
   releaseName: probate-back-office
   rollback:

--- a/k8s/aat/common/probate/probate-caveats-fe.yaml
+++ b/k8s/aat/common/probate/probate-caveats-fe.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: probate-caveats-fe
   namespace: probate
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: probate-caveats-fe
   rollback:

--- a/k8s/aat/common/probate/probate-frontend.yaml
+++ b/k8s/aat/common/probate/probate-frontend.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: probate-frontend
   namespace: probate
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: probate-frontend
   rollback:

--- a/k8s/aat/common/probate/submit-service.yaml
+++ b/k8s/aat/common/probate/submit-service.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: probate-submit-service
   namespace: probate
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: probate-submit-service
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11404

Removed flux v1 image annotation from Probate AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
