### PR TITLE
Dtspo 4181 namespaces

### DIFF
--- a/k8s/aat/cluster-00-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-00-overlay/kustomization.yaml
@@ -18,6 +18,7 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/admin/env-injector
   - ../../namespaces/monitoring/botkube

--- a/k8s/aat/cluster-01-overlay/kustomization.yaml
+++ b/k8s/aat/cluster-01-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/admin/env-injector
   - ../../namespaces/monitoring/botkube

--- a/k8s/aat/common-overlay/aac/kustomization.yaml
+++ b/k8s/aat/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/aat/common-overlay/am/kustomization.yaml
+++ b/k8s/aat/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/am/am-judicial-booking-service/am-judicial-booking-service.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/aat/common-overlay/bsp/kustomization.yaml
+++ b/k8s/aat/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
 - ../../../namespaces/bsp
+- ../../../namespaces/bsp/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/bsp/bulk-scan-payment-processor/aat.yaml

--- a/k8s/aat/common-overlay/ccd/kustomization.yaml
+++ b/k8s/aat/common-overlay/ccd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ccd
 bases:
 - ../../../namespaces/ccd
+- ../../../namespaces/ccd/namespace.yaml
 - ../../../namespaces/ccd/ccd-test-stubs-service/ccd-test-stubs-service.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/aat/common-overlay/civil/kustomization.yaml
+++ b/k8s/aat/common-overlay/civil/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: civil
 bases:
 - ../../../namespaces/civil
+- ../../../namespaces/civil/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/aat.yaml

--- a/k8s/aat/common-overlay/cpo/kustomization.yaml
+++ b/k8s/aat/common-overlay/cpo/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cpo
 bases:
 - ../../../namespaces/cpo
+- ../../../namespaces/cpo/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/aat/common-overlay/dg/kustomization.yaml
+++ b/k8s/aat/common-overlay/dg/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dg
 bases:
 - ../../../namespaces/dg
+- ../../../namespaces/dg/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/aat/common-overlay/dm-store/kustomization.yaml
+++ b/k8s/aat/common-overlay/dm-store/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dm-store
 bases:
 - ../../../namespaces/dm-store
+- ../../../namespaces/dm-store/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dm-store/dm-store/aat.yaml

--- a/k8s/aat/common-overlay/em/kustomization.yaml
+++ b/k8s/aat/common-overlay/em/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: em
 bases:
 - ../../../namespaces/em
+- ../../../namespaces/em/namespace.yaml
 - ../../../namespaces/em/em-showcase/em-showcase.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/aat/common-overlay/fact/kustomization.yaml
+++ b/k8s/aat/common-overlay/fact/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: fact
 bases:
 - ../../../namespaces/fact
+- ../../../namespaces/fact/namespace.yaml

--- a/k8s/aat/common-overlay/family-public-law/kustomization.yaml
+++ b/k8s/aat/common-overlay/family-public-law/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: family-public-law
 bases:
 - ../../../namespaces/family-public-law
+- ../../../namespaces/family-public-law/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/family-public-law/fpl-case-service/aat.yaml

--- a/k8s/aat/common-overlay/fees-pay/kustomization.yaml
+++ b/k8s/aat/common-overlay/fees-pay/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: fees-pay
 bases:
 - ../../../namespaces/fees-pay
+- ../../../namespaces/fees-pay/namespace.yaml
 - ../../../namespaces/fees-pay/ccpay-refunds-api/ccpay-refunds-api.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/aat/common-overlay/ia/kustomization.yaml
+++ b/k8s/aat/common-overlay/ia/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ia
 bases:
 - ../../../namespaces/ia
+- ../../../namespaces/ia/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ia/ia-home-office-integration-api/aat.yaml

--- a/k8s/aat/common-overlay/pcq/kustomization.yaml
+++ b/k8s/aat/common-overlay/pcq/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: pcq
 bases:
 - ../../../namespaces/pcq
+- ../../../namespaces/pcq/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/pcq/pcq-backend/aat.yaml

--- a/k8s/aat/common-overlay/rd/kustomization.yaml
+++ b/k8s/aat/common-overlay/rd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rd
 bases:
 - ../../../namespaces/rd
+- ../../../namespaces/rd/namespace.yaml
 - ../../../namespaces/rd/rd-location-ref-api/rd-location-ref-api.yaml
 - ../../../namespaces/rd/rd-judicial-api/rd-judicial-api.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml

