### PR TITLE
Removed prefix as it will be prefixed with a hyphen

### DIFF
--- a/k8s/namespaces/nfdiv/nfdiv-frontend/prod.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-frontend/prod.yaml
@@ -12,8 +12,7 @@ spec:
     nodejs:
       registerAdditionalDns:
         enabled: true
-        prefix: www
-        primaryIngressHost: end-civil-partnership.service.gov.uk
+        primaryIngressHost: www.end-civil-partnership.service.gov.uk
       environment:
         EQUALITY_URL: https://equality-and-diversity.platform.hmcts.net/
         IDAM_WEB_URL: https://hmcts-access.service.gov.uk/login


### PR DESCRIPTION
DNS prefix will resolve as: prefix-{registerAdditionalDns.primaryIngressHost} and we expect the ingress host to be https://www.end-civil-partnership.service.gov.uk