### PR TITLE
Correct group for AAC nonprod access

### DIFF
--- a/k8s/aat/common-overlay/aac/kustomization.yaml
+++ b/k8s/aat/common-overlay/aac/kustomization.yaml
@@ -20,4 +20,4 @@ patchesJson6902:
       value:
         - apiGroup: rbac.authorization.k8s.io
           kind: Group
-          name: "1250b19a-8c14-4760-9538-95b313e700db"
+          name: "7df9d173-631b-47a6-8737-0f15616d25f0"

--- a/k8s/demo/common-overlay/aac/kustomization.yaml
+++ b/k8s/demo/common-overlay/aac/kustomization.yaml
@@ -22,4 +22,4 @@ patchesJson6902:
       value:
         - apiGroup: rbac.authorization.k8s.io
           kind: Group
-          name: "1250b19a-8c14-4760-9538-95b313e700db"
+          name: "7df9d173-631b-47a6-8737-0f15616d25f0"

--- a/k8s/ithc/common-overlay/aac/kustomization.yaml
+++ b/k8s/ithc/common-overlay/aac/kustomization.yaml
@@ -20,4 +20,4 @@ patchesJson6902:
       value:
         - apiGroup: rbac.authorization.k8s.io
           kind: Group
-          name: "1250b19a-8c14-4760-9538-95b313e700db"
+          name: "7df9d173-631b-47a6-8737-0f15616d25f0"

--- a/k8s/perftest/common-overlay/aac/kustomization.yaml
+++ b/k8s/perftest/common-overlay/aac/kustomization.yaml
@@ -20,4 +20,4 @@ patchesJson6902:
       value:
         - apiGroup: rbac.authorization.k8s.io
           kind: Group
-          name: "1250b19a-8c14-4760-9538-95b313e700db"
+          name: "7df9d173-631b-47a6-8737-0f15616d25f0"


### PR DESCRIPTION
### Change description ###
Give access to `dcd_ccd` instead of `dcd_cdm`.. as noone uses that group!


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
