### PR TITLE
Add cmc identity to civil

### DIFF
--- a/apps/civil/preview/base/kustomization.yaml
+++ b/apps/civil/preview/base/kustomization.yaml
@@ -5,8 +5,10 @@ resources:
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
+  - ../../../money-claims/identity/identity.yaml
 namespace: civil
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../../xui/identity/aat.yaml
   - ../../../am/identity/aat.yaml
+  - ../../../money-claims/identity/aat.yaml

--- a/apps/money-claims/preview/base/kustomization.yaml
+++ b/apps/money-claims/preview/base/kustomization.yaml
@@ -8,11 +8,9 @@ resources:
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../money-claims/identity/identity.yaml
 namespace: money-claims
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../../ccd/identity/aat.yaml
   - ../../../xui/identity/aat.yaml
   - ../../../am/identity/aat.yaml
-  - ../../../money-claims/identity/aat.yaml

--- a/apps/money-claims/preview/base/kustomization.yaml
+++ b/apps/money-claims/preview/base/kustomization.yaml
@@ -8,9 +8,11 @@ resources:
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
+  - ../../../money-claims/identity/identity.yaml
 namespace: money-claims
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../../ccd/identity/aat.yaml
   - ../../../xui/identity/aat.yaml
   - ../../../am/identity/aat.yaml
+  - ../../../money-claims/identity/aat.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Add money-claim (cmc) managed identity to civil's kustomization to allow civil components access to cmc key vault

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
