### PR TITLE
keda 2 upgrade on preview

### DIFF
--- a/apps/admin/preview/base/kustomization.yaml
+++ b/apps/admin/preview/base/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ../../keda
 patchesStrategicMerge:
   - ../../aat/base/keda-identity.yaml
+  - ../../keda/keda2.yaml


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8487 ###
### Change description ###

Keda upgrade to v2 on preview (To be merged after change request is approved as we will do all path to live tickets at the same time)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ x] Yes - all applications that use keda v1 need to change to v2 
[ ] No
```
