### PR TITLE
DTSPO-5156 - AAT - Removed rbac rolebindings for flux-helm-operator on admin apps

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/aat-role-binding.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/aat-role-binding.yaml
@@ -18,22 +18,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
-  namespace: admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
   namespace: adoption
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -395,23 +379,6 @@ subjects:
   - name: flux-helm-operator
     namespace: admin
     kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: kured
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -435,38 +402,6 @@ kind: RoleBinding
 metadata:
   name: flux-helm-operator
   namespace: money-claims
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
-  namespace: neuvector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5156


### Change description ###
Removed flux v1 flux-helm-operator rolebindings on admin, neuvector, kured and monitoring namespaces. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