--- a/k8s/aat/common-overlay/reform-scan/kustomization.yaml
+++ b/k8s/aat/common-overlay/reform-scan/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: reform-scan
 bases:
 - ../../../namespaces/reform-scan
+- ../../../namespaces/reform-scan/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/reform-scan/reform-scan-notification-service/aat.yaml

--- a/k8s/aat/common-overlay/rpe/kustomization.yaml
+++ b/k8s/aat/common-overlay/rpe/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rpe
 bases:
 - ../../../namespaces/rpe
+- ../../../namespaces/rpe/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/rpe/draft-store-service/aat.yaml
 - ../../../namespaces/rpe/pdf-service/aat.yaml

--- a/k8s/aat/common-overlay/wa/kustomization.yaml
+++ b/k8s/aat/common-overlay/wa/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
+- ../../../namespaces/wa/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 - ../../../namespaces/wa/wa-task-batch-termination/wa-task-batch-termination.yaml
 patchesStrategicMerge:

--- a/k8s/aat/common-overlay/xui/kustomization.yaml
+++ b/k8s/aat/common-overlay/xui/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: xui
 bases:
 - ../../../namespaces/xui
+- ../../../namespaces/xui/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/xui/xui-ao-webapp/aat.yaml

--- a/k8s/demo/cluster-00-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-00-overlay/kustomization.yaml
@@ -20,6 +20,7 @@ bases:
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/osba
+  - ../../namespaces/osba/namespace.yaml
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id

--- a/k8s/demo/cluster-01-overlay/kustomization.yaml
+++ b/k8s/demo/cluster-01-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/osba
+  - ../../namespaces/osba/namespace.yaml
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/keda
   - ../../namespaces/admin/aad-pod-id

--- a/k8s/demo/common-overlay/aac/kustomization.yaml
+++ b/k8s/demo/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/demo.yaml

--- a/k8s/demo/common-overlay/am/kustomization.yaml
+++ b/k8s/demo/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 - ../../../namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
 patchesStrategicMerge:

--- a/k8s/demo/common-overlay/bsp/kustomization.yaml
+++ b/k8s/demo/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
 - ../../../namespaces/bsp
+- ../../../namespaces/bsp/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/bsp/bulk-scan-processor/demo.yaml

--- a/k8s/demo/common-overlay/ccd/kustomization.yaml
+++ b/k8s/demo/common-overlay/ccd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ccd
 bases:
 - ../../../namespaces/ccd
+- ../../../namespaces/ccd/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ccd/ccd-logstash-indexer/demo.yaml

--- a/k8s/demo/common-overlay/civil/kustomization.yaml
+++ b/k8s/demo/common-overlay/civil/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: civil
 bases:
 - ../../../namespaces/civil
+- ../../../namespaces/civil/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/demo.yaml

--- a/k8s/demo/common-overlay/cpo/kustomization.yaml
+++ b/k8s/demo/common-overlay/cpo/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cpo
 bases:
 - ../../../namespaces/cpo
+- ../../../namespaces/cpo/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/demo/common-overlay/dg/kustomization.yaml
+++ b/k8s/demo/common-overlay/dg/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dg
 bases:
 - ../../../namespaces/dg
+- ../../../namespaces/dg/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dg/dg-docassembly/demo.yaml

--- a/k8s/demo/common-overlay/dm-store/kustomization.yaml
+++ b/k8s/demo/common-overlay/dm-store/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dm-store
 bases:
 - ../../../namespaces/dm-store
+- ../../../namespaces/dm-store/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dm-store/dm-store/demo.yaml

--- a/k8s/demo/common-overlay/em/kustomization.yaml
+++ b/k8s/demo/common-overlay/em/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: em
 bases:
 - ../../../namespaces/em
+- ../../../namespaces/em/namespace.yaml
 - ../../../namespaces/em/em-showcase/em-showcase.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/demo/common-overlay/fact/kustomization.yaml
+++ b/k8s/demo/common-overlay/fact/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: fact
 bases:
 - ../../../namespaces/fact
+- ../../../namespaces/fact/namespace.yaml

--- a/k8s/demo/common-overlay/family-public-law/kustomization.yaml
+++ b/k8s/demo/common-overlay/family-public-law/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: family-public-law
 bases:
 - ../../../namespaces/family-public-law
