### PR TITLE
Test spliting namespace deploy in prep for flux v1-v2 migration

### DIFF
--- a/k8s/aat/common-overlay/lau/kustomization.yaml
+++ b/k8s/aat/common-overlay/lau/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: lau
 bases:
 - ../../../namespaces/lau
+- ../../../namespaces/lau/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/demo/common-overlay/lau/kustomization.yaml
+++ b/k8s/demo/common-overlay/lau/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: lau
 bases:
 - ../../../namespaces/lau
+- ../../../namespaces/lau/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/ithc/common-overlay/lau/kustomization.yaml
+++ b/k8s/ithc/common-overlay/lau/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: lau
 bases:
 - ../../../namespaces/lau
+- ../../../namespaces/lau/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/namespaces/lau/kustomization.yaml
+++ b/k8s/namespaces/lau/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: lau
 bases:
-- namespace.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.
 - lau-case-frontend/lau-case-frontend.yaml
 - lau-case-backend/lau-case-backend.yaml

--- a/k8s/perftest/common-overlay/lau/kustomization.yaml
+++ b/k8s/perftest/common-overlay/lau/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: lau
 bases:
 - ../../../namespaces/lau
+- ../../../namespaces/lau/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:


### PR DESCRIPTION
Using LAU as it is not in production yet.
Splitting the namespace out as it is in same kustomize as app deployments - will enable all namespaces to be moved to flux v2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
