### PR TITLE
New identity for sscs-demo-mi

### DIFF
--- a/k8s/demo/common/sscs/identity.yaml
+++ b/k8s/demo/common/sscs/identity.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: 0
   resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/sscs-demo-mi
-  clientID: 004fa397-04ab-46fb-9310-46e63cd8f160
+  clientID: d8e738f2-ec84-4945-a095-5b23a27a7ba5
 
 ---
 apiVersion: "aadpodidentity.k8s.io/v1"


### PR DESCRIPTION
New identity for sscs-demo-mi