### PR TITLE
updated traefik for Demo switchover

### DIFF
--- a/apps/admin/traefik-auth/demo/00.yaml
+++ b/apps/admin/traefik-auth/demo/00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.5.163
+  loadBalancerIP: 51.11.25.221

--- a/apps/admin/traefik-auth/demo/00.yaml
+++ b/apps/admin/traefik-auth/demo/00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.25.221
+  loadBalancerIP: 51.11.5.163

--- a/apps/admin/traefik-auth/demo/00.yaml
+++ b/apps/admin/traefik-auth/demo/00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.25.221
+  loadBalancerIP: 51.11.45.81

--- a/apps/admin/traefik-auth/demo/00.yaml
+++ b/apps/admin/traefik-auth/demo/00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.45.81
+  loadBalancerIP: 10.50.79.246

--- a/apps/admin/traefik-auth/demo/01.yaml
+++ b/apps/admin/traefik-auth/demo/01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.5.163
+  loadBalancerIP: 51.11.25.221

--- a/apps/admin/traefik-auth/demo/01.yaml
+++ b/apps/admin/traefik-auth/demo/01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 20.68.184.102
+  loadBalancerIP: 51.11.5.163

--- a/apps/admin/traefik-auth/demo/01.yaml
+++ b/apps/admin/traefik-auth/demo/01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.25.221
+  loadBalancerIP: 51.11.5.163

--- a/apps/admin/traefik-auth/demo/01.yaml
+++ b/apps/admin/traefik-auth/demo/01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.5.163
+  loadBalancerIP: 51.11.46.194

--- a/apps/admin/traefik-auth/demo/01.yaml
+++ b/apps/admin/traefik-auth/demo/01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 10.50.95.245
+  loadBalancerIP: 10.50.95.246

--- a/apps/admin/traefik-auth/demo/01.yaml
+++ b/apps/admin/traefik-auth/demo/01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.46.194
+  loadBalancerIP: 10.50.95.245

--- a/apps/admin/traefik-no-proxy/demo/00.yaml
+++ b/apps/admin/traefik-no-proxy/demo/00.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.5.163
+    loadBalancerIP: 51.11.25.221

--- a/apps/admin/traefik-no-proxy/demo/00.yaml
+++ b/apps/admin/traefik-no-proxy/demo/00.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.25.221
+    loadBalancerIP: 51.11.45.81

--- a/apps/admin/traefik-no-proxy/demo/00.yaml
+++ b/apps/admin/traefik-no-proxy/demo/00.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.45.81
+    loadBalancerIP: 51.11.46.21

--- a/apps/admin/traefik-no-proxy/demo/00.yaml
+++ b/apps/admin/traefik-no-proxy/demo/00.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.46.21
+    loadBalancerIP: 10.50.79.247

--- a/apps/admin/traefik-no-proxy/demo/01.yaml
+++ b/apps/admin/traefik-no-proxy/demo/01.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 20.68.186.154
+    loadBalancerIP: 51.11.25.221

--- a/apps/admin/traefik-no-proxy/demo/01.yaml
+++ b/apps/admin/traefik-no-proxy/demo/01.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.25.221
+    loadBalancerIP: 51.11.5.163

--- a/apps/admin/traefik-no-proxy/demo/01.yaml
+++ b/apps/admin/traefik-no-proxy/demo/01.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.46.211
+    loadBalancerIP: 10.50.95.247

--- a/apps/admin/traefik-no-proxy/demo/01.yaml
+++ b/apps/admin/traefik-no-proxy/demo/01.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.5.163
+    loadBalancerIP: 51.11.46.194

--- a/apps/admin/traefik-no-proxy/demo/01.yaml
+++ b/apps/admin/traefik-no-proxy/demo/01.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.46.194
+    loadBalancerIP: 51.11.46.211

--- a/apps/admin/traefik-private/demo/00.yaml
+++ b/apps/admin/traefik-private/demo/00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.51.15.221
+    loadBalancerIP: 10.50.79.221

--- a/apps/admin/traefik-private/demo/00.yaml
+++ b/apps/admin/traefik-private/demo/00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.221
+    loadBalancerIP: 10.50.79.250

--- a/apps/admin/traefik-private/demo/00.yaml
+++ b/apps/admin/traefik-private/demo/00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.250
+    loadBalancerIP: 10.50.79.221

--- a/apps/admin/traefik-private/demo/01.yaml
+++ b/apps/admin/traefik-private/demo/01.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.51.31.251
+    loadBalancerIP: 10.50.95.221

--- a/apps/admin/traefik-private/demo/01.yaml
+++ b/apps/admin/traefik-private/demo/01.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.95.221
+    loadBalancerIP: 10.50.95.251

