### PR TITLE
DTSPO-5164 - added unit to timeout to fix flux-v2 issue

### DIFF
--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: neuvector
 spec:
   releaseName: neuvector
-  timeout: "900"
+  timeout: "900s"
   values:
     config:
       autoScan: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5164


### Change description ###
Added missing unit to timeout to fix issue seen in flux-v2 helm operator logs.
![image](https://user-images.githubusercontent.com/22701260/138449354-82977a88-e92d-43ac-ab55-8719eaaa6360.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
