### PR TITLE
Namespaces aac, am, bsp split for flux v2 migration

### DIFF
--- a/k8s/aat/common-overlay/aac/kustomization.yaml
+++ b/k8s/aat/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:

--- a/k8s/aat/common-overlay/am/kustomization.yaml
+++ b/k8s/aat/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/am/am-judicial-booking-service/am-judicial-booking-service.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:

--- a/k8s/aat/common-overlay/bsp/kustomization.yaml
+++ b/k8s/aat/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
 - ../../../namespaces/bsp
+- ../../../namespaces/bsp/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/bsp/bulk-scan-payment-processor/aat.yaml

--- a/k8s/demo/common-overlay/aac/kustomization.yaml
+++ b/k8s/demo/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/demo.yaml

--- a/k8s/demo/common-overlay/am/kustomization.yaml
+++ b/k8s/demo/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 - ../../../namespaces/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
 patchesStrategicMerge:

--- a/k8s/demo/common-overlay/bsp/kustomization.yaml
+++ b/k8s/demo/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
 - ../../../namespaces/bsp
+- ../../../namespaces/bsp/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/bsp/bulk-scan-processor/demo.yaml

--- a/k8s/ithc/common-overlay/aac/kustomization.yaml
+++ b/k8s/ithc/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/ithc.yaml

--- a/k8s/ithc/common-overlay/am/kustomization.yaml
+++ b/k8s/ithc/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/am/am-org-role-mapping-service/ithc.yaml

--- a/k8s/namespaces/aac/kustomization.yaml
+++ b/k8s/namespaces/aac/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: am
 bases:
-- namespace.yaml
 - manage-case-assignment/manage-case-assignment.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/am/kustomization.yaml
+++ b/k8s/namespaces/am/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: am
 bases:
-- namespace.yaml
 - am-role-assignment-service/am-role-assignment-service.yaml
 - am-org-role-mapping-service/am-org-role-mapping-service.yaml
 

--- a/k8s/namespaces/bsp/kustomization.yaml
+++ b/k8s/namespaces/bsp/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: bsp
 bases:
-  - namespace.yaml
   - bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
   - bulk-scan-processor/bulk-scan-processor.yaml
   - bulk-scan-orchestrator/bulk-scan-orchestrator.yaml

--- a/k8s/perftest/common-overlay/aac/kustomization.yaml
+++ b/k8s/perftest/common-overlay/aac/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/perftest.yaml

--- a/k8s/perftest/common-overlay/am/kustomization.yaml
+++ b/k8s/perftest/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/am/am-org-role-mapping-service/perftest.yaml

--- a/k8s/perftest/common-overlay/bsp/kustomization.yaml
+++ b/k8s/perftest/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
 - ../../../namespaces/bsp
+- ../../../namespaces/bsp/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/bsp/bulk-scan-processor/perftest.yaml

--- a/k8s/prod/common-overlay/aac/kustomization.yaml
+++ b/k8s/prod/common-overlay/aac/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: aac
 bases:
 - ../../../namespaces/aac
+- ../../../namespaces/aac/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/aac/manage-case-assignment/prod.yaml

--- a/k8s/prod/common-overlay/am/kustomization.yaml
+++ b/k8s/prod/common-overlay/am/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: am
 bases:
 - ../../../namespaces/am
+- ../../../namespaces/am/namespace.yaml
 patchesStrategicMerge:
 - ../../../namespaces/am/am-org-role-mapping-service/prod.yaml
 - ../../../namespaces/am/am-role-assignment-service/prod.yaml

--- a/k8s/prod/common-overlay/bsp/kustomization.yaml
+++ b/k8s/prod/common-overlay/bsp/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: bsp
 bases:
   - ../../../namespaces/bsp
+  - ../../../namespaces/bsp/namespace.yaml
 patchesStrategicMerge:
   - ../../../namespaces/bsp/bulk-scan-payment-processor/prod.yaml
   - ../../../namespaces/bsp/bulk-scan-processor/prod.yaml


### PR DESCRIPTION
For Perftest Migration to Flux 2, splitting ns deployment from app deployments - so all ns can be moved to v2.
Already tested on namespaces previously
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
