### PR TITLE
DTSPO-5408 - Perftest Neuvector Upgrade to 4.4.2

### DIFF
--- a/apps/neuvector/neuvector/perftest/perftest.yaml
+++ b/apps/neuvector/neuvector/perftest/perftest.yaml
@@ -8,8 +8,88 @@ spec:
   values:
     neuvector:
       tag: 4.4.2
+      controller:
+        tolerations:
+          - key: "CriticalAddonsOnly"
+            operator: "Equal"
+            value: "true"
+            effect: "NoSchedule"
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - neuvector-controller-pod
+                  topologyKey: "kubernetes.io/hostname"
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: kubernetes.azure.com/mode
+                      operator: In
+                      values:
+                        - system
+      manager:
+        tolerations:
+          - key: "CriticalAddonsOnly"
+            operator: "Equal"
+            value: "true"
+            effect: "NoSchedule"
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                          - neuvector-manager-pod
+                  topologyKey: "kubernetes.io/hostname"
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                preference:
+                  matchExpressions:
+                    - key: kubernetes.azure.com/mode
+                      operator: In
+                      values:
+                        - system
       cve:
         scanner:
+          tolerations:
+            - key: "CriticalAddonsOnly"
+              operator: "Equal"
+              value: "true"
+              effect: "NoSchedule"
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                            - neuvector-scanner-pod
+                    topologyKey: "kubernetes.io/hostname"
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: kubernetes.azure.com/mode
+                        operator: In
+                        values:
+                          - system
           image:
             repository: neuvector/scanner
           replicas: 2

--- a/apps/neuvector/neuvector/perftest/perftest.yaml
+++ b/apps/neuvector/neuvector/perftest/perftest.yaml
@@ -7,99 +7,26 @@ metadata:
 spec:
   values:
     neuvector:
-      tag: 4.3.2
-      controller:
-        tolerations:
-          - key: "CriticalAddonsOnly"
-            operator: "Equal"
-            value: "true"
-            effect: "NoSchedule"
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                      - key: app
-                        operator: In
-                        values:
-                          - neuvector-controller-pod
-                  topologyKey: "kubernetes.io/hostname"
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 1
-                preference:
-                  matchExpressions:
-                    - key: kubernetes.azure.com/mode
-                      operator: In
-                      values:
-                        - system
-      manager:
-        tolerations:
-          - key: "CriticalAddonsOnly"
-            operator: "Equal"
-            value: "true"
-            effect: "NoSchedule"
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                      - key: app
-                        operator: In
-                        values:
-                          - neuvector-manager-pod
-                  topologyKey: "kubernetes.io/hostname"
-          nodeAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 1
-                preference:
-                  matchExpressions:
-                    - key: kubernetes.azure.com/mode
-                      operator: In
-                      values:
-                        - system
+      tag: 4.4.2
       cve:
         scanner:
-          tolerations:
-            - key: "CriticalAddonsOnly"
-              operator: "Equal"
-              value: "true"
-              effect: "NoSchedule"
-          affinity:
-            podAntiAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 100
-                  podAffinityTerm:
-                    labelSelector:
-                      matchExpressions:
-                        - key: app
-                          operator: In
-                          values:
-                            - neuvector-scanner-pod
-                    topologyKey: "kubernetes.io/hostname"
-            nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
-                      - key: kubernetes.azure.com/mode
-                        operator: In
-                        values:
-                          - system
           image:
             repository: neuvector/scanner
           replicas: 2
     keyvault:
-      name: cftapps-test
+      name: cftapps
       resourcegroup: core-infra-test-rg
       subscriptionid: 8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c
       tenantid: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
       aadpodidbinding: neuvector
       licensesecretname: neuvector-license-dev
+    keyVaults:
+      cftapps:
+        secrets:
+          - neuvector-admin-password
+          - neuvector-license-dev
+          - neuvector-slack-webhook
+          - neuvector-new-admin-password
   chart:
     spec:
-      version: 1.2.6
+      version: 1.2.5


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5408


### Change description ###
Upgraded neuvector to 4.4.2
Downgrade neuvector-azure-keyvault to 1.2.5  (a separate PR to be raised to switch to upstream chart). 
Added keyvaults to enable post-install config job


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
