### PR TITLE
temporarily added dynatrace crd to sbox

### DIFF
--- a/apps/monitoring/sbox/base/kustomization.yaml
+++ b/apps/monitoring/sbox/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - prometheus-values.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/dynatrace.com_dynakubes.yaml
 
 patchesStrategicMerge:
   - ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-5703

### Change description ###

Temporarily added Dynatrace CRD to sbox env to test whether it will successfully be deployed in AKS version 1.20.*. 

It fails to deploy in perftest which is currently on AKS version 1.19 and according to documentation should work in version 1.20. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
