### PR TITLE
Update probate-orchestrator-service.yaml

### DIFF
--- a/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
+++ b/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     name: probate-orchestrator-service
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    version: 1.0.11
+    version: 1.0.21
   values:
     tags:
       idam-pr: false

--- a/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
+++ b/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     name: probate-orchestrator-service
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    version: 1.0.22
+    version: 1.0.21
   values:
     tags:
       idam-pr: false

--- a/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
+++ b/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     name: probate-orchestrator-service
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    version: 1.0.21
+    version: 1.0.22
   values:
     tags:
       idam-pr: false

--- a/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
+++ b/k8s/namespaces/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
@@ -8,9 +8,9 @@ spec:
     enable: true
     retry: true
   chart:
-    name: probate-orchestrator-service
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    version: 1.0.21
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/probate-orchestrator-service
   values:
     tags:
       idam-pr: false


### PR DESCRIPTION
Orchestrator is pinned to an old version of Chart, preventing autoscaling being deployed.
updating to 1.0.21
https://tools.hmcts.net/jira/browse/DTSSE-1517