### PR TITLE
Removed Family Private Law jenkins pipeline

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -281,12 +281,6 @@ spec:
                     title: Performance Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS_.*FPRL.*\/(fprl-cos-api|fprl-ccd-definitions)\/master
-                    name: FPRL
-                    recurse: true
-                    title: Family Private Law
-                - buildMonitor:
-                    includeRegex: >-
                       ^HMCTS_.*PRL.*\/(prl-cos-api|prl-ccd-definitions|prl-dgs-api)\/master
                     name: PRL
                     recurse: true


### PR DESCRIPTION
### Change description ###
Removed Family Private Law jenkins pipeline as redundant. It was created by previous team while this project was started. Now replaced with Private Law


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
