### PR TITLE
DTSPO-5163- Botkube GitRepo HTTP Access

### DIFF
--- a/apps/monitoring/botkube/botkube-helmrepo.yaml
+++ b/apps/monitoring/botkube/botkube-helmrepo.yaml
@@ -4,9 +4,7 @@ metadata:
   name: botkube
   namespace: monitoring
 spec:
-  url: ssh://git@github.com/infracloudio/botkube
-  secretRef:
-    name: git-credentials
+  url: https://github.com/infracloudio/botkube
   ref:
     branch: develop
   ignore: |


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5163


### Change description ###
Change botkube git repo to http access to confirm github credentials is not required.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
