### PR TITLE
Revert "Removed civil_service from whitelist for Dm-Store on all lower environments"

### DIFF
--- a/k8s/namespaces/dm-store/dm-store/aat.yaml
+++ b/k8s/namespaces/dm-store/dm-store/aat.yaml
@@ -8,7 +8,7 @@ spec:
       environment:
         ENABLE_TTL: "false"
         ENABLE_CHUNKING: "false"
-        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,unspec_service,nfdiv_case_api,wa_task_management_api,wa_task_configuration_api,wa_task_monitor,adoption_web,adoption_cos_api,et_cos,wa_case_event_handler,ccd_case_disposer
+        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,unspec_service,nfdiv_case_api,civil_service,wa_task_management_api,wa_task_configuration_api,wa_task_monitor,adoption_web,adoption_cos_api,et_cos,wa_case_event_handler,ccd_case_disposer
       testsConfig:
         memoryLimits: "3072Mi"
         environment:

--- a/k8s/namespaces/dm-store/dm-store/demo.yaml
+++ b/k8s/namespaces/dm-store/dm-store/demo.yaml
@@ -8,5 +8,4 @@ spec:
       replicas: 2
       image: hmctspublic.azurecr.io/dm/store:prod-9e8e84c-20220518212355 #{"$imagepolicy": "flux-system:demo-dm-store"}
       environment:
-        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,unspec_service,nfdiv_case_api,wa_task_management_api,wa_task_configuration_api,adoption_web,adoption_cos_api,et_cos,ccd_case_disposer
         ENABLE_TTL: false

--- a/k8s/namespaces/dm-store/dm-store/ithc.yaml
+++ b/k8s/namespaces/dm-store/dm-store/ithc.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       replicas: 4
       environment:
-        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,unspec_service,nfdiv_case_api,wa_task_management_api,wa_task_configuration_api,adoption_web,adoption_cos_api,et_cos,ccd_case_disposer
         ENABLE_TTL: false
       testsConfig:
         memoryLimits: "3072Mi"

--- a/k8s/namespaces/dm-store/dm-store/perftest.yaml
+++ b/k8s/namespaces/dm-store/dm-store/perftest.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       image: hmctspublic.azurecr.io/dm/store:prod-9e8e84c-20220518212355 #{"$imagepolicy": "flux-system:perftest-dm-store"}
       environment:
-        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,unspec_service,nfdiv_case_api,wa_task_management_api,wa_task_configuration_api,adoption_web,adoption_cos_api,et_cos,ccd_case_disposer
         ENABLE_TTL: false
         REFRESH_FLAG: VAR2
 #        ENABLE_CHUNKING: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#15829

Need to rollback this change as the flow is broken as mentioned in this ticket https://tools.hmcts.net/jira/browse/CIV-2570