### PR TITLE
Scs 9588 implement kustomize sscs tribunals api 2

### DIFF
--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/aat.yaml
 - ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/aat.yaml
@@ -14,6 +15,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/aat.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/aat.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/aat.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/aat.yaml
 - ../../../namespaces/sscs/sscs-tribunals-api/aat.yaml
 patchesJson6902:
 - target:

--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -7,12 +7,14 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/aat.yaml
 - ../../../namespaces/sscs/sscs-tya-notif/aat.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/aat.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/aat.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/aat.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -7,8 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
-- ../../../namespaces/sscs/sscs-bulk-scan/aat.yaml
-- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/aat.yaml
 - ../../../namespaces/sscs/sscs-tya-notif/aat.yaml
@@ -16,7 +15,6 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-cor-frontend/aat.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/aat.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/aat.yaml
-- ../../../namespaces/sscs/sscs-tribunals-api/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/demo/common-overlay/sscs/kustomization.yaml
+++ b/k8s/demo/common-overlay/sscs/kustomization.yaml
@@ -7,12 +7,14 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/demo.yaml
 - ../../../namespaces/sscs/sscs-tya-notif/demo.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/demo.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/demo.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/demo.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/demo.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/demo/common-overlay/sscs/kustomization.yaml
+++ b/k8s/demo/common-overlay/sscs/kustomization.yaml
@@ -7,6 +7,7 @@ bases:
 - ../../../namespaces/sscs/sscs-hearings-api/sscs-hearings-api.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
 - ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/demo.yaml
@@ -14,6 +15,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/demo.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/demo.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/demo.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/demo.yaml
 - ../../../namespaces/sscs/sscs-tribunals-api/demo.yaml
 patchesJson6902:
 - target:

--- a/k8s/demo/common-overlay/sscs/kustomization.yaml
+++ b/k8s/demo/common-overlay/sscs/kustomization.yaml
@@ -8,7 +8,6 @@ bases:
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
-- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/demo.yaml
 - ../../../namespaces/sscs/sscs-tya-notif/demo.yaml
@@ -16,7 +15,6 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-cor-frontend/demo.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/demo.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/demo.yaml
-- ../../../namespaces/sscs/sscs-tribunals-api/demo.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/ithc/common-overlay/sscs/kustomization.yaml
+++ b/k8s/ithc/common-overlay/sscs/kustomization.yaml
@@ -6,11 +6,13 @@ bases:
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/ithc.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/ithc.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/ithc.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/ithc.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/ithc.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/namespaces/sscs/sscs-tribunals-api/aat.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/aat.yaml
@@ -4,28 +4,14 @@ metadata:
   name: sscs-tribunals-api
   namespace: sscs
 spec:
-  releaseName: sscs-tribunals-api
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tribunals-api
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
-      aadIdentityName: sscs
       environment:
         CREATE_CCD_ENDPOINT: true
-        UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true
         PDF_SERVICE_CONVERT_URL: https://docmosis.aat.platform.hmcts.net/rs/convert
         PDF_SERVICE_HEALTH_URL: https://docmosis.aat.platform.hmcts.net/rs/status
         DOCMOSIS_SERVICE_BASE_URL: https://docmosis.aat.platform.hmcts.net/rs/render
-        MAX_FILE_SIZE: 500MB
-        MAX_REQUEST_SIZE: 500MB
         ENHANCED_CONFIDENTIALITY_FEATURE: true
         SECURE_DOC_STORE_FEATURE: true
         POSTPONEMENTS_FEATURE: true
@@ -36,5 +22,3 @@ spec:
         GAPS_SWITCHOVER_FEATURE: true
     global:
       environment: aat
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-tribunals-api/aat.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/aat.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       environment:
         CREATE_CCD_ENDPOINT: true
         PDF_SERVICE_CONVERT_URL: https://docmosis.aat.platform.hmcts.net/rs/convert

--- a/k8s/namespaces/sscs/sscs-tribunals-api/demo.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/demo.yaml
@@ -4,29 +4,15 @@ metadata:
   name: sscs-tribunals-api
   namespace: sscs
 spec:
-  releaseName: sscs-tribunals-api
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tribunals-api
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:pr-2685-d874851-20220510110441 #{"$imagepolicy": "flux-system:demo-sscs-tribunals-api"}
-      aadIdentityName: sscs
       environment:
         CREATE_CCD_ENDPOINT: true
-        UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true
         BUNDLE_URL: http://em-ccdorc-demo.service.core-compute-demo.internal
         PDF_SERVICE_CONVERT_URL: https://docmosis.demo.platform.hmcts.net/rs/convert
         PDF_SERVICE_HEALTH_URL: https://docmosis.demo.platform.hmcts.net/rs/status
         DOCMOSIS_SERVICE_BASE_URL: https://docmosis.demo.platform.hmcts.net/rs/render
-        MAX_FILE_SIZE: 500MB
-        MAX_REQUEST_SIZE: 500MB
         ENHANCED_CONFIDENTIALITY_FEATURE: true
         SECURE_DOC_STORE_FEATURE: true
         POSTPONEMENTS_FEATURE: true
@@ -38,5 +24,3 @@ spec:
         GAPS_SWITCHOVER_FEATURE: true
     global:
       environment: demo
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-tribunals-api/ithc.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/ithc.yaml
@@ -4,28 +4,14 @@ metadata:
   name: sscs-tribunals-api
   namespace: sscs
 spec:
