### PR TITLE
Override key vault in demo

### DIFF
--- a/k8s/namespaces/civil/civil-service/demo.yaml
+++ b/k8s/namespaces/civil/civil-service/demo.yaml
@@ -6,5 +6,26 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/civil/service:pr-730-f742d40-20220303091554 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      keyVaults:
+        civil:
+          resourceGroup: civil
+          secrets:
+            - civil-idam-client-secret
+            - microservicekey-civil-service
+            - system-update-user-username
+            - system-update-user-password
+            - cross-access-user-username
+            - cross-access-user-password
+            - prd-admin-user-username
+            - prd-admin-user-password
+            - AppInsightsInstrumentationKey
+            - docmosis-api-key
+            - gov-notify-api-key
+            - sendgrid-api-key
+            - robotics-notification-sender
+            - robotics-notification-recipient
+            - launch-darkly-sdk-key
+            - robotics-notification-multipartyrecipient
+            - ordnance-survey-api-key
       environment:
         TESTING_SUPPORT_ENABLED: true


### PR DESCRIPTION
ordnance-survey-api-key is not available in prod yet. So overriding all the keyvault in demo