### PR TITLE
DTSPO-5408 - Switch Flux v2 images back to upstream - v.0.18.0

### DIFF
--- a/apps/flux-system/base/gotk-components.yaml
+++ b/apps/flux-system/base/gotk-components.yaml
@@ -4005,9 +4005,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # TODO https://github.com/fluxcd/source-controller/pull/452
-        # see https://github.com/fluxcd/source-controller/issues/439#issuecomment-943580625
-        image: docker.io/hiddeco/source-controller:libgit2-free-a62cfe8
+        image: ghcr.io/fluxcd/source-controller:v0.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/apps/flux-system/base/image-automation-components.yaml
+++ b/apps/flux-system/base/image-automation-components.yaml
@@ -2005,9 +2005,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # TODO https://github.com/fluxcd/image-automation-controller/pull/239
-        # see https://github.com/fluxcd/source-controller/issues/439#issuecomment-951806557
-        image: docker.io/hiddeco/image-automation-controller:sc-git-update-9ef9856
+        image: ghcr.io/fluxcd/image-automation-controller:v0.19.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
### Change description ###
Neuvector admissions control rules currently block Flux images (ghcr.io and docker.io/hiddeco).   Looking to create rules exception to allow flux images and switching back to upstream for source controller will minimise the number of exceptions  required

- Updated source controller and image automation controller to use upstream image.  Previously switched in #12162 to attempt an issue fix.
- Note: For source controller v0.18.0 has been chosen as [v0.19.0 or higher](https://github.com/fluxcd/source-controller/blob/main/CHANGELOG.md#0190) contains breaking changes which will require additional testing before a wider rollout so deploying v0.18.0 in the interim


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
