### PR TITLE
updated keyvault name - removed env suffix as added by template

### DIFF
--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -14,14 +14,14 @@ spec:
             repository: neuvector/scanner
           replicas: 2
     keyvault:
-      name: cftapps-ithc
+      name: cftapps
       resourcegroup: core-infra-ithc-rg
       subscriptionid: 62864d44-5da9-4ae9-89e7-0cf33942fa09
       tenantid: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
       aadpodidbinding: neuvector
       licensesecretname: neuvector-license-dev
     keyVaults:
-      cftapps-ithc:
+      cftapps:
         secrets:
           - neuvector-admin-password
           - neuvector-license-dev


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5408

### Change description ###
Follow on to #13494 - updated keyvault name, removed suffix as it is added by template.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