--- a/apps/admin/traefik/demo/00.yaml
+++ b/apps/admin/traefik/demo/00.yaml
@@ -9,7 +9,7 @@ spec:
       enabled: true
     debug:
       enabled: true
-    loadBalancerIP: 10.51.15.220
+    loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
         ip: 51.11.25.221
@@ -22,4 +22,4 @@ spec:
       domain: traefik00.demo.platform.hmcts.net
     service:
       annotations:
-        service.beta.kubernetes.io/azure-load-balancer-resource-group: aks-infra-demo-rg
+        service.beta.kubernetes.io/azure-load-balancer-resource-group: cft-demo-network-rg

--- a/apps/admin/traefik/demo/00.yaml
+++ b/apps/admin/traefik/demo/00.yaml
@@ -12,7 +12,7 @@ spec:
     loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.5.163
+        ip: 51.11.25.221
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/apps/admin/traefik/demo/00.yaml
+++ b/apps/admin/traefik/demo/00.yaml
@@ -12,7 +12,7 @@ spec:
     loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.25.221
+        ip: 51.11.5.163
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/apps/admin/traefik/demo/00.yaml
+++ b/apps/admin/traefik/demo/00.yaml
@@ -14,6 +14,7 @@ spec:
       ingressEndpoint:
         ip: 51.11.45.81
         useDefaultPublishedService: false
+        ingressClass: traefik
     forwardedHeaders:
       enabled: true
       trustedIPs:

--- a/apps/admin/traefik/demo/00.yaml
+++ b/apps/admin/traefik/demo/00.yaml
@@ -12,7 +12,7 @@ spec:
     loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.25.221
+        ip: 51.11.45.81
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/apps/admin/traefik/demo/01.yaml
+++ b/apps/admin/traefik/demo/01.yaml
@@ -9,7 +9,7 @@ spec:
       enabled: true
     debug:
       enabled: true
-    loadBalancerIP: 10.51.31.250
+    loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
         ip: 20.68.184.102
@@ -22,4 +22,4 @@ spec:
       domain: traefik01.demo.platform.hmcts.net
     service:
       annotations:
-        service.beta.kubernetes.io/azure-load-balancer-resource-group: aks-infra-demo-rg
+        service.beta.kubernetes.io/azure-load-balancer-resource-group: cft-demo-network-rg

--- a/apps/admin/traefik/demo/01.yaml
+++ b/apps/admin/traefik/demo/01.yaml
@@ -10,6 +10,10 @@ spec:
     debug:
       enabled: true
     loadBalancerIP: 10.50.95.250
+    kubernetes:
+      ingressEndpoint:
+        ip: 51.11.25.221
+        useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true
       trustedIPs:

--- a/apps/admin/traefik/demo/01.yaml
+++ b/apps/admin/traefik/demo/01.yaml
@@ -12,7 +12,7 @@ spec:
     loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.25.221
+        ip: 51.11.5.163
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/apps/admin/traefik/demo/01.yaml
+++ b/apps/admin/traefik/demo/01.yaml
@@ -10,10 +10,6 @@ spec:
     debug:
       enabled: true
     loadBalancerIP: 10.50.95.250
-    kubernetes:
-      ingressEndpoint:
-        ip: 20.68.184.102
-        useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true
       trustedIPs:

--- a/apps/admin/traefik/demo/01.yaml
+++ b/apps/admin/traefik/demo/01.yaml
@@ -14,6 +14,7 @@ spec:
       ingressEndpoint:
         ip: 51.11.46.194
         useDefaultPublishedService: false
+        ingressClass: traefik
     forwardedHeaders:
       enabled: true
       trustedIPs:

--- a/apps/admin/traefik/demo/01.yaml
+++ b/apps/admin/traefik/demo/01.yaml
@@ -12,7 +12,7 @@ spec:
     loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.5.163
+        ip: 51.11.46.194
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/external-dns-public/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/external-dns-public/patches/demo-00.yaml
@@ -15,4 +15,4 @@ spec:
         - --domain-filter=demo.platform.hmcts.net
         - --provider=azure
         - --log-level=debug
-        - --txt-owner-id=demo-inactive
+        - --txt-owner-id=demo-active

--- a/k8s/namespaces/admin/external-dns-public/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/external-dns-public/patches/demo-01.yaml
@@ -15,4 +15,4 @@ spec:
         - --domain-filter=demo.platform.hmcts.net
         - --provider=azure
         - --log-level=debug
-        - --txt-owner-id=demo-active
+        - --txt-owner-id=demo-inactive

