### PR TITLE
SSCS-9588-ImplementKustomize_SSCS_TyaNotif

### DIFF
--- a/apps/docmosis/docmosis/aat.yaml
+++ b/apps/docmosis/docmosis/aat.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.aat.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:aat-22da701-226952 #{"$imagepolicy": "flux-system:aat-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:aat-fa6bce6-227068 #{"$imagepolicy": "flux-system:aat-docmosis"}

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -6,4 +6,4 @@ spec:
   values:
     ingressClass: traefik-private
     ingressHost: docmosis.demo.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:demo-22da701-226952 #{"$imagepolicy": "flux-system:demo-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:demo-fa6bce6-227068 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -14,7 +14,7 @@ spec:
     ingressSessionAffinity:
       enabled: true
     envFromSecret: docmosis-secret
-    image: hmctsprivate.azurecr.io/docmosis:prod-22da701-226952 #{"$imagepolicy": "flux-system:docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:prod-fa6bce6-227068 #{"$imagepolicy": "flux-system:docmosis"}
   chart:
     spec:
       chart: base

--- a/apps/docmosis/docmosis/ithc.yaml
+++ b/apps/docmosis/docmosis/ithc.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.ithc.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:ithc-22da701-226952 #{"$imagepolicy": "flux-system:ithc-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:ithc-fa6bce6-227068 #{"$imagepolicy": "flux-system:ithc-docmosis"}

--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.perftest.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:perftest-22da701-226952 #{"$imagepolicy": "flux-system:perftest-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:perftest-fa6bce6-227068 #{"$imagepolicy": "flux-system:perftest-docmosis"}

--- a/apps/docmosis/docmosis/sbox.yaml
+++ b/apps/docmosis/docmosis/sbox.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.sandbox.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:sandbox-22da701-226952 #{"$imagepolicy": "flux-system:sandbox-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:sandbox-fa6bce6-227068 #{"$imagepolicy": "flux-system:sandbox-docmosis"}
     environment:
       DOCMOSIS_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
       DOCMOSIS_TORNADO_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net

--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/aat.yaml
+- ../../../namespaces/sscs/sscs-tya-notif/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/aat/common/sscs/sscs-bulk-scan.yaml
+++ b/k8s/aat/common/sscs/sscs-bulk-scan.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-cf34622-20220505160258 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
+      image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-67cc28f-20220510083123 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
       environment:
         IDAM_S2S_AUTH: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
         IDAM_API_URL: https://idam-api.aat.platform.hmcts.net

--- a/k8s/aat/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/aat/common/sscs/sscs-evidence-share.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d9b3ea7-20220505160317 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         WLU_EMAIL_TO: sscs-tests@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net

--- a/k8s/aat/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/aat/common/sscs/sscs-tya-notif.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-24b139e-20220506092336 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         JOB_SCHEDULER_DB_USERNAME: notification@sscs-tya-notif-postgres-v11-db-aat
         JOB_SCHEDULER_DB_NAME: notification

--- a/k8s/demo/common-overlay/sscs/kustomization.yaml
+++ b/k8s/demo/common-overlay/sscs/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/demo.yaml
+- ../../../namespaces/sscs/sscs-tya-notif/demo.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/demo/common/bsp/standalone-processor.yaml
+++ b/k8s/demo/common/bsp/standalone-processor.yaml
@@ -18,7 +18,7 @@ spec:
   values:
     bulk-scan-processor:
       java:
-        image: hmctspublic.azurecr.io/bulk-scan/processor:prod-6fdfb9a-20220505084812 #{"$imagepolicy": "flux-system:bulk-scan-processor"}
+        image: hmctspublic.azurecr.io/bulk-scan/processor:prod-ce00ab8-20220509145928 #{"$imagepolicy": "flux-system:bulk-scan-processor"}
         ingressClass: traefik-private
         ingressHost: bsp-standalone-processor.demo.platform.hmcts.net
         releaseNameOverride: "{{ .Release.Name }}-bsp"

--- a/k8s/ithc/common-overlay/sscs/kustomization.yaml
+++ b/k8s/ithc/common-overlay/sscs/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: sscs
 bases:
 - ../../../namespaces/sscs
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+patchesStrategicMerge:
+- ../../../namespaces/sscs/sscs-tya-notif/ithc.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/ithc/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/ithc/common/sscs/sscs-evidence-share.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d9b3ea7-20220505160317 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: gokul.sridharan@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net

