### PR TITLE
Revert "DTSPO-6659-Double AM Pod replicas"

### DIFF
--- a/k8s/namespaces/am/am-org-role-mapping-service/prod.yaml
+++ b/k8s/namespaces/am/am-org-role-mapping-service/prod.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 4
       environment:
         AM_INFO: false
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o

--- a/k8s/namespaces/am/am-role-assignment-service/prod.yaml
+++ b/k8s/namespaces/am/am-role-assignment-service/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      replicas: 10
+      replicas: 5
       memoryRequests: "1024Mi"
       memoryLimits: "2048Mi"
       cpuRequests: "1000m"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#14706 to scale back pod following cluster rebuild.