### PR TITLE
DTSPO-5163 - Updates to fix Dynatrace and Botkube Chart sources sync issues

### DIFF
--- a/apps/monitoring/botkube/botkube.yaml
+++ b/apps/monitoring/botkube/botkube.yaml
@@ -6,9 +6,10 @@ metadata:
   namespace: monitoring
 spec:
   releaseName: botkube
+  interval: 5m
   chart:
     spec:
-      chart: botkube
+      chart: helm/botkube
       sourceRef:
         name: botkube
         kind: GitRepository

--- a/apps/monitoring/dynatrace/oneagent.yaml
+++ b/apps/monitoring/dynatrace/oneagent.yaml
@@ -6,9 +6,10 @@ metadata:
   namespace: monitoring
 spec:
   releaseName: oneagent-operator
+  interval: 5m
   chart:
     spec:
-      chart: dynatrace/dynatrace-oneagent-operator
+      chart: dynatrace-oneagent-operator
       version: 0.10.2
       sourceRef:
         name: dynatrace-oneagent-operator


### PR DESCRIPTION
### Change description ###
Added mandatory interval to HelmRelease spec
Updated botkube chart part to point to GitRepo chart path - as per Helm Release spec
Updated oneagent to remove invalid chart name


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
