### PR TITLE
Add AM identity to NFDIV for upcoming Access Control changes

### DIFF
--- a/apps/nfdiv/preview/base/kustomization.yaml
+++ b/apps/nfdiv/preview/base/kustomization.yaml
@@ -4,7 +4,9 @@ resources:
   - ../../../base   # This is apps/base instead of apps/nfdiv/base as preview doesn't install everything
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
+  - ../../../am/identity/identity.yaml
 namespace: nfdiv
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../../xui/identity/aat.yaml
+  - ../../../am/identity/aat.yaml


### PR DESCRIPTION
### Change description ###
As part of upcoming CCD changes chart-ccd will require the Role Assignment Service, which needs the AM key vault.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
