### PR TITLE
updated ithc env to use updated prometheus version

### DIFF
--- a/apps/monitoring/ithc/base/kustomization.yaml
+++ b/apps/monitoring/ithc/base/kustomization.yaml
@@ -11,6 +11,6 @@ resources:
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
   - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
- 
+
 patchesStrategicMerge:
   - ../../kube-prometheus-stack/sbox/kube-prometheus-stack.yaml

--- a/apps/monitoring/ithc/base/kustomization.yaml
+++ b/apps/monitoring/ithc/base/kustomization.yaml
@@ -3,3 +3,14 @@ kind: Kustomization
 resources:
   - ../../base
   - prometheus-values.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-probes.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-30.0.1/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+ 
+patchesStrategicMerge:
+  - ../../kube-prometheus-stack/sbox/kube-prometheus-stack.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-5413

### Change description ###

Updated ITHC env to use Prometheus version 30.0.1 (as been tested in sbox already). Note the referenced kube-prometheus-stack file in the patchesStrategicMerge is from the sbox env to save duplicating this. Once confirmed as working in all env's this will be removed as the main kube-prometheus-stack file will be updated (which all envs use) to use version 30.0.1.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
