### PR TITLE
CCD-2331: Remove case-management-web from build dashboards

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -101,13 +101,13 @@ spec:
                     title: RPX-PR
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_CDM.*\/(?!.*ccd-admin-web-api).+\/master
+                      ^HMCTS_CDM.*\/(?!.*ccd-admin-web-api|.*ccd-case-management-web).+\/master
                     name: CDM
                     recurse: true
                     title: CDM Master Builds Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_Nightly.*CDM.*\/(?!.*ccd-admin-web-api).+\/master
+                      ^HMCTS_Nightly.*CDM.*\/(?!.*ccd-admin-web-api|.*ccd-case-management-web).+\/master
                     name: CDM Nightly
                     recurse: true
                     title: CDM Nightly Builds Dashboard


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2331 (https://tools.hmcts.net/jira/browse/CCD-2331)


### Change description ###
- Updated configuration to exclude ccd-case-management-web repository from build dashboards.  Repository is redundant following decommissioning of CCD-UI.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
