### PR TITLE
Remove image automation duplicates

### DIFF
--- a/apps/money-claims/automation/kustomization.yaml
+++ b/apps/money-claims/automation/kustomization.yaml
@@ -6,8 +6,6 @@ resources:
   - ../cmc-claim-store/image-repo.yaml
   - ../cmc-claim-store/demo-image-policy.yaml
   - ../cmc-claim-store/image-policy.yaml
-  - ../pdf-service/image-repo.yaml
-  - ../pdf-service/image-policy.yaml
   - ../cmc-citizen-frontend/image-repo.yaml
   - ../cmc-citizen-frontend/demo-image-policy.yaml
   - ../cmc-citizen-frontend/image-policy.yaml
@@ -18,5 +16,3 @@ resources:
   - ../cmc-s2s/image-policy.yaml
   - ../cmc-draft-store/image-repo.yaml
   - ../cmc-draft-store/image-policy.yaml
-  - ../rpe-send-letter-service/image-repo.yaml
-  - ../rpe-send-letter-service/image-policy.yaml

--- a/apps/money-claims/pdf-service/image-policy.yaml
+++ b/apps/money-claims/pdf-service/image-policy.yaml
@@ -1,7 +1,0 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
-kind: ImagePolicy
-metadata:
-  name: pdf-service
-spec:
-  imageRepositoryRef:
-    name: pdf-service

--- a/apps/money-claims/pdf-service/image-repo.yaml
+++ b/apps/money-claims/pdf-service/image-repo.yaml
@@ -1,6 +1,0 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
-kind: ImageRepository
-metadata:
-  name: pdf-service
-spec:
-  image: hmctspublic.azurecr.io/rpe/pdf-service

--- a/apps/money-claims/rpe-send-letter-service/image-policy.yaml
+++ b/apps/money-claims/rpe-send-letter-service/image-policy.yaml
@@ -1,7 +1,0 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
-kind: ImagePolicy
-metadata:
-  name: rpe-send-letter-service
-spec:
-  imageRepositoryRef:
-    name: rpe-send-letter-service

--- a/apps/money-claims/rpe-send-letter-service/image-repo.yaml
+++ b/apps/money-claims/rpe-send-letter-service/image-repo.yaml
@@ -1,6 +1,0 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
-kind: ImageRepository
-metadata:
-  name: rpe-send-letter-service
-spec:
-  image: hmctspublic.azurecr.io/rpe/send-letter-service

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -20,12 +20,11 @@ EXCLUSIONS_LIST=(
   apps/idam/idam-web-public/sbox.yaml
   *demo.yaml
   k8s/demo/*
-  apps/*/*/demo-image-policy.yaml
-  apps/*/*/perftest-image-policy.yaml
-  apps/*/*/test-image-policy.yaml
-  apps/*/*/ithc-image-policy.yaml
-  apps/*/*/sandbox-image-policy.yaml
-  apps/em/em-showcase/perftest-image-policy.yaml
+  *demo-image-policy.yaml
+  *perftest-image-policy.yaml
+  *test-image-policy.yaml
+  *ithc-image-policy.yaml
+  *sandbox-image-policy.yaml
 )
 
 EXCLUSIONS=$(IFS="|" ; echo "${EXCLUSIONS_LIST[*]}")

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -20,11 +20,11 @@ EXCLUSIONS_LIST=(
   apps/idam/idam-web-public/sbox.yaml
   *demo.yaml
   k8s/demo/*
-  apps/*/*/demo-image-policy.yaml
-  apps/*/*/perftest-image-policy.yaml
-  apps/*/*/test-image-policy.yaml
-  apps/*/*/ithc-image-policy.yaml
-  apps/*/*/sandbox-image-policy.yaml
+  *demo-image-policy.yaml
+  *perftest-image-policy.yaml
+  *test-image-policy.yaml
+  *ithc-image-policy.yaml
+  *sandbox-image-policy.yaml
   apps/em/em-showcase/perftest-image-policy.yaml
 )
 

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -20,11 +20,7 @@ EXCLUSIONS_LIST=(
   apps/idam/idam-web-public/sbox.yaml
   *demo.yaml
   k8s/demo/*
-  *demo-image-policy.yaml
-  *perftest-image-policy.yaml
-  *test-image-policy.yaml
-  *ithc-image-policy.yaml
-  *sandbox-image-policy.yaml
+  k8s/perftest/*
 )
 
 EXCLUSIONS=$(IFS="|" ; echo "${EXCLUSIONS_LIST[*]}")

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -20,6 +20,11 @@ EXCLUSIONS_LIST=(
   apps/idam/idam-web-public/sbox.yaml
   *demo.yaml
   k8s/demo/*
+  apps/*/*/demo-image-policy.yaml
+  apps/*/*/perftest-image-policy.yaml
+  apps/*/*/test-image-policy.yaml
+  apps/*/*/ithc-image-policy.yaml
+  apps/*/*/sandbox-image-policy.yaml
 )
 
 EXCLUSIONS=$(IFS="|" ; echo "${EXCLUSIONS_LIST[*]}")

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -20,7 +20,10 @@ EXCLUSIONS_LIST=(
   apps/idam/idam-web-public/sbox.yaml
   *demo.yaml
   k8s/demo/*
+  *perftest.yaml
   k8s/perftest/*
+  k8s/ithc/*
+  *ithc.yaml
 )
 
 EXCLUSIONS=$(IFS="|" ; echo "${EXCLUSIONS_LIST[*]}")

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -20,11 +20,11 @@ EXCLUSIONS_LIST=(
   apps/idam/idam-web-public/sbox.yaml
   *demo.yaml
   k8s/demo/*
-  *demo-image-policy.yaml
-  *perftest-image-policy.yaml
-  *test-image-policy.yaml
-  *ithc-image-policy.yaml
-  *sandbox-image-policy.yaml
+  apps/*/*/demo-image-policy.yaml
+  apps/*/*/perftest-image-policy.yaml
+  apps/*/*/test-image-policy.yaml
+  apps/*/*/ithc-image-policy.yaml
+  apps/*/*/sandbox-image-policy.yaml
   apps/em/em-showcase/perftest-image-policy.yaml
 )
 

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -25,6 +25,7 @@ EXCLUSIONS_LIST=(
   apps/*/*/test-image-policy.yaml
   apps/*/*/ithc-image-policy.yaml
   apps/*/*/sandbox-image-policy.yaml
+  apps/em/em-showcase/perftest-image-policy.yaml
 )
 
 EXCLUSIONS=$(IFS="|" ; echo "${EXCLUSIONS_LIST[*]}")


### PR DESCRIPTION
Remove these from money-claims as they are already deployed from rpe
Exclusions added as tests were failing because of a perftest- image
Duplicate image policies also removed
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
