### PR TITLE
DTSPO-4182 Fees-Pay AAT Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/aat/cluster-00/ccpay/bar-payment-job.yaml
+++ b/k8s/aat/cluster-00/ccpay/bar-payment-job.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: bar-csv-report
   namespace: fees-pay
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.job: glob:prod-*
 spec:
   releaseName: bar-csv-report
   rollback:

--- a/k8s/aat/cluster-00/ccpay/card-payment-job.yaml
+++ b/k8s/aat/cluster-00/ccpay/card-payment-job.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: card-csv-report
   namespace: fees-pay
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.job: glob:prod-*
 spec:
   releaseName: card-csv-report
   rollback:

--- a/k8s/aat/cluster-00/ccpay/finrem-payment-job.yaml
+++ b/k8s/aat/cluster-00/ccpay/finrem-payment-job.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: pba-finrem-weekly-csv-report
   namespace: fees-pay
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.job: glob:prod-*
 spec:
   releaseName: pba-finrem-weekly-csv-report
   rollback:

--- a/k8s/aat/cluster-00/ccpay/pba-payment-job.yaml
+++ b/k8s/aat/cluster-00/ccpay/pba-payment-job.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: pba-csv-report
   namespace: fees-pay
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.job: glob:prod-*
 spec:
   releaseName: pba-csv-report
   rollback:

--- a/k8s/aat/cluster-00/ccpay/status-payment-job.yaml
+++ b/k8s/aat/cluster-00/ccpay/status-payment-job.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: status-update
   namespace: fees-pay
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.job: glob:prod-*
 spec:
   releaseName: status-update
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11467

Removed flux v1 image annotation from Fees-Pay ccpay after image policies and repositories changes are confirmed applied in the mgmt cluster.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
