### PR TITLE
DTSPO-8035 - fix preftest secret

### DIFF
--- a/k8s/namespaces/bsp/bulk-scan-processor/perftest.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-processor/perftest.yaml
@@ -17,7 +17,7 @@ spec:
       keyVaults:
         "bulk-scan":
           secrets:
-            - name: processor-POSTGRES-PASS-V11
+            - name: processor-POSTGRES-PASS
               alias: BULK_SCANNING_DB_PASSWORD
             - name: s2s-secret
               alias: S2S_SECRET


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-8035 


### Change description ###
Secret name is wrong - processor-POSTGRES-PASS-V11 was changed for processor-POSTGRES-PASS. 

[Change where this happened ](https://github.com/hmcts/bulk-scan-processor/commit/bb6e6a9725868cd79207b1d4a86dc0d9bac3f695)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
