### PR TITLE
Added adoption namespace and managed-identity

### DIFF
--- a/apps/adoption/base/kustomization.yaml
+++ b/apps/adoption/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: adoption

--- a/apps/adoption/base/kustomize.yaml
+++ b/apps/adoption/base/kustomize.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+kind: Kustomization
+metadata:
+  name: adoption
+  namespace: flux-system
+spec:
+  path: ./apps/adoption/${ENVIRONMENT}
+  postBuild:
+    substitute:
+      NAMESPACE: "adoption"
+      TEAM_NOTIFICATION_CHANNEL: "adoption-tech"

--- a/apps/adoption/demo/base/kustomization.yaml
+++ b/apps/adoption/demo/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: adoption

--- a/apps/adoption/identity/identity.yaml
+++ b/apps/adoption/identity/identity.yaml
@@ -1,0 +1,18 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: adoption
+  namespace: adoption
+spec:
+  type: 0
+
+---
+
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: adoption-binding
+  namespace: adoption
+spec:
+  azureIdentity: adoption
+  selector: adoption


### PR DESCRIPTION
Added namespace and managed-identity for adoption applications

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ADOP-10


### Change description ###
Added namespace and managed-identity for adoption applications so that the PR builder can pass the **_AKS deploy - preview_** stage


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No
