### PR TITLE
DTSPO-5408 - Prod Neuvector - Upgrade to 4.4.2

### DIFF
--- a/apps/neuvector/neuvector/prod/prod.yaml
+++ b/apps/neuvector/neuvector/prod/prod.yaml
@@ -6,6 +6,13 @@ metadata:
   namespace: neuvector
 spec:
   values:
+    neuvector:
+      tag: 4.4.2
+      cve:
+        scanner:
+          image:
+            repository: neuvector/scanner
+          replicas: 3
     keyvault:
       name: cft-apps-prod
       resourcegroup: core-infra-prod-rg
@@ -13,3 +20,14 @@ spec:
       tenantid: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
       aadpodidbinding: neuvector
       licensesecretname: neuvector-license
+    keyVaults:
+      cft-apps-prod:
+        excludeEnvironmentSuffix: true
+        secrets:
+          - neuvector-admin-password
+          - neuvector-license
+          - neuvector-slack-webhook
+          - neuvector-new-admin-password
+  chart:
+    spec:
+      version: 1.2.5


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5408


### Change description ###
Upgraded neuvector to 4.4.2
Upgraded neuvector-azure-keyvault to 1.2.5
Added keyvaults to enable post-install config job


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
