### PR TITLE
DTSPO-5408 - ITHC Neuvector - Updated Flux v2 image registry in neuvector  admission control rules

### DIFF
--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -10,7 +10,11 @@ spec:
     rules:
       admission:
         rules:
-          - '{"config":{"id":1002,"category":"Kubernetes","comment":"Allow HMCTS registries","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://hmctspublic.azurecr.io/,https://hmctsprivate.azurecr.io/,https://ghcr.io/"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1000,"category":"Kubernetes","comment":"Allow system namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"neuvector,kube-system,knode-system"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1001,"category":"Kubernetes","comment":"Allow admin namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"admin,kured,monitoring"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1002,"category":"Kubernetes","comment":"Allow HMCTS registries","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://hmctspublic.azurecr.io/,https://hmctsprivate.azurecr.io/"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1003,"category":"Kubernetes","comment":"Allow Flux v2 registry","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://ghcr.io/fluxcd/"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1004,"category":"Kubernetes","comment":"Default deny","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://localhost/,https://*.*/"}],"disable":false,"rule_type": "deny","cfg_type":"user_created"}}'
     neuvector:
       tag: 4.4.2
       cve:


### PR DESCRIPTION
### Change description ###

- Follow up to #13549 
- Created separate rule for Flux v2 registry and using a limited scope '/fluxcd'
- entire rules being added as patch due to kustomize issues when separating single rules


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
