### PR TITLE
DTSPO-6658 - AAT AKS Upgrade - Swap AAT cluster in Jenkins

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -43,9 +43,9 @@ spec:
                       - key: REGISTRY_NAME
                         value: hmcts
                       - key: AAT_AKS_CLUSTER_NAME
-                        value: cft-aat-01-aks
+                        value: cft-aat-00-aks
                       - key: AAT_AKS_RESOURCE_GROUP
-                        value: cft-aat-01-rg
+                        value: cft-aat-00-rg
                       - key: PREVIEW_AKS_CLUSTER_NAME
                         value : cft-preview-00-aks
                       - key : PREVIEW_AKS_RESOURCE_GROUP


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6658


### Change description ###
Switch Jenkins to point to AAT-00 following rebuild and prior to rebuilding AAT-01.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
