### PR TITLE
CCD-2400: Reduce ccd-data-store-api AAT replicas

### DIFF
--- a/k8s/namespaces/ccd/ccd-data-store-api/aat.yaml
+++ b/k8s/namespaces/ccd/ccd-data-store-api/aat.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      replicas: 8
+      replicas: 6
       autoscaling:
         enabled: false
       memoryLimits: "4096Mi"


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2400 (https://tools.hmcts.net/jira/browse/CCD-2400)


### Change description ###
Reduced number of replicas in ccd-data-store-api aat.yaml from 8 to 6.  Changes made under Pull Request 13638 (https://github.com/hmcts/cnp-flux-config/pull/13638) didn't manage to resolve issue with functional tests in nightly build so reducing number of replicas to reduce resource usage.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
