### PR TITLE
Fix duplicate finrem-ps on perftest

### DIFF
--- a/k8s/perftest/common-overlay/financial-remedy/kustomization.yaml
+++ b/k8s/perftest/common-overlay/financial-remedy/kustomization.yaml
@@ -4,7 +4,6 @@ namespace: financial-remedy
 bases:
 - ../../../namespaces/financial-remedy
 - ../../../namespaces/financial-remedy/namespace.yaml
-- ../../../namespaces/financial-remedy/finrem-ps/finrem-ps.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesJson6902:
 - target:


### PR DESCRIPTION
error="getting unlocked automated resources: duplicate definition of 'financial-remedy:helmrelease/finrem-ps' (generated by k8s/perftest/common-overlay/.flux.yaml and in k8s/perftest/common/financial-remedy/finrem-ps.yaml)"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
