### PR TITLE
Flux Git sync Timeout increase

### DIFF
--- a/apps/flux-system/base/flux-config-gitrepo.yaml
+++ b/apps/flux-system/base/flux-config-gitrepo.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m0s
+  timeout: 3m0s
   ref:
     branch: master
   secretRef:


### PR DESCRIPTION
### Change description ###
Flux git sync timeout increase from default 20s to 3m.
Test to see if this fixes issues with failing [git reconciliation issue](https://github.com/fluxcd/source-controller/issues/439#issuecomment-946543966).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
