### PR TITLE
Revert "updated LB ip to new one for CFT cluster"

### DIFF
--- a/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.221
+    loadBalancerIP: 10.51.15.221


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#13405