### PR TITLE
DTSPO-6658 Apply Dynatrace CRDs

### DIFF
--- a/apps/monitoring/base/kustomize.yaml
+++ b/apps/monitoring/base/kustomize.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-crd
+    - name: dynatrace-crd
   path: ./apps/monitoring/${ENVIRONMENT}/${CLUSTER}
   postBuild:
     substitute:
@@ -20,3 +21,11 @@ metadata:
   namespace: flux-system
 spec:
   path: ./apps/monitoring/kube-prometheus-stack-crds
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: dynatrace-crd
+  namespace: flux-system
+spec:
+  path: ./apps/monitoring/dynatrace-crds

--- a/apps/monitoring/dynatrace-crds/kustomization.yaml
+++ b/apps/monitoring/dynatrace-crds/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/latest/download/dynatrace.com_oneagents.yaml
+  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/latest/download/dynatrace.com_oneagentapms.yaml

--- a/apps/monitoring/dynatrace-crds/kustomization.yaml
+++ b/apps/monitoring/dynatrace-crds/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/latest/download/dynatrace.com_oneagents.yaml
-  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/latest/download/dynatrace.com_oneagentapms.yaml
+  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/v0.10.2/dynatrace.com_oneagents.yaml
+  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/v0.10.2/dynatrace.com_oneagentapms.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6658

### Change description ###
Dynatrace CRDs need to be applied [before using the charts](https://github.com/Dynatrace/helm-charts/blob/3c6ac8e9d9d62c1925e79f3fbd93e6be9af1bbea/dynatrace-oneagent-operator/chart/default/app-readme.md#additional-instructions).  These are currently manually applied after cluster rebuild.

**Note**: CRDs are already manually applied in the clusters and there should be no impact on existing environments.  Validation will be done by uninstalling CRDs in AAT-01 which is currently being rebuild.  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
