### PR TITLE
keda 2 upgrade on prod

### DIFF
--- a/apps/admin/prod/base/kustomization.yaml
+++ b/apps/admin/prod/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../rbac/reader-clusterrole.yaml
 patchesStrategicMerge:
   - keda-identity.yaml
+  - ../../keda/keda2.yaml
 patches:
   - path: ../../../rbac/prod-reader-clusterrole.yaml
     target:

--- a/apps/admin/prod/base/kustomization.yaml
+++ b/apps/admin/prod/base/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - ../../../rbac/reader-clusterrole.yaml
 patchesStrategicMerge:
   - keda-identity.yaml
-  - ../../keda/keda2.yaml
 patches:
   - path: ../../../rbac/prod-reader-clusterrole.yaml
     target:

--- a/k8s/namespaces/fees-pay/ccpay-callback-function/prod.yaml
+++ b/k8s/namespaces/fees-pay/ccpay-callback-function/prod.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: ccpay-callback-function
 spec:
+  chart:
+    ref: keda-v2-test
   values:
     function:
       aadIdentityName: ccpay


### PR DESCRIPTION
### JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8487 ###
### Change description ###

Keda upgrade to v2 on preview (To be merged after [change request](https://mojcppprod.service-now.com/nav_to.do?uri=change_request.do?sys_id=f758a8f51be78558291765b9bd4bcb62) is approved as we will do all path to live tickets at the same time)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ x] Yes - all applications that use keda v1 need to change to v2 
[ ] No
```
