### PR TITLE
keda 2 upgrade on perftest

### DIFF
--- a/apps/admin/perftest/base/kustomization.yaml
+++ b/apps/admin/perftest/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 patchesStrategicMerge:
   - keda-identity.yaml
+  - ../../keda/keda2.yaml

--- a/k8s/namespaces/fees-pay/ccpay-callback-function/perftest.yaml
+++ b/k8s/namespaces/fees-pay/ccpay-callback-function/perftest.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: ccpay-callback-function
 spec:
+  chart:
+    ref: keda-v2-test
   values:
     function:
       aadIdentityName: ccpay


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8487 ###
### Change description ###

Keda upgrade to v2 on perftest (To be merged after change request is approved as we will do all environments at the same time - in order to keep in sync with teams - it will be easier)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ x] Yes - all applications that use keda v1 need to change to v2 
[ ] No
```
