### PR TITLE
SSCS-9588-ImplementKustomize_SSCS_TyaNotif3

### DIFF
--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/aat.yaml
+- ../../../namespaces/sscs/sscs-tya-notif/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/demo/common-overlay/sscs/kustomization.yaml
+++ b/k8s/demo/common-overlay/sscs/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/demo.yaml
+- ../../../namespaces/sscs/sscs-tya-notif/demo.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/ithc/common-overlay/sscs/kustomization.yaml
+++ b/k8s/ithc/common-overlay/sscs/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: sscs
 bases:
 - ../../../namespaces/sscs
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+patchesStrategicMerge:
+- ../../../namespaces/sscs/sscs-tya-notif/ithc.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/namespaces/sscs/kustomization.yaml
+++ b/k8s/namespaces/sscs/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: sscs
 bases:
 - namespace.yaml
+- sscs-tya-notif/sscs-tya-notif.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/sscs/sscs-tya-notif/aat.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/aat.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-f822e9c-20220505120102 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         JOB_SCHEDULER_DB_USERNAME: notification@sscs-tya-notif-postgres-v11-db-aat
         JOB_SCHEDULER_DB_NAME: notification

--- a/k8s/namespaces/sscs/sscs-tya-notif/demo.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/demo.yaml
@@ -5,13 +5,6 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/sscs/sscs-tya-notif/ithc.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/ithc.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-f822e9c-20220505120102 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         JOB_SCHEDULER_DB_USERNAME: "notification@sscs-tya-notif-postgres-v11-db-ithc"
         JOB_SCHEDULER_DB_NAME: "notification"

--- a/k8s/namespaces/sscs/sscs-tya-notif/perftest.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/perftest.yaml
@@ -6,18 +6,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-d6497b0-20220504142519   #{"$imagepolicy": "flux-system:sscs-tya-notif"
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-994eb6b-20220121092259   #{"$imagepolicy": "flux-system:sscs-tya-notif"
       environment:
         COVID_19_NOTIFICATION_FEATURE: false
         PDF_SERVICE_HEALTH_URL: https://docmosis.perftest.platform.hmcts.net/rs/status

--- a/k8s/namespaces/sscs/sscs-tya-notif/prod.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/prod.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tya-notif
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-98575b1-20220510082945 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
+      image: hmctspublic.azurecr.io/sscs/tya-notif:prod-f822e9c-20220505120102 #{"$imagepolicy": "flux-system:sscs-tya-notif"}
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks

--- a/k8s/namespaces/sscs/sscs-tya-notif/sscs-tya-notif.yaml
+++ b/k8s/namespaces/sscs/sscs-tya-notif/sscs-tya-notif.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: sscs-tya-notif
+  namespace: sscs
+spec:
+  releaseName: sscs-tya-notif
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-tya-notif

--- a/k8s/perftest/common-overlay/sscs/kustomization.yaml
+++ b/k8s/perftest/common-overlay/sscs/kustomization.yaml
@@ -4,6 +4,8 @@ namespace: sscs
 bases:
 - ../../../namespaces/sscs
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
+patchesStrategicMerge:
+- ../../../namespaces/sscs/sscs-tya-notif/perftest.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/prod/common-overlay/sscs/kustomization.yaml
+++ b/k8s/prod/common-overlay/sscs/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: sscs
 bases:
 - ../../../namespaces/sscs
+patchesStrategicMerge:
+- ../../../namespaces/sscs/sscs-tya-notif/prod.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9588


### Change description ###
SSCS-tyaNotif migrated to FluxV1
Migration of application tya-notif in SSCS Namespaces to Kustomize.
Application currently running in aat, demo, ithc, perftest and prod clusters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
