### PR TITLE
idam-web-public (non-prod): Address CVE-2020-36518

### DIFF
--- a/k8s/aat/common/idam/idam-web-public.yaml
+++ b/k8s/aat/common/idam/idam-web-public.yaml
@@ -18,7 +18,7 @@ spec:
     version: 0.2.20
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f6a6d82-20220304165516
+      image: hmctspublic.azurecr.io/idam/web-public:prod-1f1604e-20220323091627
       ingressHost: idam-web-public.aat.platform.hmcts.net
       replicas: 2
       aadIdentityName: idam

--- a/k8s/demo/common/idam/idam-web-public.yaml
+++ b/k8s/demo/common/idam/idam-web-public.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.2.20
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f6a6d82-20220304165516
+      image: hmctspublic.azurecr.io/idam/web-public:prod-1f1604e-20220323091627
       imagePullPolicy: Always
       ingressClass: traefik-no-proxy
       ingressHost: idam-web-public.demo.platform.hmcts.net

--- a/k8s/ithc/common/idam/idam-web-public.yaml
+++ b/k8s/ithc/common/idam/idam-web-public.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.2.20
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f6a6d82-20220304165516
+      image: hmctspublic.azurecr.io/idam/web-public:prod-1f1604e-20220323091627
       imagePullPolicy: Always
       ingressHost: idam-web-public.ithc.platform.hmcts.net
       replicas: 1

--- a/k8s/perftest/common/idam/idam-web-public.yaml
+++ b/k8s/perftest/common/idam/idam-web-public.yaml
@@ -15,7 +15,7 @@ spec:
     version: 0.2.20
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f6a6d82-20220304165516
+      image: hmctspublic.azurecr.io/idam/web-public:prod-1f1604e-20220323091627
       imagePullPolicy: Always
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       aadIdentityName: idam


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7301


### Change description ###
Latest prod images for idam-web-public to non-prod environments.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
