### PR TITLE
Disable regular smoke/ functional tests broken on Java 17 atm

### DIFF
--- a/k8s/aat/common/cnp/plum-recipe-backend.yaml
+++ b/k8s/aat/common/cnp/plum-recipe-backend.yaml
@@ -25,17 +25,13 @@ spec:
           SLACK_NOTIFY_SUCCESS: "false"
       smoketestscron:
         image: hmctspublic.azurecr.io/plum/recipe-backend-test:prod-4573350-20211123172403 #{"$imagepolicy": "flux-system:plum-recipe-backend-recipe-backend-test"}
-        enabled: true
         schedule: "10 0/1 * * *"
       functionaltestscron:
         image: hmctspublic.azurecr.io/plum/recipe-backend-test:prod-4573350-20211123172403 #{"$imagepolicy": "flux-system:plum-recipe-backend-recipe-backend-test"}
-        enabled: true
         schedule: "20 0/3 * * *"
       smoketests:
-        enabled: true
         image: hmctspublic.azurecr.io/plum/recipe-backend-test:prod-4573350-20211123172403 #{"$imagepolicy": "flux-system:plum-recipe-backend-recipe-backend-test"}
       functionaltests:
-        enabled: true
         image: hmctspublic.azurecr.io/plum/recipe-backend-test:prod-4573350-20211123172403 #{"$imagepolicy": "flux-system:plum-recipe-backend-recipe-backend-test"}
     global:
       environment: aat

--- a/k8s/namespaces/rpe/draft-store-service/aat.yaml
+++ b/k8s/namespaces/rpe/draft-store-service/aat.yaml
@@ -26,13 +26,3 @@ spec:
           IDAM_USER_EMAIL_FOR_TESTS: "reformplatformengineering+tests@gmail.com"
           IDAM_CLIENT_ID_FOR_TESTS: "cmc_citizen"
           IDAM_REDIRECT_URI_FOR_TESTS: "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"
-      smoketestscron:
-        enabled: true
-        schedule: "15 0/1 * * *"
-      functionaltestscron:
-        enabled: true
-        schedule: "25 0/6 * * *"
-      smoketests:
-        enabled: true
-      functionaltests:
-        enabled: true

--- a/k8s/namespaces/rpe/pdf-service/aat.yaml
+++ b/k8s/namespaces/rpe/pdf-service/aat.yaml
@@ -12,13 +12,4 @@ spec:
           TEST_URL: http://pdf-service-java
           SLACK_CHANNEL: "platops-build-notices"
           SLACK_NOTIFY_SUCCESS: "false"
-      smoketestscron:
-        enabled: true
-        schedule: "35 0/1 * * *"
-      functionaltestscron:
-        enabled: true
-        schedule: "45 0/6 * * *"
-      smoketests:
-        enabled: true
-      functionaltests:
-        enabled: true
+


### PR DESCRIPTION
No one ever has time to look at these and the tests are currently failing on Java 17  because it's hardcoded to 11:
https://github.com/hmcts/cnp-jenkins-library/blob/master/resources/uk/gov/hmcts/gradle/Dockerfile_test#L17

This feature is used so little, we can just bump to 17 later on when the users have updated