### PR TITLE
Revert "DTSPO-6658 Apply Dynatrace CRDs"

### DIFF
--- a/apps/monitoring/base/kustomize.yaml
+++ b/apps/monitoring/base/kustomize.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-crd
-    - name: dynatrace-crd
   path: ./apps/monitoring/${ENVIRONMENT}/${CLUSTER}
   postBuild:
     substitute:
@@ -21,11 +20,3 @@ metadata:
   namespace: flux-system
 spec:
   path: ./apps/monitoring/kube-prometheus-stack-crds
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-kind: Kustomization
-metadata:
-  name: dynatrace-crd
-  namespace: flux-system
-spec:
-  path: ./apps/monitoring/dynatrace-crds

--- a/apps/monitoring/dynatrace-crds/kustomization.yaml
+++ b/apps/monitoring/dynatrace-crds/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/v0.10.2/dynatrace.com_oneagents.yaml
-  - https://github.com/Dynatrace/dynatrace-oneagent-operator/releases/download/v0.10.2/dynatrace.com_oneagentapms.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#14311

CRDs successfully applied in AAT but failed in Prod due to error below:

`dynatrace-crd    False     CustomResourceDefinition/oneagents.dynatrace.com dry-run failed, error: failed to convert new object: unable to convert unstructured object to apiextensions.k8s.io/v1, Kind=CustomResourceDefinition: cannot convert int64 to float64   16m`

Will review prod error and revisit change later.
