### PR TITLE
DTSPO-5408 - ITHC Perftest - Disable environment suffix in KV name 2

### DIFF
--- a/apps/neuvector/neuvector/perftest/perftest.yaml
+++ b/apps/neuvector/neuvector/perftest/perftest.yaml
@@ -102,12 +102,12 @@ spec:
       licensesecretname: neuvector-license-dev
     keyVaults:
       cftapps-test:
-      excludeEnvironmentSuffix: true
-      secrets:
-        - neuvector-admin-password
-        - neuvector-license-dev
-        - neuvector-slack-webhook
-        - neuvector-new-admin-password
+        excludeEnvironmentSuffix: true
+        secrets:
+          - neuvector-admin-password
+          - neuvector-license-dev
+          - neuvector-slack-webhook
+          - neuvector-new-admin-password
   chart:
     spec:
       version: 1.2.5


### PR DESCRIPTION
### JIRA link (if applicable) ###
Follow up to #13505 - fixed yaml

### Change description ###
Set the option to disable environment suffix in KV name - to support perftest KV which will is being resolved as 'cftapps-perftest' instead of the actual keyvault name 'cftapps-test'.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
