### PR TITLE
DTSPO-2277 - Revert Flux v1 Helm Operator RBAC and grant permission on prod01

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac-prod.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac-prod.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-helm-operator-ro
+rules:
+  - apiGroups: ['*']
+    resources: ['*']
+    verbs: ['*']
+
+  - nonResourceURLs: ['*']
+    verbs: ['*']

--- a/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
@@ -32,22 +32,7 @@ rules:
       - get
       - watch
       - list
-  - apiGroups: ['*']
-    resources: ['customresourcedefinitions']
-    verbs:
-      - create
-  - apiGroups: ['*']
-    resources: ['clusterroles']
-    verbs:
-      - bind
-      - create
-  - apiGroups: ['*']
-    resources: ['clusterrolebindings']
-    verbs:
-      - create
-  - apiGroups: ['neuvector.com']
-    resources: ['*']
-    verbs: ['*']
+
   - nonResourceURLs: ['*']
     verbs: ['*']
 ---

--- a/k8s/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/kustomization.yaml
@@ -34,6 +34,7 @@ patchesStrategicMerge:
   - ../../namespaces/admin/flux/patches/prod/flux.yaml
   - ../../namespaces/admin/flux/patches/prod/cluster-01/flux.yaml
   - ../../namespaces/admin/flux-helm-operator/patches/disable-rbac.yaml
+  - ../../namespaces/admin/flux-helm-operator/rbac/read-only-rbac-prod.yaml
 
   # fluxcloud patch
   - ../../namespaces/admin/fluxcloud/patches/prod/cluster-01/fluxcloud.yaml


### PR DESCRIPTION
### Change description ###
Revert custom rbac permission changes in previous PRs ([PR-12749](https://github.com/hmcts/cnp-flux-config/pull/12749), [PR-12751](https://github.com/hmcts/cnp-flux-config/pull/12751) and [PR-12752](https://github.com/hmcts/cnp-flux-config/pull/12752))
Adding full permission for flux-helm-operator to allow neuvector hr reinstall


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
