### PR TITLE
Add Dynatrace Dynakubes crd

### DIFF
--- a/apps/monitoring/base/kustomize.yaml
+++ b/apps/monitoring/base/kustomize.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-crd
+    - name: dynatrace-crd
   path: ./apps/monitoring/${ENVIRONMENT}/${CLUSTER}
   postBuild:
     substitute:
@@ -20,3 +21,12 @@ metadata:
   namespace: flux-system
 spec:
   path: ./apps/monitoring/kube-prometheus-stack-crds
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: dynatrace-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/monitoring/dynatrace-crds

--- a/apps/monitoring/base/kustomize.yaml
+++ b/apps/monitoring/base/kustomize.yaml
@@ -29,4 +29,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m
-  path: ./apps/monitoring/dynatrace-crds
+  path: ./apps/monitoring/dynatrace/dynatrace-crds

--- a/apps/monitoring/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/monitoring/dynatrace/dynatrace-crds/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.4.2/dynatrace.com_dynakubes.yaml


### PR DESCRIPTION
### Change description ###
Getting below error so adding dynakubes crd
{"error":"customresourcedefinitions.apiextensions.k8s.io \"dynakubes.dynatrace.com\" not found","level":"error","logger":"main.controller.deployment","msg":"Reconciler error","name":"dynatrace-webhook","namespace":"monitoring","reconciler group":"apps","reconciler kind":"Deployment","stacktrace":"customresourcedefinitions.apiextensions.k8s.io \"dynakubes.dynatrace.com\" not found


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
