### PR TITLE
DTSPO-5132 - Update Image-Automation Controller to use Pre-release Image

### DIFF
--- a/apps/flux-system/base/image-automation-components.yaml
+++ b/apps/flux-system/base/image-automation-components.yaml
@@ -2005,9 +2005,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # TODO https://github.com/fluxcd/image-automation-controller/pull/238
-        # see https://github.com/fluxcd/source-controller/issues/439#issuecomment-943580625
-        image: docker.io/hiddeco/image-automation-controller:libgit2-free-e9bdffc
+        # TODO https://github.com/fluxcd/image-automation-controller/pull/239
+        # see https://github.com/fluxcd/source-controller/issues/439#issuecomment-951806557
+        image: docker.io/hiddeco/image-automation-controller:sc-git-update-9ef9856
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Updating to use [pre-release image](https://github.com/fluxcd/source-controller/issues/439#issuecomment-951806557) to test ssh timeout issue fix.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
