### PR TITLE
Flux flag removed as deprecated

### DIFF
--- a/apps/flux-system/base/kustomize.yaml
+++ b/apps/flux-system/base/kustomize.yaml
@@ -10,5 +10,4 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-config
-  validation: client
   path: ./clusters/${ENVIRONMENT}/${CLUSTER}


### PR DESCRIPTION
Removing validation flag as deprecated on new flux version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
