### PR TITLE
SSCS-9588-ImplementKustomize_SSCS_EvidenceShare

### DIFF
--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -10,6 +10,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/aat.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/aat.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/aat.yaml
+- ../../../namespaces/sscs/sscs-evidence-share/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/demo/common-overlay/sscs/kustomization.yaml
+++ b/k8s/demo/common-overlay/sscs/kustomization.yaml
@@ -10,6 +10,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/demo.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/demo.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/demo.yaml
+- ../../../namespaces/sscs/sscs-evidence-share/demo.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/ithc/common-overlay/sscs/kustomization.yaml
+++ b/k8s/ithc/common-overlay/sscs/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/ithc.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/ithc.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/ithc.yaml
+- ../../../namespaces/sscs/sscs-evidence-share/ithc.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/namespaces/sscs/kustomization.yaml
+++ b/k8s/namespaces/sscs/kustomization.yaml
@@ -6,4 +6,5 @@ bases:
 - sscs-tya-notif/sscs-tya-notif.yaml
 - sscs-ccd-callback-orchestrator/sscs-ccd-callback-orchestrator.yaml
 - sscs-cor-frontend/sscs-cor-frontend.yaml
+- sscs-evidence-share/sscs-evidence-share.yaml
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.

--- a/k8s/namespaces/sscs/sscs-evidence-share/aat.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/aat.yaml
@@ -4,12 +4,9 @@ metadata:
   name: sscs-evidence-share
   namespace: sscs
 spec:
-  releaseName: sscs-evidence-share
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         WLU_EMAIL_TO: sscs-tests@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
@@ -22,5 +19,3 @@ spec:
         GAPS_SWITCHOVER_FEATURE: true
     global:
       environment: aat
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/aat.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/aat.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-evidence-share
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-evidence-share
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         WLU_EMAIL_TO: sscs-tests@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net

--- a/k8s/namespaces/sscs/sscs-evidence-share/demo.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/demo.yaml
@@ -4,12 +4,9 @@ metadata:
   name: sscs-evidence-share
   namespace: sscs
 spec:
-  releaseName: sscs-evidence-share
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:pr-1283-9665907-20220504171554 #{"$imagepolicy": "flux-system:demo-sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:pr-1301-226854b-20220510105503 #{"$imagepolicy": "flux-system:demo-sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: jaya.jayasree@hmcts.net
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
@@ -25,5 +22,3 @@ spec:
         GAPS_SWITCHOVER_FEATURE: true
     global:
       environment: demo
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/demo.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/demo.yaml
@@ -5,18 +5,11 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-evidence-share
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-evidence-share
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:pr-1301-226854b-20220510105503 #{"$imagepolicy": "flux-system:demo-sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:pr-1283-9665907-20220504171554 #{"$imagepolicy": "flux-system:demo-sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: jaya.jayasree@hmcts.net
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
@@ -28,7 +21,7 @@ spec:
         SECURE_DOC_STORE_FEATURE: true
         ENHANCED_CONFIDENTIALITY_FEATURE: true
         RESTART: false
-        DUMMY_PROPERTY: false
+        DUMMY_PROPERTY: true
         GAPS_SWITCHOVER_FEATURE: true
     global:
       environment: demo

--- a/k8s/namespaces/sscs/sscs-evidence-share/ithc.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/ithc.yaml
@@ -4,12 +4,9 @@ metadata:
   name: sscs-evidence-share
   namespace: sscs
 spec:
-  releaseName: sscs-evidence-share
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: gokul.sridharan@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
@@ -20,5 +17,3 @@ spec:
         ENHANCED_CONFIDENTIALITY_FEATURE: true
     global:
       environment: ithc
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/ithc.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/ithc.yaml
@@ -5,26 +5,20 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-evidence-share
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-evidence-share
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: gokul.sridharan@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
         WLU_EMAIL_TO: sscs-tests@HMCTS.NET
-        PDF_SERVICE_HEALTH_URL: https://docmosis.perftest.platform.hmcts.net/rs/status
-        PDF_SERVICE_BASE_URL: https://docmosis.perftest.platform.hmcts.net/rs/render
+        PDF_SERVICE_HEALTH_URL: https://docmosis.ithc.platform.hmcts.net/rs/status
+        PDF_SERVICE_BASE_URL: https://docmosis.ithc.platform.hmcts.net/rs/render
+        SECURE_DOC_STORE_FEATURE: true
         ENHANCED_CONFIDENTIALITY_FEATURE: true
     global:
