### PR TITLE
remove rbac for v2 ns - demo, perftest

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/demo-role-binding.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/demo-role-binding.yaml
@@ -12,21 +12,21 @@ subjects:
     namespace: admin
     kind: ServiceAccount
 
----
+# ---
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: flux-helm-operator
+#   namespace: admin
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: flux-helm-operator
+# subjects:
+#   - name: flux-helm-operator
+#     namespace: admin
+#     kind: ServiceAccount
 
 ---
 
@@ -83,22 +83,6 @@ kind: RoleBinding
 metadata:
   name: flux-helm-operator
   namespace: camunda
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: catalog
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -258,22 +242,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
-  namespace: etcd
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
   namespace: ethos
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -402,22 +370,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
-  namespace: kured
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
   namespace: lau
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -450,39 +402,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
-  namespace: monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
   namespace: nfdiv
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: osba
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/k8s/namespaces/admin/flux-helm-operator/rbac/perftest-role-binding.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/perftest-role-binding.yaml
@@ -12,21 +12,21 @@ subjects:
     namespace: admin
     kind: ServiceAccount
 
----
+# ---
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: RoleBinding
+# metadata:
+#   name: flux-helm-operator
+#   namespace: admin
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: flux-helm-operator
+# subjects:
+#   - name: flux-helm-operator
+#     namespace: admin
+#     kind: ServiceAccount
 
 ---
 
@@ -338,22 +338,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
-  namespace: kured
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
   namespace: lau
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -371,38 +355,6 @@ kind: RoleBinding
 metadata:
   name: flux-helm-operator
   namespace: money-claims
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: neuvector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
V1 rbac removed from v2 namespaces
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
