### PR TITLE
Revert "DTSPO-6659 - PROD - AKS Upgrade - Double Pods Replica"

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-97407f6-20210803165122
-      replicas: 8
+      replicas: 4
       ingressHost: idam-api.platform.hmcts.net
       aadIdentityName: idam
       useInterpodAntiAffinity: true

--- a/apps/idam/idam-web-public/idam-web-public.yaml
+++ b/apps/idam/idam-web-public/idam-web-public.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: idam-web-public
   values:
     java:
-      replicas: 8
       image: hmctspublic.azurecr.io/idam/web-public:prod-c93ad97-20210806181552
       ingressHost: hmcts-access.service.gov.uk
       aadIdentityName: idam

--- a/k8s/namespaces/ccd/ccd-data-store-api/prod.yaml
+++ b/k8s/namespaces/ccd/ccd-data-store-api/prod.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      replicas: 24
+      replicas: 12
       autoscaling:
         enabled: false
       memoryLimits: "4096Mi"

--- a/k8s/namespaces/ccd/ccd-definition-store-api/prod.yaml
+++ b/k8s/namespaces/ccd/ccd-definition-store-api/prod.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-definition-store-api
   values:
     java:
-      replicas: 8
+      replicas: 4
       memoryRequests: "2048Mi"
       memoryLimits: "4096Mi"
       cpuRequests: "2000m"

--- a/k8s/namespaces/dm-store/dm-store/dm-store.yaml
+++ b/k8s/namespaces/dm-store/dm-store/dm-store.yaml
@@ -10,7 +10,7 @@ spec:
     path: stable/dm-store
   values:
     java:
-      replicas: 14
+      replicas: 7
       memoryRequests: "2048Mi"
       cpuRequests: "1000m"
       memoryLimits: "4096Mi"

--- a/k8s/prod/common/idam/idam-api.yaml
+++ b/k8s/prod/common/idam/idam-api.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-d726bd2-20220303153802
-      replicas: 8
+      replicas: 4
       ingressHost: idam-api.platform.hmcts.net
       aadIdentityName: idam
       useInterpodAntiAffinity: true

--- a/k8s/prod/common/idam/idam-web-public.yaml
+++ b/k8s/prod/common/idam/idam-web-public.yaml
@@ -18,7 +18,6 @@ spec:
     version: 0.2.20
   values:
     java:
-      replicas: 8
       image: hmctspublic.azurecr.io/idam/web-public:prod-f6a6d82-20220304165516
       ingressHost: hmcts-access.service.gov.uk
       aadIdentityName: idam


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#14336 to scale back pods to original values following clusters rebuild.