--- a/k8s/namespaces/admin/external-dns/patches/demo/cluster-00/external-dns-deployment.yaml
+++ b/k8s/namespaces/admin/external-dns/patches/demo/cluster-00/external-dns-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         - --source=ingress
         - --domain-filter=demo.platform.hmcts.net
         - --provider=azure-private-dns
-        - --txt-owner-id=demo-inactive
+        - --txt-owner-id=demo-active
         - --azure-resource-group=core-infra-intsvc-rg
         - --azure-subscription-id=1baf5470-1c3e-40d3-a6f7-74bfbce4b348
         - --log-level=debug

--- a/k8s/namespaces/admin/external-dns/patches/demo/cluster-01/external-dns-deployment.yaml
+++ b/k8s/namespaces/admin/external-dns/patches/demo/cluster-01/external-dns-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         - --source=ingress
         - --domain-filter=demo.platform.hmcts.net
         - --provider=azure-private-dns
-        - --txt-owner-id=demo-active
+        - --txt-owner-id=demo-inactive
         - --azure-resource-group=core-infra-intsvc-rg
         - --azure-subscription-id=1baf5470-1c3e-40d3-a6f7-74bfbce4b348
         - --log-level=debug

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.5.163
+  loadBalancerIP: 51.11.25.221

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.25.221
+  loadBalancerIP: 51.11.5.163

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.25.221
+  loadBalancerIP: 51.11.45.81

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-00.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.45.81
+  loadBalancerIP: 10.50.79.246

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.5.163
+  loadBalancerIP: 51.11.25.221

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 20.68.184.102
+  loadBalancerIP: 51.11.5.163

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.25.221
+  loadBalancerIP: 51.11.5.163

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.5.163
+  loadBalancerIP: 51.11.46.194

--- a/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-auth/patches/demo-01.yaml
@@ -4,4 +4,4 @@ metadata:
   name: traefik-forward-auth
   namespace: admin
 spec:
-  loadBalancerIP: 51.11.46.194
+  loadBalancerIP: 10.50.95.246

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 10.50.79.250
+    loadBalancer: 51.11.25.221
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik
       - --providers.kubernetesingress.ingressendpoint.ip=20.108.131.175

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -10,4 +10,4 @@ spec:
     loadBalancer: 51.11.25.221
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
-      - --providers.kubernetesingress.ingressendpoint.ip=20.108.131.175
+      - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -9,5 +9,5 @@ spec:
   values:
     loadBalancer: 51.11.25.221
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik
+      - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=20.108.131.175

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 51.11.25.221
+    loadBalancer: 51.11.5.163
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
+    loadBalancer: 10.50.79.250
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik
       - --providers.kubernetesingress.ingressendpoint.ip=20.108.131.175

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,4 +7,6 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 51.11.5.163
+    additionalArguments:
+      - --providers.kubernetesingress.ingressclass=traefik
+      - --providers.kubernetesingress.ingressendpoint.ip=20.108.131.175

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 51.11.5.163
+    loadBalancer: 51.11.25.221
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -9,5 +9,5 @@ spec:
   values:
     loadBalancer: 10.50.79.245
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
-      - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81
+      - --providers.kubernetes.ingressclass=traefik-no-proxy
+      - --providers.kubernetes.ingressendpoint.publishedService=traefik

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   values:
     loadBalancer: 10.50.79.245
-    additionalArguments:
-      - --providers.kubernetes.ingressclass=traefik-no-proxy
-      - --providers.kubernetes.ingressendpoint.publishedService=traefik
+    kubernetes:
+      ingressEndpoint:
+        ip: 51.11.45.81
+        useDefaultPublishedService: false

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -9,5 +9,5 @@ spec:
   values:
     loadBalancer: 10.50.79.230
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik-private
+      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,7 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 10.50.79.230
-    additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
-      - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81
+    loadBalancer: 10.50.79.246

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -8,3 +8,6 @@ metadata:
 spec:
   values:
     loadBalancer: 10.50.79.245
+    additionalArguments:
+      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
+      - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 10.50.79.246
+    loadBalancer: 10.50.79.245

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-00.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 51.11.25.221
+    loadBalancer: 10.50.79.230
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.45.81

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 10.50.95.250
+    loadBalancer: 51.11.25.221
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik
       - --providers.kubernetesingress.ingressendpoint.ip=20.90.5.129

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -10,4 +10,4 @@ spec:
     loadBalancer: 51.11.25.221
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
-      - --providers.kubernetesingress.ingressendpoint.ip=20.90.5.129
+      - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,4 +7,6 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 20.68.186.154
+    additionalArguments:
+      - --providers.kubernetesingress.ingressclass=traefik
+      - --providers.kubernetesingress.ingressendpoint.ip=20.90.5.129

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 51.11.25.221
+    loadBalancer: 51.11.5.163
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -9,5 +9,5 @@ spec:
   values:
     loadBalancer: 51.11.25.221
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik
+      - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=20.90.5.129

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
+    loadBalancer: 10.50.95.250
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik
       - --providers.kubernetesingress.ingressendpoint.ip=20.90.5.129

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,4 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 10.50.95.240
+    loadBalancer: 10.50.95.245

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 51.11.5.163
+    loadBalancer: 10.50.95.230
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -7,7 +7,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancer: 10.50.95.230
-    additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
-      - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194
+    loadBalancer: 10.50.95.240

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -8,3 +8,5 @@ metadata:
 spec:
   values:
     loadBalancer: 10.50.95.245
