### PR TITLE
DTSPO-5286 - image-automation-controller memory upgrade patch

### DIFF
--- a/apps/flux-system/base/patches/image-automation-components-patch.yaml
+++ b/apps/flux-system/base/patches/image-automation-components-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-automation-controller
+  namespace: flux-system
+spec:
+  selector:
+    matchLabels:
+      app: image-automation-controller
+  template:
+    spec:
+      containers:
+        - name: manager
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 2Gi

--- a/apps/flux-system/ptl-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/ptl-intsvc/base/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - ../../base/image-update-automation.yaml
   - git-credentials.yaml
   - ../../automation
+
+patchesStrategicMerge:
+  - ../../base/patches/image-automation-components-patch.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5286


### Change description ###
added patch to upgrade image automation controller memory to 2G


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