+- ../../../namespaces/family-public-law/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/family-public-law/fpl-case-service/demo.yaml

--- a/k8s/demo/common-overlay/fees-pay/kustomization.yaml
+++ b/k8s/demo/common-overlay/fees-pay/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: fees-pay
 bases:
 - ../../../namespaces/fees-pay
+- ../../../namespaces/fees-pay/namespace.yaml
 - ../../../namespaces/fees-pay/ccpay-refunds-api/ccpay-refunds-api.yaml
 - ../../../namespaces/fees-pay/ccpay-paymentoutcome-web/ccpay-paymentoutcome-web.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml

--- a/k8s/demo/common-overlay/ia/kustomization.yaml
+++ b/k8s/demo/common-overlay/ia/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ia
 bases:
 - ../../../namespaces/ia
+- ../../../namespaces/ia/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ia/ia-case-payments-api/demo.yaml

--- a/k8s/demo/common-overlay/pcq/kustomization.yaml
+++ b/k8s/demo/common-overlay/pcq/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: pcq
 bases:
 - ../../../namespaces/pcq
+- ../../../namespaces/pcq/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/demo/common-overlay/rd/kustomization.yaml
+++ b/k8s/demo/common-overlay/rd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rd
 bases:
 - ../../../namespaces/rd
+- ../../../namespaces/rd/namespace.yaml
 - ../../../namespaces/rd/rd-judicial-api/rd-judicial-api.yaml
 - ../../../namespaces/rd/rd-location-ref-api/rd-location-ref-api.yaml
 - ../../../namespaces/rd/rd-professional-api-integration/rd-professional-api-integration.yaml

--- a/k8s/demo/common-overlay/reform-scan/kustomization.yaml
+++ b/k8s/demo/common-overlay/reform-scan/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: reform-scan
 bases:
 - ../../../namespaces/reform-scan
+- ../../../namespaces/reform-scan/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/reform-scan/reform-scan-notification-service/demo.yaml

--- a/k8s/demo/common-overlay/rpe/kustomization.yaml
+++ b/k8s/demo/common-overlay/rpe/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: rpe
 bases:
 - ../../../namespaces/rpe
+- ../../../namespaces/rpe/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/rpe/rpe-send-letter-service/demo.yaml

--- a/k8s/demo/common-overlay/wa/kustomization.yaml
+++ b/k8s/demo/common-overlay/wa/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
+- ../../../namespaces/wa/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/wa/wa-case-event-handler/demo.yaml

--- a/k8s/demo/common-overlay/xui/kustomization.yaml
+++ b/k8s/demo/common-overlay/xui/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: xui
 bases:
 - ../../../namespaces/xui
+- ../../../namespaces/xui/namespace.yaml
 - ../../../namespaces/xui/xui-webapp-integration/xui-webapp-integration.yaml
 - ../../../namespaces/xui/xui-webapp-ac-integration/xui-webapp-ac-integration.yaml
 - ../../../namespaces/xui/xui-ao-webapp-integration/xui-ao-webapp-integration.yaml

--- a/k8s/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-00-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/admin/keda

--- a/k8s/ithc/cluster-01-overlay/kustomization.yaml
+++ b/k8s/ithc/cluster-01-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/admin/env-injector
   - ../../namespaces/admin/aad-pod-id
   - ../../namespaces/kube-system/aad-pod-id

--- a/k8s/ithc/common-overlay/aac/kustomization.yaml
+++ b/k8s/ithc/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/ithc.yaml

--- a/k8s/ithc/common-overlay/am/kustomization.yaml
+++ b/k8s/ithc/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/am/am-org-role-mapping-service/ithc.yaml

--- a/k8s/ithc/common-overlay/ccd/kustomization.yaml
+++ b/k8s/ithc/common-overlay/ccd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ccd
 bases:
 - ../../../namespaces/ccd
+- ../../../namespaces/ccd/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ccd/ccd-logstash-indexer/ithc.yaml

--- a/k8s/ithc/common-overlay/civil/kustomization.yaml
+++ b/k8s/ithc/common-overlay/civil/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: civil
 bases:
 - ../../../namespaces/civil
+- ../../../namespaces/civil/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/ithc.yaml

--- a/k8s/ithc/common-overlay/cpo/kustomization.yaml
+++ b/k8s/ithc/common-overlay/cpo/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cpo
 bases:
 - ../../../namespaces/cpo
