### PR TITLE
Change startupProbe path

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -10,7 +10,9 @@ spec:
       healthProbes: true
       probes:
         startupProbe:
-          failureThreshold: 15
+          httpGet:
+            path: /
+          failureThreshold: 20
       javaOpts: >-
         -XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=60.0 -XX:MinRAMPercentage=20.0 -XX:+UseParallelOldGC -Xlog:gc*=info,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/workspace/gc.log::filecount=5,filesize=40M -Djava.util.logging.config.file=/var/jenkins_home/userconf/logging.properties -Djenkins.azure-keyvault.uami.enabled=true -Djenkins.ui.refresh=true -Djenkins.model.Jenkins.logStartupPerformance=true -Dkubernetes.websocket.ping.interval=30000 -Dorg.apache.commons.jelly.tags.fmt.timeZone=Europe/London -Djava.net.preferIPv4Stack=true -Dhudson.model.WorkspaceCleanupThread.retainForDays=2 -Dhudson.model.DirectoryBrowserSupport.CSP="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self'"
       ingress:


### PR DESCRIPTION
Seeing `Startup probe failed: HTTP probe failed with statuscode: 503` in SBOX Jenkins pod logs, timeout period seems fine but also seeing:

```
WARNING: Exception thrown during refresh
java.util.concurrent.CompletionException: org.springframework.security.access.AccessDeniedException: Please login to access job HMCTS_Sandbox_CDM
```

In the pod logs, meaning the '/login' default path could be causing the 503.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
