### PR TITLE
Removal of env variable AZURE_STORAGE_IMPORT_AUDITS_GET_LIMIT

### DIFF
--- a/k8s/namespaces/ccd/ccd-definition-store-api/ithc.yaml
+++ b/k8s/namespaces/ccd/ccd-definition-store-api/ithc.yaml
@@ -10,7 +10,6 @@ spec:
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v11-ithc.postgres.database.azure.com
         DEFINITION_STORE_DB_USERNAME: ccd@ccd-definition-store-api-postgres-db-v11-ithc
         DEFINITION_STORE_DB_MAX_POOL_SIZE: 25
-        AZURE_STORAGE_IMPORT_AUDITS_GET_LIMIT: 0
         FLYWAY_NOOP_STRATEGY: true
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp,aac_manage_case_assignment,em_hrs_api
         DUMMY_VAR: 1


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-572

### Change description ###

Removal of AZURE_STORAGE_IMPORT_AUDITS_GET_LIMIT from k8s/namespaces/ccd/ccd-definition-store-api/ithc.yaml to test the fix in https://github.com/hmcts/ccd-definition-store-api/pull/1095

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
