### PR TITLE
DTSPO-4182 Reform-Scan AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/aat.yaml
@@ -2,14 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router
-  annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
@@ -2,9 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: reform-scan-blob-router
   timeout: 600

--- a/k8s/namespaces/reform-scan/reform-scan-notification-service/aat.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-notification-service/aat.yaml
@@ -2,12 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: reform-scan-notification-service
-  annotations:
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11418

Removed flux v1 image annotation from Reform-Scan AAT after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
