### PR TITLE
missing flux v2 resource rbac

### DIFF
--- a/apps/rbac/edit-clusterrole.yaml
+++ b/apps/rbac/edit-clusterrole.yaml
@@ -29,6 +29,9 @@ rules:
 - apiGroups: ['helm.fluxcd.io']
   resources: ['helmreleases']
   verbs: ['create', 'update', 'delete', 'watch', 'list', 'get']
+- apiGroups: ['helm.toolkit.fluxcd.io']
+  resources: ['helmreleases']
+  verbs: ['create', 'update', 'delete', 'watch', 'list', 'get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Was previously added to reader-clusterrole, but preview uses edit-clusterrole

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
