### PR TITLE
DTSPO-5408 - AAT Neuvector - Upgrade chart to 4.4.2 and neuvector-azure-keyvault to 1.2.5

### DIFF
--- a/apps/neuvector/neuvector/aat/aat.yaml
+++ b/apps/neuvector/neuvector/aat/aat.yaml
@@ -6,10 +6,27 @@ metadata:
   namespace: neuvector
 spec:
   values:
+    neuvector:
+      tag: 4.4.2
+      cve:
+        scanner:
+          image:
+            repository: neuvector/scanner
+          replicas: 2
     keyvault:
-      name: cftapps-stg
+      name: cftapps
       resourcegroup: core-infra-stg-rg
       subscriptionid: 96c274ce-846d-4e48-89a7-d528432298a7
       tenantid: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
       aadpodidbinding: neuvector
       licensesecretname: neuvector-license-dev
+    keyVaults:
+      cftapps:
+        secrets:
+          - neuvector-admin-password
+          - neuvector-license-dev
+          - neuvector-slack-webhook
+          - neuvector-new-admin-password
+  chart:
+    spec:
+      version: 1.2.5


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5408


### Change description ###
Upgraded neuvector to 4.4.2
Upgraded neuvector-azure-keyvault to 1.2.5
Added keyvaults to enable post-install config job


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
