### PR TITLE
DTSPO-4182 BAR Demo Image Automation - Flux v1 Annotation Removal

### DIFF
--- a/k8s/demo/common/bar/bar-app.yaml
+++ b/k8s/demo/common/bar/bar-app.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: bar-api
   namespace: bar
-  annotations:
-    flux.weave.works/automated: "true"
-    flux.weave.works/tag.java: pr-502-*
 spec:
   releaseName: bar-api
   rollback:

--- a/k8s/demo/common/bar/bar-web.yaml
+++ b/k8s/demo/common/bar/bar-web.yaml
@@ -4,9 +4,6 @@ kind: HelmRelease
 metadata:
   name: bar-web
   namespace: bar
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.nodejs: glob:demo-*
 spec:
   releaseName: bar-web
   rollback:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Follow up to Flux V2 migration PR - #11547
Removed flux v1 image annotation from BAR Demo after image policies and repositories changes are confirmed applied in the mgmt cluster

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
