### PR TITLE
Flux v1 tuning - Extend git.pollInterval

### DIFF
--- a/k8s/namespaces/admin/flux/flux.yaml
+++ b/k8s/namespaces/admin/flux/flux.yaml
@@ -18,7 +18,7 @@ spec:
   values:
     git:
       url: git@github.com:hmcts/cnp-flux-config
-      pollInterval: 1m
+      pollInterval: 3m
       secretName: flux-git-deploy
       timeout: "180s"
     syncGarbageCollection:


### PR DESCRIPTION
Tested on perftest clusters where flux was previously failing
Have tested multiple values, was still seeing some timeouts and restarts at 2 mins.
https://github.com/fluxcd/flux/blob/v1.24.3/chart/flux/values.yaml#L103

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