+- ../../../namespaces/cpo/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/ithc/common-overlay/dg/kustomization.yaml
+++ b/k8s/ithc/common-overlay/dg/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dg
 bases:
 - ../../../namespaces/dg
+- ../../../namespaces/dg/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/ithc/common-overlay/dm-store/kustomization.yaml
+++ b/k8s/ithc/common-overlay/dm-store/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dm-store
 bases:
 - ../../../namespaces/dm-store
+- ../../../namespaces/dm-store/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dm-store/dm-store/ithc.yaml

--- a/k8s/ithc/common-overlay/em/kustomization.yaml
+++ b/k8s/ithc/common-overlay/em/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: em
 bases:
 - ../../../namespaces/em
+- ../../../namespaces/em/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/em/em-ccd-orchestrator/ithc.yaml

--- a/k8s/ithc/common-overlay/fact/kustomization.yaml
+++ b/k8s/ithc/common-overlay/fact/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: fact
 bases:
 - ../../../namespaces/fact
+- ../../../namespaces/fact/namespace.yaml

--- a/k8s/ithc/common-overlay/family-public-law/kustomization.yaml
+++ b/k8s/ithc/common-overlay/family-public-law/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: family-public-law
 bases:
 - ../../../namespaces/family-public-law
+- ../../../namespaces/family-public-law/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/family-public-law/fpl-case-service/ithc.yaml

--- a/k8s/ithc/common-overlay/fees-pay/kustomization.yaml
+++ b/k8s/ithc/common-overlay/fees-pay/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: fees-pay
 bases:
 - ../../../namespaces/fees-pay
+- ../../../namespaces/fees-pay/namespace.yaml
 - ../../../namespaces/fees-pay/ccpay-refunds-api/ccpay-refunds-api.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/ithc/common-overlay/ia/kustomization.yaml
+++ b/k8s/ithc/common-overlay/ia/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ia
 bases:
 - ../../../namespaces/ia
+- ../../../namespaces/ia/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ia/ia-home-office-integration-api/ithc.yaml

--- a/k8s/ithc/common-overlay/pcq/kustomization.yaml
+++ b/k8s/ithc/common-overlay/pcq/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: pcq
 bases:
 - ../../../namespaces/pcq
+- ../../../namespaces/pcq/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/ithc/common-overlay/rd/kustomization.yaml
+++ b/k8s/ithc/common-overlay/rd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rd
 bases:
 - ../../../namespaces/rd
+- ../../../namespaces/rd/namespace.yaml
 - ../../../namespaces/rd/rd-judicial-api/rd-judicial-api.yaml
 - ../../../namespaces/rd/rd-location-ref-api/rd-location-ref-api.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml

--- a/k8s/ithc/common-overlay/rpe/kustomization.yaml
+++ b/k8s/ithc/common-overlay/rpe/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: rpe
 bases:
 - ../../../namespaces/rpe
+- ../../../namespaces/rpe/namespace.yaml

--- a/k8s/ithc/common-overlay/wa/kustomization.yaml
+++ b/k8s/ithc/common-overlay/wa/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
+- ../../../namespaces/wa/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/wa/wa-case-event-handler/ithc.yaml

--- a/k8s/ithc/common-overlay/xui/kustomization.yaml
+++ b/k8s/ithc/common-overlay/xui/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: xui
 bases:
 - ../../../namespaces/xui
+- ../../../namespaces/xui/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/xui/xui-ao-webapp/ithc.yaml

--- a/k8s/namespaces/aac/kustomization.yaml
+++ b/k8s/namespaces/aac/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: am
 bases:
-- namespace.yaml
 - manage-case-assignment/manage-case-assignment.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/all-namespaces/nonprod-role.yaml
+++ b/k8s/namespaces/all-namespaces/nonprod-role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nonprod-team-permissions
 rules:
 - apiGroups: ['']
-  resources: ['pods','configmaps']
+  resources: ['pods']
   verbs: ['delete']
 - apiGroups: ['']
   resources: ['secrets']

--- a/k8s/namespaces/all-namespaces/nonprod-role.yaml
+++ b/k8s/namespaces/all-namespaces/nonprod-role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nonprod-team-permissions
 rules:
 - apiGroups: ['']
-  resources: ['pods']
+  resources: ['pods','configmaps']
   verbs: ['delete']
 - apiGroups: ['']
   resources: ['secrets']

