### PR TITLE
global_search on demo ac int

### DIFF
--- a/apps/ccd/ccd-ac-int-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-ac-int-data-store-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1676-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1745-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/k8s/demo/common/ccd/ac-int-data-store-api.yaml
+++ b/k8s/demo/common/ccd/ac-int-data-store-api.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 1
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-1676-5260ccb-20211014122019 #{"$imagepolicy": "flux-system:demo-ccd-ac-int-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-1745-e38d229-20211130112559 #{"$imagepolicy": "flux-system:demo-ccd-ac-int-data-store-api"}
       ingressHost: ccd-ac-int-data-store-api-demo.service.core-compute-demo.internal
       environment:
         DEFINITION_STORE_HOST: http://ccd-ac-int-definition-store-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RDM-12948](https://tools.hmcts.net/jira/browse/RDM-12948)

### Change description ###

Switch global_search DEMO AC-INT to point to a different PR to allow redeployment whilst we wait for a combined AC/GS version to be available.

NB: This data-store PR is based on the last green build for PR hmcts/ccd-data-store-api#1676 (5260ccb run 7).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
