### PR TITLE
Flux Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Please see [Repo setup](docs/repo-setup.md) for details on how this repo is orga
 
 ## Adding an app to flux
 
-All App deployments are managed through `HelmRelease` manifests. 
-Depending on the [Migration Status](#Migration-status) and the environment you are adding your config to, refer to [v2 setup](docs/app-deployment-v2.md) or/and [v1 setup](docs/app-deployment.md).
+All App deployments are managed through `HelmRelease` manifests.  See [App Deployment section](docs/app-deployment.md) for more details.    
+
 
 ## Creating Sealed Secrets
 

--- a/docs/app-deployment-v2.md
+++ b/docs/app-deployment-v2.md
@@ -1,7 +1,7 @@
 
 # Application Configuration
 
->Note: Depending on the [Migration Status](/README.md#Migration-status) and the environment you are adding config, you should also do [v1 setup](app-deployment.md)
+>Note: Only use for Flux v2 applications
 
 The section covers how to configure a new application in this repository to deploy to various environments. We use [kustomize](https://github.com/kubernetes-sigs/kustomize) for templating/patching manifests in this repo. 
 

--- a/docs/app-deployment.md
+++ b/docs/app-deployment.md
@@ -1,8 +1,6 @@
 
 # Application Configuration
 
->Note: Depending on the [Migration Status](/README.md#Migration status) and the environment you are adding config, you should also do [v2 setup](app-deployment-v2.md)
-
 The section covers how to configure a new application in this repository to deploy to various environments. We use [kustomize](https://github.com/kubernetes-sigs/kustomize) for templating/patching manifests in this repo. 
 
 **It is important to follow below discussed naming convention, file and folder names should match application helm release name**


### PR DESCRIPTION

### Change description ###
Documentation updated to remove flux v2 application configuration links and prevent teams from prematurely adding apps to Flux v2 prior to environment migration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
