### PR TITLE
DTSPO-5408 - ITHC Perftest - Disable environment suffix in KV name

### DIFF
--- a/apps/neuvector/neuvector/perftest/perftest.yaml
+++ b/apps/neuvector/neuvector/perftest/perftest.yaml
@@ -103,11 +103,11 @@ spec:
     keyVaults:
       cftapps-test:
       excludeEnvironmentSuffix: true
-        secrets:
-          - neuvector-admin-password
-          - neuvector-license-dev
-          - neuvector-slack-webhook
-          - neuvector-new-admin-password
+      secrets:
+        - neuvector-admin-password
+        - neuvector-license-dev
+        - neuvector-slack-webhook
+        - neuvector-new-admin-password
   chart:
     spec:
       version: 1.2.5

--- a/apps/neuvector/neuvector/perftest/perftest.yaml
+++ b/apps/neuvector/neuvector/perftest/perftest.yaml
@@ -94,14 +94,15 @@ spec:
             repository: neuvector/scanner
           replicas: 2
     keyvault:
-      name: cftapps
+      name: cftapps-test
       resourcegroup: core-infra-test-rg
       subscriptionid: 8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c
       tenantid: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
       aadpodidbinding: neuvector
       licensesecretname: neuvector-license-dev
     keyVaults:
-      cftapps:
+      cftapps-test:
+      excludeEnvironmentSuffix: true
         secrets:
           - neuvector-admin-password
           - neuvector-license-dev


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5408


### Change description ###
Set the option to disable environment suffix in KV name - to support perftest KV which will is being resolved as 'cftapps-perftest' instead of the actual keyvault name 'cftapps-test'.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