--- a/k8s/namespaces/am/kustomization.yaml
+++ b/k8s/namespaces/am/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: am
 bases:
-- namespace.yaml
 - am-role-assignment-service/am-role-assignment-service.yaml
 - am-org-role-mapping-service/am-org-role-mapping-service.yaml
 

--- a/k8s/namespaces/bsp/kustomization.yaml
+++ b/k8s/namespaces/bsp/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: bsp
 bases:
-  - namespace.yaml
   - bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
   - bulk-scan-processor/bulk-scan-processor.yaml
   - bulk-scan-orchestrator/bulk-scan-orchestrator.yaml

--- a/k8s/namespaces/ccd/kustomization.yaml
+++ b/k8s/namespaces/ccd/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ccd
 bases:
-- namespace.yaml
 - logstash
 - ccd-case-document-am-api/ccd-case-document-am-api.yaml
 - ccd-api-gateway-web/ccd-api-gateway-web.yaml

--- a/k8s/namespaces/civil/kustomization.yaml
+++ b/k8s/namespaces/civil/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: civil
 bases:
-- namespace.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.
 - civil-service/civil-service.yaml

--- a/k8s/namespaces/cpo/kustomization.yaml
+++ b/k8s/namespaces/cpo/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cpo
 bases:
-- namespace.yaml
 - case-payment-orders-api/case-payment-orders-api.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/dg/kustomization.yaml
+++ b/k8s/namespaces/dg/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: dg
 bases:
-- namespace.yaml
 - dg-docassembly/dg-docassembly.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/dm-store/kustomization.yaml
+++ b/k8s/namespaces/dm-store/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: dm-store
 bases:
-- namespace.yaml
 - dm-store/dm-store.yaml

--- a/k8s/namespaces/em/kustomization.yaml
+++ b/k8s/namespaces/em/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: em
 bases:
-- namespace.yaml
 - em-npa/em-npa.yaml
 - em-anno/em-anno.yaml
 - em-stitching/em-stitching.yaml

--- a/k8s/namespaces/fact/kustomization.yaml
+++ b/k8s/namespaces/fact/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: fact
 bases:
-- namespace.yaml
 - fact-frontend/fact-frontend.yaml
 - fact-api/fact-api.yaml
 - fact-admin/fact-admin.yaml

--- a/k8s/namespaces/family-public-law/kustomization.yaml
+++ b/k8s/namespaces/family-public-law/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: family-public-law
 bases:
-- namespace.yaml
 - fpl-case-service/fpl-case-service.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/fees-pay/kustomization.yaml
+++ b/k8s/namespaces/fees-pay/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: fees-pay
 bases:
-- namespace.yaml
 - ccpay-callback-function/ccpay-callback-function.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/ia/kustomization.yaml
+++ b/k8s/namespaces/ia/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ia
 bases:
-- namespace.yaml
 - ia-home-office-integration-api/ia-home-office-integration-api.yaml
 - ia-case-payments-api/ia-case-payments-api.yaml
 - ia-case-access-api/ia-case-access-api.yaml

--- a/k8s/namespaces/neuvector/kustomization.yaml
+++ b/k8s/namespaces/neuvector/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
   - neuvector.yaml
   - fluentbit.yaml

--- a/k8s/namespaces/osba/kustomization.yaml
+++ b/k8s/namespaces/osba/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
   - etcd.yaml
   - osba.yaml
   - service-catalog.yaml

--- a/k8s/namespaces/pcq/kustomization.yaml
+++ b/k8s/namespaces/pcq/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: pcq
 bases:
-- namespace.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.
 - pcq-backend/pcq-backend.yaml
 - pcq-frontend/pcq-frontend.yaml

--- a/k8s/namespaces/rd/kustomization.yaml
+++ b/k8s/namespaces/rd/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rd
 bases:
-- namespace.yaml
 # - rd-judicial-api/rd-judicial-api.yaml
 - rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
 - rd-user-profile-api/rd-user-profile-api.yaml

--- a/k8s/namespaces/reform-scan/kustomization.yaml
+++ b/k8s/namespaces/reform-scan/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: reform-scan
 bases:
-- namespace.yaml
 - reform-scan-blob-router/reform-scan-blob-router.yaml
 - reform-scan-notification-service/reform-scan-notification-service.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/rpe/kustomization.yaml
+++ b/k8s/namespaces/rpe/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rpe
 bases:
-- namespace.yaml
 - draft-store-service/draft-store-service.yaml
 - rpe-service-auth-provider/rpe-service-auth-provider.yaml
 - pdf-service/pdf-service.yaml

--- a/k8s/namespaces/wa/kustomization.yaml
+++ b/k8s/namespaces/wa/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: wa
 bases:
-- namespace.yaml
 - wa-workflow-api/wa-workflow-api.yaml
 - wa-task-management-api/wa-task-management-api.yaml
 - wa-task-configuration-api/wa-task-configuration-api.yaml

--- a/k8s/namespaces/xui/kustomization.yaml
+++ b/k8s/namespaces/xui/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: xui
 bases:
-- namespace.yaml
 - xui-ao-webapp/xui-ao-webapp.yaml
 - xui-mo-webapp/xui-mo-webapp.yaml
 - xui-webapp/xui-webapp.yaml

--- a/k8s/perftest/cluster-00-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-00-overlay/kustomization.yaml
@@ -15,6 +15,7 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/admin/env-injector

--- a/k8s/perftest/cluster-01-overlay/kustomization.yaml
+++ b/k8s/perftest/cluster-01-overlay/kustomization.yaml
@@ -14,6 +14,7 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/monitoring/node-problem-detector
   - ../../namespaces/admin/env-injector

--- a/k8s/perftest/common-overlay/aac/kustomization.yaml
+++ b/k8s/perftest/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/perftest.yaml

--- a/k8s/perftest/common-overlay/am/kustomization.yaml
+++ b/k8s/perftest/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/am/am-org-role-mapping-service/perftest.yaml

--- a/k8s/perftest/common-overlay/bsp/kustomization.yaml
+++ b/k8s/perftest/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
 - ../../../namespaces/bsp
+- ../../../namespaces/bsp/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/bsp/bulk-scan-processor/perftest.yaml

--- a/k8s/perftest/common-overlay/ccd/kustomization.yaml
+++ b/k8s/perftest/common-overlay/ccd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ccd
 bases:
 - ../../../namespaces/ccd
+- ../../../namespaces/ccd/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ccd/ccd-logstash-indexer/perftest.yaml

--- a/k8s/perftest/common-overlay/civil/kustomization.yaml
+++ b/k8s/perftest/common-overlay/civil/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: civil
 bases:
 - ../../../namespaces/civil
+- ../../../namespaces/civil/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/perftest.yaml

--- a/k8s/perftest/common-overlay/cpo/kustomization.yaml
+++ b/k8s/perftest/common-overlay/cpo/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: cpo
 bases:
 - ../../../namespaces/cpo
+- ../../../namespaces/cpo/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/perftest/common-overlay/dg/kustomization.yaml
+++ b/k8s/perftest/common-overlay/dg/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dg
 bases:
 - ../../../namespaces/dg
+- ../../../namespaces/dg/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/perftest/common-overlay/dm-store/kustomization.yaml
+++ b/k8s/perftest/common-overlay/dm-store/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: dm-store
 bases:
 - ../../../namespaces/dm-store
+- ../../../namespaces/dm-store/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dm-store/dm-store/perftest.yaml

--- a/k8s/perftest/common-overlay/em/kustomization.yaml
+++ b/k8s/perftest/common-overlay/em/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: em
 bases:
 - ../../../namespaces/em
+- ../../../namespaces/em/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/em/em-stitching/perftest.yaml

--- a/k8s/perftest/common-overlay/fact/kustomization.yaml
+++ b/k8s/perftest/common-overlay/fact/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: fact
 bases:
 - ../../../namespaces/fact
+- ../../../namespaces/fact/namespace.yaml

--- a/k8s/perftest/common-overlay/family-public-law/kustomization.yaml
+++ b/k8s/perftest/common-overlay/family-public-law/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: family-public-law
 bases:
 - ../../../namespaces/family-public-law
+- ../../../namespaces/family-public-law/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/family-public-law/fpl-case-service/perftest.yaml

--- a/k8s/perftest/common-overlay/fees-pay/kustomization.yaml
+++ b/k8s/perftest/common-overlay/fees-pay/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: fees-pay
 bases:
 - ../../../namespaces/fees-pay
+- ../../../namespaces/fees-pay/namespace.yaml
 - ../../../namespaces/fees-pay/ccpay-refunds-api/ccpay-refunds-api.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/perftest/common-overlay/ia/kustomization.yaml