--- a/k8s/ithc/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/ithc/common/sscs/sscs-tya-notif.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-24b139e-20220506092336 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         JOB_SCHEDULER_DB_USERNAME: "notification@sscs-tya-notif-postgres-v11-db-ithc"
         JOB_SCHEDULER_DB_NAME: "notification"

--- a/k8s/namespaces/bsp/bulk-scan-processor/bulk-scan-processor.yaml
+++ b/k8s/namespaces/bsp/bulk-scan-processor/bulk-scan-processor.yaml
@@ -15,10 +15,10 @@ spec:
       cpuRequests: "500m"
       cpuLimits: "2500m"
       memoryLimits: "4096Mi"
-      image: hmctspublic.azurecr.io/bulk-scan/processor:prod-6fdfb9a-20220505084812 #{"$imagepolicy": "flux-system:bulk-scan-processor"}
+      image: hmctspublic.azurecr.io/bulk-scan/processor:prod-ce00ab8-20220509145928 #{"$imagepolicy": "flux-system:bulk-scan-processor"}
       environment:
         STORAGE_BLOB_SELECTED_CONTAINER: ALL
       smoketests:
-        image: hmctspublic.azurecr.io/bulk-scan/processor-test:prod-6fdfb9a-20220505084812 #{"$imagepolicy": "flux-system:bulk-scan-processor-processor-test"}
+        image: hmctspublic.azurecr.io/bulk-scan/processor-test:prod-ce00ab8-20220509145928 #{"$imagepolicy": "flux-system:bulk-scan-processor-processor-test"}
       functionaltests:
-        image: hmctspublic.azurecr.io/bulk-scan/processor-test:prod-6fdfb9a-20220505084812 #{"$imagepolicy": "flux-system:bulk-scan-processor-processor-test"}
+        image: hmctspublic.azurecr.io/bulk-scan/processor-test:prod-ce00ab8-20220509145928 #{"$imagepolicy": "flux-system:bulk-scan-processor-processor-test"}

--- a/k8s/namespaces/docmosis/docmosis/aat.yaml
+++ b/k8s/namespaces/docmosis/docmosis/aat.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.aat.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:aat-22da701-226952 #{"$imagepolicy": "flux-system:aat-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:aat-fa6bce6-227068 #{"$imagepolicy": "flux-system:aat-docmosis"}

--- a/k8s/namespaces/docmosis/docmosis/demo.yaml
+++ b/k8s/namespaces/docmosis/docmosis/demo.yaml
@@ -6,4 +6,4 @@ spec:
   values:
     ingressClass: traefik-private
     ingressHost: docmosis.demo.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:demo-22da701-226952 #{"$imagepolicy": "flux-system:demo-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:demo-fa6bce6-227068 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/k8s/namespaces/docmosis/docmosis/docmosis.yaml
+++ b/k8s/namespaces/docmosis/docmosis/docmosis.yaml
@@ -22,7 +22,7 @@ spec:
     ingressSessionAffinity:
       enabled: true
     envFromSecret: docmosis-secret
-    image: hmctsprivate.azurecr.io/docmosis:prod-22da701-226952 #{"$imagepolicy": "flux-system:docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:prod-fa6bce6-227068 #{"$imagepolicy": "flux-system:docmosis"}
     environment:
       VAR_TA: trigger1
     java:

--- a/k8s/namespaces/docmosis/docmosis/ithc.yaml
+++ b/k8s/namespaces/docmosis/docmosis/ithc.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.ithc.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:ithc-22da701-226952 #{"$imagepolicy": "flux-system:ithc-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:ithc-fa6bce6-227068 #{"$imagepolicy": "flux-system:ithc-docmosis"}

--- a/k8s/namespaces/docmosis/docmosis/perftest.yaml
+++ b/k8s/namespaces/docmosis/docmosis/perftest.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.perftest.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:perftest-22da701-226952 #{"$imagepolicy": "flux-system:perftest-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:perftest-fa6bce6-227068 #{"$imagepolicy": "flux-system:perftest-docmosis"}

