### PR TITLE
SCS-9588-ImplementKustomize_SSCS_TribunalsFEnd_T1

### DIFF
--- a/k8s/aat/common-overlay/sscs/kustomization.yaml
+++ b/k8s/aat/common-overlay/sscs/kustomization.yaml
@@ -8,6 +8,7 @@ bases:
 - ../../../namespaces/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/sscs-evidence-share.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
+- ../../../namespaces/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
 patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-hearings-api/aat.yaml
 - ../../../namespaces/sscs/sscs-tya-notif/aat.yaml
@@ -15,6 +16,7 @@ patchesStrategicMerge:
 - ../../../namespaces/sscs/sscs-cor-frontend/aat.yaml
 - ../../../namespaces/sscs/sscs-evidence-share/aat.yaml
 - ../../../namespaces/sscs/sscs-bulk-scan/aat.yaml
+- ../../../namespaces/sscs/sscs-tribunals-frontend/aat.yaml
 patchesJson6902:
 - target:
     group: rbac.authorization.k8s.io


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9588


### Change description ###
Migration of application SSCS_TribunalsFE in SSCS Namespaces to Kustomize.
Application currently running in aat, demo, ithc and perftest clusters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