+++ b/k8s/perftest/common-overlay/ia/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ia
 bases:
 - ../../../namespaces/ia
+- ../../../namespaces/ia/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ia/ia-case-notifications-api/perftest.yaml

--- a/k8s/perftest/common-overlay/pcq/kustomization.yaml
+++ b/k8s/perftest/common-overlay/pcq/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: pcq
 bases:
 - ../../../namespaces/pcq
+- ../../../namespaces/pcq/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/perftest/common-overlay/rd/kustomization.yaml
+++ b/k8s/perftest/common-overlay/rd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rd
 bases:
 - ../../../namespaces/rd
+- ../../../namespaces/rd/namespace.yaml
 - ../../../namespaces/rd/rd-location-ref-api/rd-location-ref-api.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/perftest/common-overlay/reform-scan/kustomization.yaml
+++ b/k8s/perftest/common-overlay/reform-scan/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: reform-scan
 bases:
 - ../../../namespaces/reform-scan
+- ../../../namespaces/reform-scan/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/reform-scan/reform-scan-notification-service/perftest.yaml

--- a/k8s/perftest/common-overlay/rpe/kustomization.yaml
+++ b/k8s/perftest/common-overlay/rpe/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: rpe
 bases:
 - ../../../namespaces/rpe
+- ../../../namespaces/rpe/namespace.yaml

--- a/k8s/perftest/common-overlay/wa/kustomization.yaml
+++ b/k8s/perftest/common-overlay/wa/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
+- ../../../namespaces/wa/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/wa/wa-case-event-handler/perftest.yaml

--- a/k8s/perftest/common-overlay/xui/kustomization.yaml
+++ b/k8s/perftest/common-overlay/xui/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: xui
 bases:
 - ../../../namespaces/xui
+- ../../../namespaces/xui/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/xui/xui-ao-webapp/perftest.yaml

--- a/k8s/prod/cluster-00-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/kustomization.yaml
@@ -17,6 +17,7 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/admin/env-injector
   - ../../namespaces/monitoring/botkube

--- a/k8s/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
   - ../../namespaces/kube-system/nodelocaldns
   - ../../namespaces/kured
   - ../../namespaces/neuvector
+  - ../../namespaces/neuvector/namespace.yaml
   - ../../namespaces/monitoring/kube-prometheus-stack
   - ../../namespaces/admin/env-injector
   - ../../namespaces/monitoring/botkube

--- a/k8s/prod/common-overlay/aac/kustomization.yaml
+++ b/k8s/prod/common-overlay/aac/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/prod.yaml

--- a/k8s/prod/common-overlay/am/kustomization.yaml
+++ b/k8s/prod/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/am/am-org-role-mapping-service/prod.yaml
 - ../../../namespaces/am/am-role-assignment-service/prod.yaml

--- a/k8s/prod/common-overlay/bsp/kustomization.yaml
+++ b/k8s/prod/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
   - ../../../namespaces/bsp
+  - ../../../namespaces/bsp/namespace.yaml
 patchesStrategicMerge:
   - ../../../namespaces/bsp/bulk-scan-payment-processor/prod.yaml
   - ../../../namespaces/bsp/bulk-scan-processor/prod.yaml

--- a/k8s/prod/common-overlay/ccd/kustomization.yaml
+++ b/k8s/prod/common-overlay/ccd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ccd
 bases:
 - ../../../namespaces/ccd
+- ../../../namespaces/ccd/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ccd/ccd-logstash-indexer/prod.yaml
 - ../../../namespaces/ccd/ccd-logstash-indexer2/prod.yaml

--- a/k8s/prod/common-overlay/civil/kustomization.yaml
+++ b/k8s/prod/common-overlay/civil/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: civil
 bases:
 - ../../../namespaces/civil
+- ../../../namespaces/civil/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/prod.yaml

--- a/k8s/prod/common-overlay/cpo/kustomization.yaml
+++ b/k8s/prod/common-overlay/cpo/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: cpo
 bases:
 - ../../../namespaces/cpo
+- ../../../namespaces/cpo/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/cpo/case-payment-orders-api/prod.yaml

--- a/k8s/prod/common-overlay/dg/kustomization.yaml
+++ b/k8s/prod/common-overlay/dg/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: dg
 bases:
 - ../../../namespaces/dg
