### PR TITLE
Preview quotas for highest usage teams

### DIFF
--- a/apps/civil/preview/base/kustomization.yaml
+++ b/apps/civil/preview/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../am/identity/identity.yaml
   - ../../../money-claims/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
+  - resource-limits.yaml
 namespace: civil
 patchesStrategicMerge:
   - ../../identity/aat.yaml

--- a/apps/civil/preview/base/resource-limits.yaml
+++ b/apps/civil/preview/base/resource-limits.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: civil-quota
+  namespace: civil
+spec:
+  hard:
+    requests.cpu: "50"
+    requests.memory: 140Gi

--- a/apps/family-public-law/preview/base/kustomization.yaml
+++ b/apps/family-public-law/preview/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../aac/identity/identity.yaml
   - ../../../am/identity/identity.yaml
+  - resource-limits.yaml
 namespace: family-public-law
 patchesStrategicMerge:
   - ../../identity/aat.yaml

--- a/apps/family-public-law/preview/base/resource-limits.yaml
+++ b/apps/family-public-law/preview/base/resource-limits.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: fpl-quota
+  namespace: family-public-law
+spec:
+  hard:
+    requests.cpu: "50"
+    requests.memory: 140Gi

--- a/apps/financial-remedy/preview/base/kustomization.yaml
+++ b/apps/financial-remedy/preview/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
+  - resource-limits.yaml
 namespace: financial-remedy
 patchesStrategicMerge:
   - ../../identity/aat.yaml

--- a/apps/financial-remedy/preview/base/resource-limits.yaml
+++ b/apps/financial-remedy/preview/base/resource-limits.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: financial-remedy-quota
+  namespace: financial-remedy
+spec:
+  hard:
+    requests.cpu: "50"
+    requests.memory: 140Gi


### PR DESCRIPTION
Quota is set to the same as cmc has, they had the same issue with many ccd pods also being spun up.
These teams can clear releases that are no longer needed to make space for new ones.

In next sprint will change this to lower duplication, and give all teams a max usage on preview.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```