-  releaseName: sscs-tribunals-api
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tribunals-api
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
-      aadIdentityName: sscs
       environment:
-        UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true
         BUNDLE_URL: http://em-ccdorc-ithc.service.core-compute-ithc.internal
         PDF_SERVICE_CONVERT_URL: https://docmosis.ithc.platform.hmcts.net/rs/convert
         PDF_SERVICE_HEALTH_URL: https://docmosis.ithc.platform.hmcts.net/rs/status
         DOCMOSIS_SERVICE_BASE_URL: https://docmosis.ithc.platform.hmcts.net/rs/render
-        MAX_FILE_SIZE: 500MB
-        MAX_REQUEST_SIZE: 500MB
         ENHANCED_CONFIDENTIALITY_FEATURE: true
         SECURE_DOC_STORE_FEATURE: true
         POSTPONEMENTS_FEATURE: true
@@ -34,5 +20,3 @@ spec:
         RD_LOCATION_REF_API_URL: http://rd-location-ref-api-ithc.service.core-compute-ithc.internal
     global:
       environment: ithc
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-tribunals-api/ithc.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/ithc.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       environment:
         BUNDLE_URL: http://em-ccdorc-ithc.service.core-compute-ithc.internal
         PDF_SERVICE_CONVERT_URL: https://docmosis.ithc.platform.hmcts.net/rs/convert

--- a/k8s/namespaces/sscs/sscs-tribunals-api/perftest.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/perftest.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       environment:
         PDF_SERVICE_CONVERT_URL: https://docmosis.perftest.platform.hmcts.net/rs/convert
         PDF_SERVICE_HEALTH_URL: https://docmosis.perftest.platform.hmcts.net/rs/status

--- a/k8s/namespaces/sscs/sscs-tribunals-api/perftest.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/perftest.yaml
@@ -4,34 +4,18 @@ metadata:
   name: sscs-tribunals-api
   namespace: sscs
 spec:
-  releaseName: sscs-tribunals-api
-  rollback:
-    enable: true
-    retry: true
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/sscs-tribunals-api
   values:
     java:
-      replicas: 2
-      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
-      aadIdentityName: sscs
       environment:
-        UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true
         PDF_SERVICE_CONVERT_URL: https://docmosis.perftest.platform.hmcts.net/rs/convert
         PDF_SERVICE_HEALTH_URL: https://docmosis.perftest.platform.hmcts.net/rs/status
         DOCMOSIS_SERVICE_BASE_URL: https://docmosis.perftest.platform.hmcts.net/rs/render
         ROOT_LOGGING_LEVEL: DEBUG
         DUMMY_PARAM: true
-        MAX_FILE_SIZE: 500MB
-        MAX_REQUEST_SIZE: 500MB
         ENHANCED_CONFIDENTIALITY_FEATURE: true
         SSCS2_FEATURE: true
         WORK_ALLOCATION_FEATURE: true
         RD_LOCATION_REF_API_URL: http://rd-location-ref-api-perftest.service.core-compute-perftest.internal
     global:
       environment: perftest
-      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      enableKeyVaults: true

--- a/k8s/namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+++ b/k8s/namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: sscs-tribunals-api
+  namespace: sscs
+spec:
+  releaseName: sscs-tribunals-api
+  rollback:
+    enable: true
+    retry: true
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/sscs-tribunals-api
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-c57e19c-20220506140005 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
+      environment:
+        UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true
+        MAX_FILE_SIZE: 500MB
+        MAX_REQUEST_SIZE: 500MB
+    global:
+      environment: prod

--- a/k8s/perftest/common-overlay/sscs/kustomization.yaml
+++ b/k8s/perftest/common-overlay/sscs/kustomization.yaml
@@ -7,14 +7,12 @@ bases:
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
-- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/perftest.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/perftest.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/perftest.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/perftest.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/perftest.yaml
-- ../../../namespaces/sscs/sscs-tribunals-api/perftest.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/perftest/common-overlay/sscs/kustomization.yaml
+++ b/k8s/perftest/common-overlay/sscs/kustomization.yaml
@@ -6,11 +6,13 @@ bases:
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/perftest.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/perftest.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/perftest.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/perftest.yaml
+- ../../../namespaces/sscs/sscs-tribunals-api/perftest.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io

--- a/k8s/perftest/common-overlay/sscs/kustomization.yaml
+++ b/k8s/perftest/common-overlay/sscs/kustomization.yaml
@@ -6,12 +6,14 @@ bases:
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
 - ../../../namespaces/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-tya-notif/perftest.yaml
 - ../../../namespaces/sscs/sscs-ccd-callback-orchestrator/perftest.yaml
 - ../../../namespaces/sscs/sscs-cor-frontend/perftest.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/perftest.yaml
+- ../../../namespaces/sscs/sscs-bulk-scan/perftest.yaml
 - ../../../namespaces/sscs/sscs-tribunals-api/perftest.yaml
 patchesJson6902:
 - target:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9588


### Change description ###
Migration of application SSCS_TribunalsAPI in SSCS Namespaces to Kustomize.
Application currently running in aat, demo, ithc and perftest clusters.

Replacement for https://github.com/hmcts/cnp-flux-config/pull/15676


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
