### PR TITLE
Revert "re-enabled dynatrace cluster role in Perftest"

### DIFF
--- a/apps/monitoring/dynatrace/perftest/dynatrace-cluster-role.yaml
+++ b/apps/monitoring/dynatrace/perftest/dynatrace-cluster-role.yaml
@@ -1,8 +1,8 @@
-# apiVersion: v1
-# kind: ServiceAccount
-# metadata:
-#   name: dynatrace-operator
-#   namespace: monitoring
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dynatrace-operator
+  namespace: monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/apps/monitoring/dynatrace/perftest/kustomization.yaml
+++ b/apps/monitoring/dynatrace/perftest/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - dynatrace-cluster-role.yaml
+  # - dynatrace-cluster-role.yaml
   - ../dynatrace-operator/dynatrace-operator.yaml
   - ../dynatrace-operator/dynatrace-operator-helmrepo.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#13194