### PR TITLE
Add env vars as cron jobs failing to start

### DIFF
--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/aat-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/aat-00.yaml
@@ -11,3 +11,6 @@ spec:
         BULK_ACTION_BATCH_SIZE_MIN: 3
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: aat

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/demo-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/demo-00.yaml
@@ -7,3 +7,6 @@ spec:
   values:
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: demo

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/ithc-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/ithc-00.yaml
@@ -7,3 +7,6 @@ spec:
   values:
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: ithc

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/perftest-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/perftest-00.yaml
@@ -9,3 +9,6 @@ spec:
       suspend: true
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: perftest

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/aat-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/aat-00.yaml
@@ -11,3 +11,6 @@ spec:
         BULK_ACTION_BATCH_SIZE_MIN: 3
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: aat

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/demo-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/demo-00.yaml
@@ -7,3 +7,6 @@ spec:
   values:
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: demo

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/ithc-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/ithc-00.yaml
@@ -7,3 +7,6 @@ spec:
   values:
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: ithc

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/perftest-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/perftest-00.yaml
@@ -9,3 +9,6 @@ spec:
       suspend: true
     global:
       jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: perftest


### PR DESCRIPTION
### Change description ###
Add env vars, env var is not set for the job - NFDIV cron jobs have failed to start

Error -
  Warning  FailedMount  2m12s (x501 over 13h)  kubelet  (combined from similar events): MountVolume.SetUp failed for volume "vault-nfdiv" : rpc error: code = Unknown desc = error mounting secret time="2021-11-12T10:14:10Z" level=fatal msg="[error] : failed to get objectType:secret, objectName:AppInsightsInstrumentationKey, objectVersion:: keyvault.BaseClient#GetSecret: Failure sending request: StatusCode=0 -- Original Error: Get \"https://nfdiv-.vault.azure.net/secrets/AppInsightsInstrumentationKey/?api-version=2016-10-01\": dial tcp: lookup nfdiv-.vault.azure.net: no such host"
 for pod: nfdiv/nfdiv-cron-process-cases-to-be-removed-job-1636647600-nbdlp


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
