### PR TITLE
dg docassmbly already deployed from dg folder

### DIFF
--- a/apps/money-claims/automation/kustomization.yaml
+++ b/apps/money-claims/automation/kustomization.yaml
@@ -14,8 +14,6 @@ resources:
   - ../cmc-legal-frontend/image-repo.yaml
   - ../cmc-legal-frontend/demo-image-policy.yaml
   - ../cmc-legal-frontend/image-policy.yaml
-  - ../dg-docassembly/image-repo.yaml
-  - ../dg-docassembly/image-policy.yaml
   - ../cmc-s2s/image-repo.yaml
   - ../cmc-s2s/image-policy.yaml
   - ../cmc-draft-store/image-repo.yaml


### PR DESCRIPTION
dg-docassembly image automation removed from money-claims
Duplicated as already in dg/automation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
