### PR TITLE
Disable prometheus metrics log analytics ingestion

### DIFF
--- a/apps/kube-system/container-azm-ms-agentconfig/container-azm-ms-agentconfig.yaml
+++ b/apps/kube-system/container-azm-ms-agentconfig/container-azm-ms-agentconfig.yaml
@@ -50,7 +50,7 @@ data:
         #     set this to `https` & most likely set the tls config.
         # - prometheus.io/path: If the metrics path is not /metrics, define it with this annotation.
         # - prometheus.io/port: If port is not 9102 use this annotation
-        monitor_kubernetes_pods = true
+        monitor_kubernetes_pods = false
 
     [prometheus_data_collection_settings.node]
         # Node level scrape endpoint(s). These metrics will be scraped from agent's DaemonSet running in every node in the cluster


### PR DESCRIPTION
This scraping is incurring significant ingestion charges and consists largely of verbose DNS statistics