--- a/k8s/namespaces/em/em-anno/demo.yaml
+++ b/k8s/namespaces/em/em-anno/demo.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/em/anno:prod-7882f96-20220510075602 #{"$imagepolicy": "flux-system:em-anno"}
+      image: hmctspublic.azurecr.io/em/anno:prod-2ef5852-20220510090321 #{"$imagepolicy": "flux-system:em-anno"}
       environment:
         TEST_VAR: value1

--- a/k8s/namespaces/em/em-anno/em-anno.yaml
+++ b/k8s/namespaces/em/em-anno/em-anno.yaml
@@ -12,7 +12,7 @@ spec:
     java:
       useInterpodAntiAffinity: true
       replicas: 2
-      image: hmctspublic.azurecr.io/em/anno:prod-7882f96-20220510075602 #{"$imagepolicy": "flux-system:em-anno"}
+      image: hmctspublic.azurecr.io/em/anno:prod-2ef5852-20220510090321 #{"$imagepolicy": "flux-system:em-anno"}
       environment:
         ENABLE_METADATA_ENDPOINT: true
         TEST_VAR: value1

--- a/k8s/namespaces/em/em-npa/demo.yaml
+++ b/k8s/namespaces/em/em-npa/demo.yaml
@@ -9,6 +9,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/em/npa:prod-3524ff9-20220510075625 #{"$imagepolicy": "flux-system:em-npa"}
+      image: hmctspublic.azurecr.io/em/npa:prod-95540c8-20220510090509 #{"$imagepolicy": "flux-system:em-npa"}
       environment:
         TEST_VAR: value1

--- a/k8s/namespaces/em/em-npa/em-npa.yaml
+++ b/k8s/namespaces/em/em-npa/em-npa.yaml
@@ -12,4 +12,4 @@ spec:
     java:
       useInterpodAntiAffinity: true
       replicas: 2
-      image: hmctspublic.azurecr.io/em/npa:prod-3524ff9-20220510075625 #{"$imagepolicy": "flux-system:em-npa"}
+      image: hmctspublic.azurecr.io/em/npa:prod-95540c8-20220510090509 #{"$imagepolicy": "flux-system:em-npa"}

--- a/k8s/namespaces/ethos/repl-docmosis-service/demo.yaml
+++ b/k8s/namespaces/ethos/repl-docmosis-service/demo.yaml
@@ -7,6 +7,6 @@ spec:
   releaseName: repl-docmosis-service
   values:
     java:
-      image: hmctspublic.azurecr.io/ethos/repl-docmosis-backend:pr-1760-a1f2c89-20220506082728 #{"$imagepolicy": "flux-system:demo-repl-docmosis-service"}
+      image: hmctspublic.azurecr.io/ethos/repl-docmosis-backend:pr-1760-ca65763-20220510075306 #{"$imagepolicy": "flux-system:demo-repl-docmosis-service"}
     environment:
       SECURE_DOC_STORE_FEATURE: true

--- a/k8s/namespaces/fees-pay/ccpay-bubble-frontend/demo.yaml
+++ b/k8s/namespaces/fees-pay/ccpay-bubble-frontend/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccpay-bubble-frontend
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccpay/bubble-frontend:pr-648-5dac904-20220421223036 #{"$imagepolicy": "flux-system:demo-ccpay-bubble-frontend"}
+      image: hmctspublic.azurecr.io/ccpay/bubble-frontend:pr-657-e534737-20220509161421 #{"$imagepolicy": "flux-system:demo-ccpay-bubble-frontend"}
       environment:
         PCIPAL_ANTENNA_URL: https://paybubble.demo.platform.hmcts.net/ccd-search
         DUMMY_RESTART_VAR: true

--- a/k8s/namespaces/hmc/hmc-cft-hearing-service/hmc-cft-hearing-service.yaml
+++ b/k8s/namespaces/hmc/hmc-cft-hearing-service/hmc-cft-hearing-service.yaml
@@ -12,7 +12,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-c31c794-20220509124417 #{"$imagepolicy": "flux-system:hmc-cft-hearing-service"}
+      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-ec167e2-20220510090529 #{"$imagepolicy": "flux-system:hmc-cft-hearing-service"}
       environment:
         HMC_ACCESS_CONTROL_ENABLED: false
         DUMMY_VAR: 1

