### PR TITLE
Add cmc identity to civil's AAT

### DIFF
--- a/apps/civil/aat/base/kustomization.yaml
+++ b/apps/civil/aat/base/kustomization.yaml
@@ -4,7 +4,9 @@ resources:
   - ../../base
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
+  - ../../../money-claims/identity/identity.yaml
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../../xui/identity/aat.yaml
   - ../../../am/identity/aat.yaml
+  - ../../../money-claims/identity/aat.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Add money-claim (cmc) managed identity to civil's AAT kustomization to allow civil components access to cmc AAT key vault

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
