### PR TITLE
DTSPO-5498 Fix jenkins config

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -590,7 +590,7 @@ spec:
                       \ -XX:+AlwaysPreTouch -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled\
                       \ -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions\
                       \ -XX:G1SummarizeRSetStatsPeriod=1"
-                        label: "ubuntu"
+                        labels: "ubuntu"
                         location: "UK South"
                         noOfParallelJobs: 1
                         osDiskSize: 60


### PR DESCRIPTION
> Caused by: io.jenkins.plugins.casc.ConfiguratorException: Invalid configuration elements for type class com.microsoft.azure.vmagent.AzureVMAgentTemplate : label.
Available attributes : agentLaunchMethod, agentWorkspace, availabilityType, builtInImage, credentialsId, diskType, doNotUseMachineIfInitFails, enableMSI, enableUAMI, ephemeralOSDisk, executeInitScriptAsRoot, existingStorageAccountName, imageReference, imageTopLevelType, initScript, installDocker, installGit, installMaven, javaPath, jvmOptions, labels, location, newStorageAccountName, noOfParallelJobs, nsgName, osDiskSize, osDiskStorageAccountType, osType, preInstallSsh, retentionStrategy, shutdownOnIdle, spotInstance, storageAccountName, storageAccountNameReferenceType, storageAccountType, subnetName, templateDesc, templateDisabled, templateName, templateProvisionStrategy, templateStatusDetails, templateVerified, terminateScript, uamiID, usageMode, usePrivateIP, virtualMachineSize, virtualNetworkName, virtualNetworkResourceGroupName
	at io.jenkins.plugins.casc.BaseConf