### PR TITLE
DTSPO-2277 - Grant flux v1 helm operator rbac permissions to allow neuvector hr update

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
@@ -36,6 +36,15 @@ rules:
     resources: ['customresourcedefinitions']
     verbs:
       - create
+  - apiGroups: ['*']
+    resources: ['clusterroles']
+    verbs:
+      - bind
+      - create
+  - apiGroups: ['*']
+    resources: ['clusterrolebindings']
+    verbs:
+      - create
   - nonResourceURLs: ['*']
     verbs: ['*']
 ---


### PR DESCRIPTION
### Change description ###
Temporarily adding cluster and clusterrole bindings rbac permission to flux-helm-operator


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
