### PR TITLE
Preview - quota - fix as expecting string

### DIFF
--- a/apps/money-claims/preview/base/resource-limits.yaml
+++ b/apps/money-claims/preview/base/resource-limits.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: money-claims
 spec:
   hard:
-    requests.cpu: 50  #Using ~ 72 currently
+    requests.cpu: "50"  #Using ~ 72 currently
     requests.memory: 140Gi  #Using ~ 200Gi Currently


### PR DESCRIPTION
Reconciliation failed - ResourceQuota/money-claims/money-claims-quota dry-run failed, error: failed to create typed patch object: .spec.hard.requests.cpu: expected string, got &value.valueUnstructured{Value:50}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
