### PR TITLE
CTSC work-allocation migrated to FluxV1

### DIFF
--- a/k8s/aat/common-overlay/ctsc/kustomization.yaml
+++ b/k8s/aat/common-overlay/ctsc/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: ctsc
 bases:
 - ../../../namespaces/ctsc
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+patchesStrategicMerge:
+- ../../../namespaces/ctsc/ctsc-work-allocation/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/demo/common-overlay/ctsc/kustomization.yaml
+++ b/k8s/demo/common-overlay/ctsc/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: ctsc
 bases:
 - ../../../namespaces/ctsc
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+patchesStrategicMerge:
+- ../../../namespaces/ctsc/ctsc-work-allocation/demo.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/namespaces/ctsc/ctsc-work-allocation/aat.yaml
+++ b/k8s/namespaces/ctsc/ctsc-work-allocation/aat.yaml
@@ -3,27 +3,19 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: ctsc-work-allocation
+  namespace: ctsc
 spec:
   releaseName: ctsc-work-allocation
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/ctsc-work-allocation
   values:
     java:
       replicas: 0
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ctsc/work-allocation:prod-4112441-20210629154144   #{"$imagepolicy": "flux-system:ctsc-work-allocation"}
       environment:
-        IDAM_CLIENT_BASE_URL: https://idam-api.platform.hmcts.net
-        TEST_ENDPOINTS_ENABLED: false
+        TEST_ENDPOINTS_ENABLED: true
         SMTP_ENABLED: true
         CCD_DRY_RUN: false
-        DEEPLINK_BASE_URL: https://manage-case.platform.hmcts.net/v2/case/
     global:
-      environment: prod
+      environment: aat
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/namespaces/ctsc/ctsc-work-allocation/ctsc-work-allocation.yaml
+++ b/k8s/namespaces/ctsc/ctsc-work-allocation/ctsc-work-allocation.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ctsc-work-allocation
+spec:
+  releaseName: ctsc-work-allocation
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/ctsc-work-allocation

--- a/k8s/namespaces/ctsc/ctsc-work-allocation/demo.yaml
+++ b/k8s/namespaces/ctsc/ctsc-work-allocation/demo.yaml
@@ -6,13 +6,6 @@ metadata:
   namespace: ctsc
 spec:
   releaseName: ctsc-work-allocation
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/ctsc-work-allocation
   values:
     java:
       replicas: 0

--- a/k8s/namespaces/ctsc/ctsc-work-allocation/prod.yaml
+++ b/k8s/namespaces/ctsc/ctsc-work-allocation/prod.yaml
@@ -6,23 +6,18 @@ metadata:
   namespace: ctsc
 spec:
   releaseName: ctsc-work-allocation
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/ctsc-work-allocation
   values:
     java:
       replicas: 0
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ctsc/work-allocation:prod-4112441-20210629154144   #{"$imagepolicy": "flux-system:ctsc-work-allocation"}
       environment:
-        TEST_ENDPOINTS_ENABLED: true
+        IDAM_CLIENT_BASE_URL: https://idam-api.platform.hmcts.net
+        TEST_ENDPOINTS_ENABLED: false
         SMTP_ENABLED: true
         CCD_DRY_RUN: false
+        DEEPLINK_BASE_URL: https://manage-case.platform.hmcts.net/v2/case/
     global:
-      environment: aat
+      environment: prod
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/namespaces/ctsc/kustomization.yaml
+++ b/k8s/namespaces/ctsc/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: ctsc
 bases:
 - namespace.yaml
+- ctsc-work-allocation/ctsc-work-allocation.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/prod/common-overlay/ctsc/kustomization.yaml
+++ b/k8s/prod/common-overlay/ctsc/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: ctsc
 bases:
 - ../../../namespaces/ctsc
+patchesStrategicMerge:
+- ../../../namespaces/ctsc/ctsc-work-allocation/prod.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/projects/SSCS/issues/SSCS-9588


### Change description ###
Migration of ctsc-work-allocation in prod,aat and demo Namespaces to Kustomize. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
