### PR TITLE
DTSPO-5408 - Flux v2 - Switching Flux v2 images to hmctspublic

### DIFF
--- a/apps/flux-system/base/gotk-components.yaml
+++ b/apps/flux-system/base/gotk-components.yaml
@@ -3777,7 +3777,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/helm-controller:v0.12.0
+        image: hmctspublic.azurecr.io/fluxcd/helm-controller:v0.12.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3850,7 +3850,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v0.15.5
+        image: hmctspublic.azurecr.io/fluxcd/kustomize-controller:v0.15.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3924,7 +3924,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/notification-controller:v0.17.1
+        image: hmctspublic.azurecr.io/fluxcd/notification-controller:v0.17.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4005,7 +4005,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/source-controller:v0.18.0
+        image: hmctspublic.azurecr.io/fluxcd/source-controller:v0.18.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/apps/flux-system/base/image-automation-components.yaml
+++ b/apps/flux-system/base/image-automation-components.yaml
@@ -2005,7 +2005,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/image-automation-controller:v0.19.0
+        image: hmctspublic.azurecr.io/fluxcd/image-automation-controller:v0.19.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -2080,7 +2080,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/image-reflector-controller:v0.12.0
+        image: hmctspublic.azurecr.io/fluxcd/image-reflector-controller:v0.12.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
### Change description ###
Flux v2 pods are blocked by Neuvector admission rules - see PR #13552 
Flux v2 upstream images have been copied to hmctspublic and now switching over to use these instead of the upstream images
This above will remove the need to create additional neuvector rules for the upstream images


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
