### PR TITLE
split namespace for flux v1-v2 migration for more apps

### DIFF
--- a/k8s/aat/common-overlay/camunda/kustomization.yaml
+++ b/k8s/aat/common-overlay/camunda/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: camunda
 bases:
 - ../../../namespaces/camunda
+- ../../../namespaces/camunda/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/camunda/camunda-api/aat.yaml
 - ../../../namespaces/camunda/camunda-optimize/aat.yaml

--- a/k8s/aat/common-overlay/docmosis/kustomization.yaml
+++ b/k8s/aat/common-overlay/docmosis/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: docmosis
 bases:
 - ../../../namespaces/docmosis
+- ../../../namespaces/docmosis/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/docmosis/docmosis/aat.yaml

--- a/k8s/aat/common-overlay/nfdiv/kustomization.yaml
+++ b/k8s/aat/common-overlay/nfdiv/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: nfdiv
 bases:
 - ../../../namespaces/nfdiv
+- ../../../namespaces/nfdiv/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/nfdiv/nfdiv-case-api/aat.yaml

--- a/k8s/demo/common-overlay/camunda/kustomization.yaml
+++ b/k8s/demo/common-overlay/camunda/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: camunda
 bases:
 - ../../../namespaces/camunda
+- ../../../namespaces/camunda/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/camunda/camunda-ui/demo.yaml
 - ../../../namespaces/camunda/camunda-optimize/demo.yaml

--- a/k8s/demo/common-overlay/docmosis/kustomization.yaml
+++ b/k8s/demo/common-overlay/docmosis/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: docmosis
 bases:
 - ../../../namespaces/docmosis
+- ../../../namespaces/docmosis/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/docmosis/docmosis/demo.yaml

--- a/k8s/demo/common-overlay/nfdiv/kustomization.yaml
+++ b/k8s/demo/common-overlay/nfdiv/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: nfdiv
 bases:
 - ../../../namespaces/nfdiv
+- ../../../namespaces/nfdiv/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/nfdiv/nfdiv-case-api/demo.yaml

--- a/k8s/ithc/common-overlay/camunda/kustomization.yaml
+++ b/k8s/ithc/common-overlay/camunda/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: camunda
 bases:
 - ../../../namespaces/camunda
+- ../../../namespaces/camunda/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/camunda/camunda-api/ithc.yaml
 - ../../../namespaces/camunda/camunda-optimize/ithc.yaml

--- a/k8s/ithc/common-overlay/docmosis/kustomization.yaml
+++ b/k8s/ithc/common-overlay/docmosis/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: docmosis
 bases:
 - ../../../namespaces/docmosis
+- ../../../namespaces/docmosis/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/docmosis/docmosis/ithc.yaml

--- a/k8s/ithc/common-overlay/nfdiv/kustomization.yaml
+++ b/k8s/ithc/common-overlay/nfdiv/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: nfdiv
 bases:
 - ../../../namespaces/nfdiv
+- ../../../namespaces/nfdiv/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/namespaces/camunda/kustomization.yaml
+++ b/k8s/namespaces/camunda/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: camunda
 bases:
-- namespace.yaml
 - camunda-ui/camunda-ui.yaml
 - camunda-api/camunda-api.yaml
 - camunda-optimize/camunda-optimize.yaml

--- a/k8s/namespaces/docmosis/kustomization.yaml
+++ b/k8s/namespaces/docmosis/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: docmosis
 bases:
-- namespace.yaml
 - docmosis/docmosis.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/nfdiv/kustomization.yaml
+++ b/k8s/namespaces/nfdiv/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: nfdiv
 bases:
-- namespace.yaml
 - nfdiv-frontend/nfdiv-frontend.yaml
 - nfdiv-case-api/nfdiv-case-api.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/perftest/common-overlay/camunda/kustomization.yaml
+++ b/k8s/perftest/common-overlay/camunda/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: camunda
 bases:
 - ../../../namespaces/camunda
+- ../../../namespaces/camunda/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/camunda/camunda-api/perftest.yaml
 - ../../../namespaces/camunda/camunda-optimize/perftest.yaml

--- a/k8s/perftest/common-overlay/docmosis/kustomization.yaml
+++ b/k8s/perftest/common-overlay/docmosis/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: docmosis
 bases:
 - ../../../namespaces/docmosis
+- ../../../namespaces/docmosis/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/docmosis/docmosis/perftest.yaml

--- a/k8s/perftest/common-overlay/nfdiv/kustomization.yaml
+++ b/k8s/perftest/common-overlay/nfdiv/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: nfdiv
 bases:
 - ../../../namespaces/nfdiv
+- ../../../namespaces/nfdiv/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/prod/common-overlay/camunda/kustomization.yaml
+++ b/k8s/prod/common-overlay/camunda/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: camunda
 bases:
 - ../../../namespaces/camunda
+- ../../../namespaces/camunda/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/camunda/camunda-ui/prod.yaml
 - ../../../namespaces/camunda/camunda-api/prod.yaml

--- a/k8s/prod/common-overlay/docmosis/kustomization.yaml
+++ b/k8s/prod/common-overlay/docmosis/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: docmosis
 bases:
 - ../../../namespaces/docmosis
+- ../../../namespaces/docmosis/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/docmosis/docmosis/prod.yaml


### PR DESCRIPTION
Separating namespaces out for flux migration to v2 - already tested with lau. This is for camunda, docmosis, nfdiv.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
