### PR TITLE
Add private-law to helm op v1 aat/demo perms

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/aat-role-binding.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/aat-role-binding.yaml
@@ -514,6 +514,22 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
+  namespace: private-law
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux-helm-operator
+subjects:
+  - name: flux-helm-operator
+    namespace: admin
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-helm-operator
   namespace: probate
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/k8s/namespaces/admin/flux-helm-operator/rbac/demo-role-binding.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/demo-role-binding.yaml
@@ -434,6 +434,22 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
+  namespace: private-law
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux-helm-operator
+subjects:
+  - name: flux-helm-operator
+    namespace: admin
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux-helm-operator
   namespace: probate
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
DTSPO-5549
Give perms to new private-law ns to v1 helm op - were split out by namespace to enable current v2 migration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
