### PR TITLE
DTSPO-4182 RPE AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/apps/flux-system/automation/kustomization.yaml
+++ b/apps/flux-system/automation/kustomization.yaml
@@ -4,22 +4,19 @@ namespace: flux-system
 resources:
   - registry-credential-sync/hmctspublic/kustomize.yaml
   - registry-credential-sync/hmctsprivate/kustomize.yaml
-  - ../../backstage/automation
-  - ../../cnp/automation
-  - ../../slack-help-bot/automation
-  - ../../rpe/automation
-  - ../../docmosis/automation
-  - ../../sscs/automation
   - ../../aac/automation
   - ../../am/automation
+  - ../../backstage/automation
   - ../../bar/automation
   - ../../bsp/automation
   - ../../civil/automation
+  - ../../cnp/automation
   - ../../cpo/automation
   - ../../ctsc/automation
   - ../../dg/automation
   - ../../divorce/automation
   - ../../dm-store/automation
+  - ../../docmosis/automation
   - ../../em/automation
   - ../../ethos/automation
   - ../../fact/automation
@@ -36,6 +33,9 @@ resources:
   - ../../probate/automation
   - ../../rd/automation
   - ../../reform-scan/automation
+  - ../../rpe/automation
+  - ../../slack-help-bot/automation
+  - ../../sscs/automation
 
 patches:
   - path: hmctspublic-image-repo.yaml

--- a/k8s/namespaces/rpe/draft-store-service/aat.yaml
+++ b/k8s/namespaces/rpe/draft-store-service/aat.yaml
@@ -2,18 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: draft-store-service
-  annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketestscron: java.smoketestscron.image
-    filter.fluxcd.io/java.smoketestscron: glob:prod-*
-    repository.fluxcd.io/java.functionaltestscron: java.functionaltestscron.image
-    filter.fluxcd.io/java.functionaltestscron: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/rpe/draft-store-service/aat.yaml
+++ b/k8s/namespaces/rpe/draft-store-service/aat.yaml
@@ -2,6 +2,18 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: draft-store-service
+  annotations:
+    fluxcd.io/automated: "true"
+    repository.fluxcd.io/java: java.image
+    filter.fluxcd.io/java: glob:prod-*
+    repository.fluxcd.io/java.smoketestscron: java.smoketestscron.image
+    filter.fluxcd.io/java.smoketestscron: glob:prod-*
+    repository.fluxcd.io/java.functionaltestscron: java.functionaltestscron.image
+    filter.fluxcd.io/java.functionaltestscron: glob:prod-*
+    repository.fluxcd.io/java.smoketests: java.smoketests.image
+    filter.fluxcd.io/java.smoketests: glob:prod-*
+    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
+    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/rpe/pdf-service/aat.yaml
+++ b/k8s/namespaces/rpe/pdf-service/aat.yaml
@@ -3,17 +3,6 @@ kind: HelmRelease
 metadata:
   name: pdf-service
   annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketestscron: java.smoketestscron.image
-    filter.fluxcd.io/java.smoketestscron: glob:prod-*
-    repository.fluxcd.io/java.functionaltestscron: java.functionaltestscron.image
-    filter.fluxcd.io/java.functionaltestscron: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/rpe/pdf-service/aat.yaml
+++ b/k8s/namespaces/rpe/pdf-service/aat.yaml
@@ -2,18 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: pdf-service
-  annotations:
-    fluxcd.io/automated: "true"
-    repository.fluxcd.io/java: java.image
-    filter.fluxcd.io/java: glob:prod-*
-    repository.fluxcd.io/java.smoketestscron: java.smoketestscron.image
-    filter.fluxcd.io/java.smoketestscron: glob:prod-*
-    repository.fluxcd.io/java.functionaltestscron: java.functionaltestscron.image
-    filter.fluxcd.io/java.functionaltestscron: glob:prod-*
-    repository.fluxcd.io/java.smoketests: java.smoketests.image
-    filter.fluxcd.io/java.smoketests: glob:prod-*
-    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
-    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:

--- a/k8s/namespaces/rpe/pdf-service/aat.yaml
+++ b/k8s/namespaces/rpe/pdf-service/aat.yaml
@@ -2,6 +2,18 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: pdf-service
+  annotations:
+    fluxcd.io/automated: "true"
+    repository.fluxcd.io/java: java.image
+    filter.fluxcd.io/java: glob:prod-*
+    repository.fluxcd.io/java.smoketestscron: java.smoketestscron.image
+    filter.fluxcd.io/java.smoketestscron: glob:prod-*
+    repository.fluxcd.io/java.functionaltestscron: java.functionaltestscron.image
+    filter.fluxcd.io/java.functionaltestscron: glob:prod-*
+    repository.fluxcd.io/java.smoketests: java.smoketests.image
+    filter.fluxcd.io/java.smoketests: glob:prod-*
+    repository.fluxcd.io/java.functionaltests: java.functionaltests.image
+    filter.fluxcd.io/java.functionaltests: glob:prod-*
 spec:
   values:
     java:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11425

Removed flux v1 image annotation from RPE after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
