### PR TITLE
RDM-12932 - Revert "disabled DOCUMENT_HASH_CLONE"

### DIFF
--- a/k8s/namespaces/ccd/ccd-data-store-api/prod.yaml
+++ b/k8s/namespaces/ccd/ccd-data-store-api/prod.yaml
@@ -28,4 +28,3 @@ spec:
         IDAM_API_BASE_URL: https://idam-api.platform.hmcts.net
         IDAM_OIDC_URL: https://hmcts-access.service.gov.uk
         LOGGING_LEVEL_UK_GOV_HMCTS_CCD_SECURITY_FILTERS: DEBUG
-        DOCUMENT_HASH_CLONE_ENABLED: false


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#12340