### PR TITLE
Dtspo 7583/kedav2 demo

### DIFF
--- a/apps/admin/demo/base/kustomization.yaml
+++ b/apps/admin/demo/base/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
 
 patchesStrategicMerge:
   - keda-identity.yaml
+  - ../../keda/keda2.yaml


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7583


### Change description ###
Depends on https://github.com/hmcts/cnp-flux-config/pull/15288 (MERGED)

Once the PR above is merged, this PR adds a patch to the Demo base Helm Release that upgrades keda to keda 2.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
