### PR TITLE
keda v2 base patch

### DIFF
--- a/apps/admin/keda/keda2.yaml
+++ b/apps/admin/keda/keda2.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: keda
+  namespace: admin
+spec:
+  values:
+    podIdentity:
+      activeDirectory:
+        identity: keda
+  chart:
+    spec:
+      chart: keda
+      version: 2.6.0


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-7583](https://tools.hmcts.net/jira/browse/DTSPO-7583)


### Change description ###
Base Keda version 2. Preparation for Preview and subsequent environments migration.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
