### PR TITLE
Changing schedule for Cron in prod to business hours only

### DIFF
--- a/k8s/namespaces/wa/wa-task-batch-configuration/prod-00.yaml
+++ b/k8s/namespaces/wa/wa-task-batch-configuration/prod-00.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 * * * *"
+      schedule: "0 8-18 * * 1-5"
       environment:
         JOB_NAME: CONFIGURATION
     global:


### PR DESCRIPTION
Changing the schedule for the WA Configuration CronJob to run every hour 8am to 6pm Mon-Friday.