### PR TITLE
DTSPO-7559 Disable stapler instrumentation in Jenkins

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -23,6 +23,7 @@ spec:
         -Djava.net.preferIPv4Stack=true
         -Dhudson.model.WorkspaceCleanupThread.retainForDays=2
         -Djenkins.scm.api.SCMEvent.EVENT_THREAD_POOL_SIZE=11
+        -Dotel.instrumentation.jenkins.web.enabled=false
       ingress:
         hostName: sandbox-build.platform.hmcts.net
       secondaryingress:


### PR DESCRIPTION
not needed for now and it means a lot of spam in dynatrace, can enable later if we want