--- a/k8s/namespaces/pcq/pcq-frontend/pcq-frontend.yaml
+++ b/k8s/namespaces/pcq/pcq-frontend/pcq-frontend.yaml
@@ -16,4 +16,4 @@ spec:
       cpuLimits: "1500m"
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/pcq/frontend:prod-0516b5e-20220509143810 #{"$imagepolicy": "flux-system:pcq-frontend"}
+      image: hmctspublic.azurecr.io/pcq/frontend:prod-7477186-20220510092235 #{"$imagepolicy": "flux-system:pcq-frontend"}

--- a/k8s/namespaces/sscs/kustomization.yaml
+++ b/k8s/namespaces/sscs/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: sscs
 bases:
 - namespace.yaml
+- sscs-tya-notif/sscs-tya-notif.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/sscs/sscs-tya-notif/aat.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/aat.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-f822e9c-20220505120102 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         JOB_SCHEDULER_DB_USERNAME: notification@sscs-tya-notif-postgres-v11-db-aat
         JOB_SCHEDULER_DB_NAME: notification

--- a/k8s/namespaces/sscs/sscs-tya-notif/demo.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/demo.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/sscs/sscs-tya-notif/ithc.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/ithc.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-f822e9c-20220505120102 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         JOB_SCHEDULER_DB_USERNAME: "notification@sscs-tya-notif-postgres-v11-db-ithc"
         JOB_SCHEDULER_DB_NAME: "notification"

--- a/k8s/namespaces/sscs/sscs-tya-notif/perftest.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/perftest.yaml
@@ -6,18 +6,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-d6497b0-20220504142519   #{"$imagepolicy": "flux-system:sscs-tya-notif"
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-994eb6b-20220121092259   #{"$imagepolicy": "flux-system:sscs-tya-notif"
       environment:
         COVID_19_NOTIFICATION_FEATURE: false
         PDF_SERVICE_HEALTH_URL: https://docmosis.perftest.platform.hmcts.net/rs/status

--- a/k8s/namespaces/sscs/sscs-tya-notif/prod.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/prod.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-f822e9c-20220505120102 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks

--- a/k8s/namespaces/sscs/sscs-tya-notif/sscs-tya-notif.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/sscs-tya-notif.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: sscs-tya-notif
+  namespace: sscs
+spec:
+  releaseName: sscs-tya-notif
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-tya-notif

--- a/k8s/perftest/common-overlay/sscs/kustomization.yaml
+++ b/k8s/perftest/common-overlay/sscs/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: sscs
 bases:
 - ../../../namespaces/sscs
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+patchesStrategicMerge:
+- ../../../namespaces/sscs/sscs-tya-notif/perftest.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/perftest/common/sscs/sscs-bulk-scan.yaml
+++ b/k8s/perftest/common/sscs/sscs-bulk-scan.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-cf34622-20220505160258 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
+      image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-67cc28f-20220510083123 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
       environment:
     global:
       environment: perftest

--- a/k8s/perftest/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/perftest/common/sscs/sscs-evidence-share.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d9b3ea7-20220505160317 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: gokul.sridharan@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net

--- a/k8s/prod/common-overlay/sscs/kustomization.yaml
+++ b/k8s/prod/common-overlay/sscs/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: sscs
 bases:
 - ../../../namespaces/sscs
+patchesStrategicMerge:
+- ../../../namespaces/sscs/sscs-tya-notif/prod.yaml

--- a/k8s/prod/common/sscs/sscs-bulk-scan.yaml
+++ b/k8s/prod/common/sscs/sscs-bulk-scan.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-cf34622-20220505160258 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
+      image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-67cc28f-20220510083123 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
       environment:
         IDAM_URL: https://idam-api.platform.hmcts.net
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks

--- a/k8s/prod/common/sscs/sscs-evidence-share.yaml
+++ b/k8s/prod/common/sscs/sscs-evidence-share.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d9b3ea7-20220505160317 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks

--- a/k8s/prod/common/sscs/sscs-tya-notif.yaml
+++ b/k8s/prod/common/sscs/sscs-tya-notif.yaml
@@ -16,7 +16,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-24b139e-20220506092336 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9588


### Change description ###
SSCS-tyaNotif migrated to FluxV1
Migration of application tya-notif in SSCS Namespaces to Kustomize.
Application currently running in aat, demo, ithc, perftest and prod clusters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
