### PR TITLE
DTSPO-4182 CCD AAT Image Automation - Flux v1 Annotation Removal 

### DIFF
--- a/k8s/aat/common/ccd/api-gateway-web.yaml
+++ b/k8s/aat/common/ccd/api-gateway-web.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web
   namespace: ccd
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.nodejs: glob:prod-*
 spec:
   releaseName: ccd-api-gateway-web
   rollback:

--- a/k8s/aat/common/ccd/data-store-api.yaml
+++ b/k8s/aat/common/ccd/data-store-api.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ccd-data-store-api
   namespace: ccd
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: ccd-data-store-api
   rollback:

--- a/k8s/aat/common/ccd/definition-store-api.yaml
+++ b/k8s/aat/common/ccd/definition-store-api.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: ccd-definition-store-api
   namespace: ccd
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: glob:prod-*
 spec:
   releaseName: ccd-definition-store-api
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11475 

Removed flux v1 image annotation from CCD AAT after image policies and repositories changes are confirmed applied in the mgmt

![image](https://user-images.githubusercontent.com/22701260/132477070-dedbb9c9-a5a7-44df-a0bb-c55c889305a6.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
