### PR TITLE
Add AM identity to SSCS for upcoming Access Control changes

### DIFF
--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../rpe/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../em/identity/identity.yaml
+  - ../../../am/identity/identity.yaml
 namespace: sscs
 patchesStrategicMerge:
   - ../../identity/aat.yaml
@@ -14,3 +15,4 @@ patchesStrategicMerge:
   - ../../../rpe/identity/aat.yaml
   - ../../../ccd/identity/aat.yaml
   - ../../../em/identity/aat.yaml
+  - ../../../am/identity/aat.yaml


### PR DESCRIPTION
### Change description ###
As part of upcoming CCD changes chart-ccd will require the Role Assignment Service, which needs the AM key vault.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
