### PR TITLE
Demo, traefik - Remove force upgrade as not in new helm version

### DIFF
--- a/apps/admin/traefik/demo/traefik.yaml
+++ b/apps/admin/traefik/demo/traefik.yaml
@@ -4,7 +4,6 @@ metadata:
   name: traefik
   namespace: admin
 spec:
-  forceUpgrade: true
   # valueFileSecrets:
   #   - name: "traefik-values"
   values:


### PR DESCRIPTION
"error":"HelmRelease/admin/traefik dry-run failed, error: failed to create typed patch object: .spec.forceUpgrade: field not declared in schema

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
