### PR TITLE
remove admin rbac from helm op v1 for migration safety

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/prod-role-binding.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/prod-role-binding.yaml
@@ -18,22 +18,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flux-helm-operator
-  namespace: admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: flux-helm-operator
-subjects:
-  - name: flux-helm-operator
-    namespace: admin
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: flux-helm-operator
   namespace: am
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
(will be added back in after v2 migration for use by flux/fluxcloud/helmop v1)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
