### PR TITLE
NFDIV-2322 : adding remind respondent solicitor cron config to prod

### DIFF
--- a/k8s/namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-00.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-00.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: nfdiv-cron-remind-respondent-solicitor
+spec:
+  releaseName: nfdiv-cron-remind-respondent-solicitor
+  values:
+    job:
+      schedule: "0,20,40 * * * *"
+      environment:
+        IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
+    global:
+      jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: prod

--- a/k8s/namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-01.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-01.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: nfdiv-cron-remind-respondent-solicitor
+spec:
+  releaseName: nfdiv-cron-remind-respondent-solicitor
+  values:
+    job:
+      schedule: "10,30,50 * * * *"
+      environment:
+        IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
+    global:
+      jobKind: CronJob
+      enableKeyVaults: true
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: prod

--- a/k8s/prod/cluster-00-overlay/nfdiv/kustomization.yaml
+++ b/k8s/prod/cluster-00-overlay/nfdiv/kustomization.yaml
@@ -19,6 +19,7 @@ bases:
   - ../../../namespaces/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
+  - ../../../namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
 patchesStrategicMerge:
   - ../../../namespaces/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod-00.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-migrate-cases/prod-00.yaml
@@ -37,3 +38,4 @@ patchesStrategicMerge:
   - ../../../namespaces/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod-00.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod-00.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod-00.yaml
+  - ../../../namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-00.yaml

--- a/k8s/prod/cluster-01-overlay/nfdiv/kustomization.yaml
+++ b/k8s/prod/cluster-01-overlay/nfdiv/kustomization.yaml
@@ -19,6 +19,7 @@ bases:
   - ../../../namespaces/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
+  - ../../../namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
 patchesStrategicMerge:
   - ../../../namespaces/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod-01.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-migrate-cases/prod-01.yaml
@@ -37,3 +38,4 @@ patchesStrategicMerge:
   - ../../../namespaces/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod-01.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod-01.yaml
   - ../../../namespaces/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod-01.yaml
+  - ../../../namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-01.yaml


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/NFDIV-2322


### Change description ###
Remind respondent solicitor cron on prod was disabled due to the errors seen in issue 2322. 
The fix for that has been approved and merged, hence enabling the cron config in prod again. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
