### PR TITLE
CHG5007200: Scale idam-api back up

### DIFF
--- a/k8s/aat/common/idam/idam-api.yaml
+++ b/k8s/aat/common/idam/idam-api.yaml
@@ -18,7 +18,7 @@ spec:
     version: 0.4.3
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-d82ff46-20220225083042
+      image: hmctspublic.azurecr.io/idam/api:prod-c6efeaa-20220302213755
       replicas: 4
       ingressHost: idam-api.aat.platform.hmcts.net
       aadIdentityName: idam

--- a/k8s/demo/common/idam/idam-api.yaml
+++ b/k8s/demo/common/idam/idam-api.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.4.3
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-d82ff46-20220225083042
+      image: hmctspublic.azurecr.io/idam/api:prod-c6efeaa-20220302213755
       imagePullPolicy: Always
       replicas: 2
       ingressClass: traefik-private

--- a/k8s/ithc/common/idam/idam-api.yaml
+++ b/k8s/ithc/common/idam/idam-api.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.4.3
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-d82ff46-20220225083042
+      image: hmctspublic.azurecr.io/idam/api:prod-c6efeaa-20220302213755
       imagePullPolicy: Always
       ingressHost: idam-api.ithc.platform.hmcts.net
       replicas: 1

--- a/k8s/perftest/cluster-00/idam/idam-api.yaml
+++ b/k8s/perftest/cluster-00/idam/idam-api.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.4.3
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-d82ff46-20220225083042
+      image: hmctspublic.azurecr.io/idam/api:prod-c6efeaa-20220302213755
       imagePullPolicy: Always
       replicas: 4
       ingressHost: idam-api.perftest.platform.hmcts.net

--- a/k8s/perftest/cluster-01/idam/idam-api.yaml
+++ b/k8s/perftest/cluster-01/idam/idam-api.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.4.3
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-d82ff46-20220225083042
+      image: hmctspublic.azurecr.io/idam/api:prod-c6efeaa-20220302213755
       imagePullPolicy: Always
       replicas: 4
       ingressHost: idam-api.perftest.platform.hmcts.net

--- a/k8s/prod/common/idam/idam-api.yaml
+++ b/k8s/prod/common/idam/idam-api.yaml
@@ -18,8 +18,8 @@ spec:
     version: 0.4.3
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-efb7cfc-20220214150644
-      replicas: 0
+      image: hmctspublic.azurecr.io/idam/api:prod-c6efeaa-20220302213755
+      replicas: 4
       ingressHost: idam-api.platform.hmcts.net
       aadIdentityName: idam
       useInterpodAntiAffinity: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
CHG5007200

https://tools.hmcts.net/jira/browse/SIDM-6817


### Change description ###
* Scale idam-api in Prod back to 4 replicas. 
* Apply latest idam-api prod image to all environments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