+- ../../../namespaces/dg/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dg/dg-docassembly/prod.yaml

--- a/k8s/prod/common-overlay/dm-store/kustomization.yaml
+++ b/k8s/prod/common-overlay/dm-store/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: dm-store
 bases:
 - ../../../namespaces/dm-store
+- ../../../namespaces/dm-store/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/dm-store/dm-store/prod.yaml

--- a/k8s/prod/common-overlay/em/kustomization.yaml
+++ b/k8s/prod/common-overlay/em/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: em
 bases:
 - ../../../namespaces/em
+- ../../../namespaces/em/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/em/em-npa/prod.yaml
 - ../../../namespaces/em/em-anno/prod.yaml

--- a/k8s/prod/common-overlay/fact/kustomization.yaml
+++ b/k8s/prod/common-overlay/fact/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: fact
 bases:
 - ../../../namespaces/fact
+- ../../../namespaces/fact/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/fact/fact-frontend/prod.yaml
 - ../../../namespaces/fact/fact-admin/prod.yaml

--- a/k8s/prod/common-overlay/family-public-law/kustomization.yaml
+++ b/k8s/prod/common-overlay/family-public-law/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: family-public-law
 bases:
 - ../../../namespaces/family-public-law
+- ../../../namespaces/family-public-law/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/family-public-law/fpl-case-service/prod.yaml

--- a/k8s/prod/common-overlay/fees-pay/kustomization.yaml
+++ b/k8s/prod/common-overlay/fees-pay/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: fees-pay
 bases:
 - ../../../namespaces/fees-pay
+- ../../../namespaces/fees-pay/namespace.yaml

--- a/k8s/prod/common-overlay/ia/kustomization.yaml
+++ b/k8s/prod/common-overlay/ia/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: ia
 bases:
 - ../../../namespaces/ia
+- ../../../namespaces/ia/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/ia/ia-home-office-integration-api/prod.yaml
 - ../../../namespaces/ia/ia-case-payments-api/prod.yaml

--- a/k8s/prod/common-overlay/pcq/kustomization.yaml
+++ b/k8s/prod/common-overlay/pcq/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: pcq
 bases:
 - ../../../namespaces/pcq
+- ../../../namespaces/pcq/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/pcq/pcq-frontend/prod.yaml

--- a/k8s/prod/common-overlay/rd/kustomization.yaml
+++ b/k8s/prod/common-overlay/rd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rd
 bases:
 - ../../../namespaces/rd
+- ../../../namespaces/rd/namespace.yaml
 - ../../../namespaces/rd/rd-judicial-api/rd-judicial-api.yaml
 - ../../../namespaces/rd/rd-location-ref-api/rd-location-ref-api.yaml
 patchesStrategicMerge:

--- a/k8s/prod/common-overlay/reform-scan/kustomization.yaml
+++ b/k8s/prod/common-overlay/reform-scan/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: reform-scan
 bases:
 - ../../../namespaces/reform-scan
+- ../../../namespaces/reform-scan/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/reform-scan/reform-scan-notification-service/prod.yaml
 - ../../../namespaces/reform-scan/reform-scan-blob-router/prod.yaml

--- a/k8s/prod/common-overlay/rpe/kustomization.yaml
+++ b/k8s/prod/common-overlay/rpe/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: rpe
 bases:
 - ../../../namespaces/rpe
+- ../../../namespaces/rpe/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/rpe/draft-store-service/prod.yaml
 - ../../../namespaces/rpe/rpe-send-letter-service/prod.yaml

--- a/k8s/prod/common-overlay/wa/kustomization.yaml
+++ b/k8s/prod/common-overlay/wa/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: wa
 bases:
 - ../../../namespaces/wa
+- ../../../namespaces/wa/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/wa/wa-case-event-handler/prod.yaml
 - ../../../namespaces/wa/wa-task-management-api/prod.yaml

--- a/k8s/prod/common-overlay/xui/kustomization.yaml
+++ b/k8s/prod/common-overlay/xui/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: xui
 bases:
 - ../../../namespaces/xui
+- ../../../namespaces/xui/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/xui/xui-ao-webapp/prod.yaml
 - ../../../namespaces/xui/xui-mo-webapp/prod.yaml


### PR DESCRIPTION
This is to enable migrating all namespaces to Flux v2
No functional change, just separating the two so all namespaces can all be migrated over. Tested on 2 previous PRs, no redeployments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
