### PR TITLE
DTSPO-5164 - fixing flux v2 issue - aks-addon-exception missing namespace 

### DIFF
--- a/apps/kube-system/aad-pod-id/mic-exception.yaml
+++ b/apps/kube-system/aad-pod-id/mic-exception.yaml
@@ -2,6 +2,7 @@ apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzurePodIdentityException
 metadata:
   name: aks-addon-exception
+  namespace: kube-system
 spec:
   podLabels:
     kubernetes.azure.com/managedby: aks


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5164


### Change description ###
Added missing namespace to aks-addon-exception to fix issue seen in flux-v2 kustomize controller logs.
![image](https://user-images.githubusercontent.com/22701260/138468404-c2a3caa6-fef3-4abc-bd80-092b44794acc.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
