### PR TITLE
keda 2 upgrade on aat

### DIFF
--- a/apps/admin/aat/base/kustomization.yaml
+++ b/apps/admin/aat/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 patchesStrategicMerge:
   - keda-identity.yaml
+  - ../../keda/keda2.yaml

--- a/k8s/namespaces/fees-pay/ccpay-callback-function/aat.yaml
+++ b/k8s/namespaces/fees-pay/ccpay-callback-function/aat.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: ccpay-callback-function
 spec:
+  chart:
+    ref: keda-v2-test
   values:
     function:
       aadIdentityName: ccpay


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8487 ###
### Change description ###

Keda upgrade to v2 on preview (To be merged after change request is approved as we will do all path to live tickets at the same time)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ x] Yes - all applications that use keda v1 need to change to v2 
[ ] No
```