+      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
+      - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -9,5 +9,5 @@ spec:
   values:
     loadBalancer: 10.50.95.230
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik-private
+      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
       - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -8,5 +8,6 @@ metadata:
 spec:
   values:
     loadBalancer: 10.50.95.245
-      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
-      - --providers.kubernetesingress.ingressendpoint.ip=51.11.46.194
+    additionalArguments:
+      - --providers.kubernetes.ingressclass=traefik-no-proxy
+      - --providers.kubernetes.ingressendpoint.publishedService=traefik

--- a/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-no-proxy/patches/demo-01.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   values:
     loadBalancer: 10.50.95.245
-    additionalArguments:
-      - --providers.kubernetes.ingressclass=traefik-no-proxy
-      - --providers.kubernetes.ingressendpoint.publishedService=traefik
+    kubernetes:
+      ingressEndpoint:
+        ip: 51.11.46.194
+        useDefaultPublishedService: false

--- a/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.51.15.221
+    loadBalancerIP: 10.50.79.221

--- a/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.250
+    loadBalancerIP: 10.50.79.251

--- a/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.251
+    loadBalancerIP: 10.50.79.221

--- a/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-00.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.221
+    loadBalancerIP: 10.50.79.250

--- a/k8s/namespaces/admin/traefik-private/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-01.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.51.31.251
+    loadBalancerIP: 10.50.95.251

--- a/k8s/namespaces/admin/traefik-private/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-01.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.95.251
+    loadBalancerIP: 10.50.95.250

--- a/k8s/namespaces/admin/traefik-private/patches/demo-01.yaml
+++ b/k8s/namespaces/admin/traefik-private/patches/demo-01.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.95.250
+    loadBalancerIP: 10.50.95.251

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
@@ -8,7 +8,7 @@ spec:
     loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.5.163
+        ip: 51.11.25.221
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.51.15.220
+    loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
         ip: 51.11.25.221
@@ -18,4 +18,4 @@ spec:
       domain: traefik00.demo.platform.hmcts.net
     service:
       annotations:
-        service.beta.kubernetes.io/azure-load-balancer-resource-group: aks-infra-demo-rg
+        service.beta.kubernetes.io/azure-load-balancer-resource-group: cft-demo-network-rg

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.220
+    loadBalancerIP: 10.50.79.250
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.25.221
+        ip: 51.11.5.163
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.50.79.250
+    loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
         ip: 51.11.5.163

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-00/traefik.yaml
@@ -8,7 +8,7 @@ spec:
     loadBalancerIP: 10.50.79.220
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.25.221
+        ip: 51.11.45.81
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
@@ -8,7 +8,7 @@ spec:
     loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.5.163
+        ip: 51.11.25.221
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
@@ -8,7 +8,7 @@ spec:
     loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.25.221
+        ip: 51.11.5.163
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: admin
 spec:
   values:
-    loadBalancerIP: 10.51.31.250
+    loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
         ip: 20.68.184.102
@@ -18,4 +18,4 @@ spec:
       domain: traefik01.demo.platform.hmcts.net
     service:
       annotations:
-        service.beta.kubernetes.io/azure-load-balancer-resource-group: aks-infra-demo-rg
+        service.beta.kubernetes.io/azure-load-balancer-resource-group: cft-demo-network-rg

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
@@ -8,7 +8,7 @@ spec:
     loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
-        ip: 20.68.184.102
+        ip: 51.11.5.163
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true

--- a/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
+++ b/k8s/namespaces/admin/traefik/patches/demo/cluster-01/traefik.yaml
@@ -8,7 +8,7 @@ spec:
     loadBalancerIP: 10.50.95.250
     kubernetes:
       ingressEndpoint:
-        ip: 51.11.5.163
+        ip: 51.11.46.194
         useDefaultPublishedService: false
     forwardedHeaders:
       enabled: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-5329

### Change description ###

updated traefik to use new AKS cluster

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
