### PR TITLE
DTSPO-4182 - Disable Flux v1 ACR scanning in AAT/Demo

### DIFF
--- a/k8s/namespaces/admin/flux/patches/aat/flux.yaml
+++ b/k8s/namespaces/admin/flux/patches/aat/flux.yaml
@@ -9,3 +9,5 @@ spec:
     git:
       email: "flux-aat@hmcts.net"
       user: "Flux AAT"
+    registry:
+      includeImage: "none"

--- a/k8s/namespaces/admin/flux/patches/demo/flux.yaml
+++ b/k8s/namespaces/admin/flux/patches/demo/flux.yaml
@@ -9,3 +9,5 @@ spec:
     git:
       email: "hmcts-flux-demo@hmcts.net"
       user: "Flux demo"
+    registry:
+      includeImage: "none"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4182


### Change description ###
Disable flux v1 ACR scanning in AAT and Demo following migration of image automation to flux v2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