-      environment: perftest
+      environment: ithc
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/perftest.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/perftest.yaml
@@ -5,27 +5,19 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-evidence-share
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-evidence-share
   values:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: gokul.sridharan@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
         WLU_EMAIL_TO: sscs-tests@HMCTS.NET
-        PDF_SERVICE_HEALTH_URL: https://docmosis.ithc.platform.hmcts.net/rs/status
-        PDF_SERVICE_BASE_URL: https://docmosis.ithc.platform.hmcts.net/rs/render
-        SECURE_DOC_STORE_FEATURE: true
+        PDF_SERVICE_HEALTH_URL: https://docmosis.perftest.platform.hmcts.net/rs/status
+        PDF_SERVICE_BASE_URL: https://docmosis.perftest.platform.hmcts.net/rs/render
         ENHANCED_CONFIDENTIALITY_FEATURE: true
     global:
-      environment: ithc
+      environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/perftest.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/perftest.yaml
@@ -4,12 +4,9 @@ metadata:
   name: sscs-evidence-share
   namespace: sscs
 spec:
-  releaseName: sscs-evidence-share
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bb91c3b-20220510083202 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: gokul.sridharan@HMCTS.NET
         WLU_EMAIL_FROM: noreply@mail-sscs-nonprod.platform.hmcts.net
@@ -19,5 +16,3 @@ spec:
         ENHANCED_CONFIDENTIALITY_FEATURE: true
     global:
       environment: perftest
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/prod.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/prod.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: sscs-evidence-share
+  namespace: sscs
+spec:
+  releaseName: sscs-evidence-share
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
+      environment:
+        IDAM_API_URL: https://idam-api.platform.hmcts.net
+        IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks
+        PDF_SERVICE_BASE_URL: https://docmosis.platform.hmcts.net/rs/render
+        PDF_SERVICE_HEALTH_URL: https://docmosis.platform.hmcts.net/rs/status
+        IDAM_OAUTH2_REDIRECT_URL: https://sscs-case-loader-prod.service.core-compute-prod.internal
+        WLU_EMAIL_FROM: noreply@mail-sscs.platform.hmcts.net
+        WLU_EMAIL_TO: welsh.language.unit.manager@justice.gov.uk
+        ROBOTICS_EMAIL_FROM_SEND_GRID: noreply@mail-sscs.platform.hmcts.net
+        WLU_EMAIL_FROM_SEND_GRID: noreply@mail-sscs.platform.hmcts.net
+        SCOTTISH_PO_BOX_ENABLED: true
+        SECURE_DOC_STORE_FEATURE: true
+        CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-prod.service.core-compute-prod.internal/
+        ENHANCED_CONFIDENTIALITY_FEATURE: true
+        GAPS_SWITCHOVER_FEATURE: true
+        DUMMY_PROPERTY: true
+    global:
+      environment: prod
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/prod.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/prod.yaml
@@ -4,11 +4,8 @@ metadata:
   name: sscs-evidence-share
   namespace: sscs
 spec:
-  releaseName: sscs-evidence-share
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/evidence-share:prod-d796dc1-20220504173105 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
@@ -28,5 +25,3 @@ spec:
         DUMMY_PROPERTY: true
     global:
       environment: prod
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: sscs-evidence-share
+  namespace: sscs
+spec:
+  releaseName: sscs-evidence-share
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-evidence-share

--- a/k8s/namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+++ b/k8s/namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
@@ -12,3 +12,10 @@ spec:
     git: git@github.com:hmcts/hmcts-charts
     ref: master
     path: stable/sscs-evidence-share
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+    global:
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      enableKeyVaults: true

--- a/k8s/perftest/common-overlay/sscs/kustomization.yaml
+++ b/k8s/perftest/common-overlay/sscs/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/perftest.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/perftest.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/perftest.yaml
+- ../../../namespaces/sscs/sscs-evidence-share/perftest.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9588


### Change description ###
SSCS-evidence share migrated to FluxV1
Migration of application CCD evidence share in SSCS Namespaces to Kustomize.
Application currently running in aat, demo, ithc, and perftest clusters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
