### PR TITLE
Neuvector - remove flag as it was unique to 1 cluster

### DIFF
--- a/k8s/namespaces/neuvector/patches/prod/cluster-00/neuvector.yaml
+++ b/k8s/namespaces/neuvector/patches/prod/cluster-00/neuvector.yaml
@@ -24,7 +24,6 @@ spec:
           update: '{"config":{"id":7,"comment":"","from":"AllPods","to":"Mta","ports":"tcp/25","action":"allow","applications":[],"disable":false}}'
         - create: '{"insert":{"after":7,"rules":[{"id":8,"comment":"","from":"AllPods","to":"Idam","ports":"tcp/443","action":"allow","applications":["SSL"],"disable":true,"learned": false}]}}'
           update: '{"config":{"id":8,"comment":"","from":"AllPods","to":"Idam","ports":"tcp/443","action":"allow","applications":["SSL"],"disable":true}}'
-    redeploy: true
     neuvector:
       controller:
         azureFileShare:


### PR DESCRIPTION
This is unique to prod 00, seems to have been added to try to force a neuvector redeploy in the past - but want to remove it as it is only set here and want to rule this out as there is a difference with neuvector on prod 00

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
