### PR TITLE
SIDM-7276 deploy to aat

### DIFF
--- a/apps/idam/aat/base/kustomization.yaml
+++ b/apps/idam/aat/base/kustomization.yaml
@@ -2,5 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../idam-testing-support-api/idam-testing-support-api.yaml
 patchesStrategicMerge:
+  - ../../idam-testing-support-api/aat.yaml
   - ../../identity/aat.yaml

--- a/apps/idam/idam-testing-support-api/aat.yaml
+++ b/apps/idam/idam-testing-support-api/aat.yaml
@@ -1,0 +1,13 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: idam-testing-support-api
+  namespace: idam
+spec:
+  releaseName: idam-testing-support-api
+  values:
+    java:
+      ingressHost: idam-testing-support-api.aat.platform.hmcts.net
+      environment:
+        IDAM_API_URL: https://idam-api.aat.platform.hmcts.net
+        SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: https://idam-web-public.aat.platform.hmcts.net/o/jwks

--- a/apps/idam/idam-testing-support-api/idam-testing-support-api.yaml
+++ b/apps/idam/idam-testing-support-api/idam-testing-support-api.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: idam-testing-support-api
-      version: 0.0.12
+      version: 0.0.14
       sourceRef:
         kind: HelmRepository
         name: hmctspublic


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-7276

### Change description ###

Deploy testing support api to AAT.

Note that this API will never be deployed to prod, which is why it isn't being added to the base kustomize.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
