### PR TITLE
DTSPO-5498 Set bash as default shell

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -310,6 +310,10 @@ spec:
               location:
                 adminAddress: jenkins-reform@hmcts.net
                 url: 'https://build.platform.hmcts.net'
+          shell: |
+            unclassified:
+              shell:
+                shell: "/bin/bash"
           azure-key-vault: |
             unclassified:
               azureKeyVault:


### PR DESCRIPTION
Centos agents seem to have /bin/sh as a bash shell whereas ubuntu doesn't and the pipeline relies on bash for at least nvm.

We can change on a per step basis if required, but let's try this first I think it should be safe