### PR TITLE
DTSPO-5408 - ITHC - Neuvector admission rule exception for Flux images

### DIFF
--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: neuvector
 spec:
   values:
+    autoScan: true
+    rules:
+      admission:
+        rules:
+          - '{"config":{"id":1002,"category":"Kubernetes","comment":"Allow HMCTS registries","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://hmctspublic.azurecr.io/,https://hmctsprivate.azurecr.io/,https://ghcr.io/"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
     neuvector:
       tag: 4.4.2
       cve:


### PR DESCRIPTION
### Change description ###
Added an admission rule exception for flux images which is currently being blocked by Neuvector


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
