### PR TITLE
Increase memory limit svc cat

### DIFF
--- a/apps/catalog/svc-cat/svc-cat.yaml
+++ b/apps/catalog/svc-cat/svc-cat.yaml
@@ -21,8 +21,12 @@ spec:
       healthcheck:
         enabled: false
       resources:
+        requests:
+          cpu: 100m
+          memory: 50Mi
         limits:
-          memory: 300Mi
+          cpu: 100m
+          memory: 100Mi
   chart:
     spec:
       chart: catalog

--- a/apps/catalog/svc-cat/svc-cat.yaml
+++ b/apps/catalog/svc-cat/svc-cat.yaml
@@ -24,7 +24,7 @@ spec:
         requests:
           memory: 50Mi
         limits:
-          memory: 100Mi
+          memory: 500Mi
   chart:
     spec:
       chart: catalog

--- a/apps/catalog/svc-cat/svc-cat.yaml
+++ b/apps/catalog/svc-cat/svc-cat.yaml
@@ -22,10 +22,8 @@ spec:
         enabled: false
       resources:
         requests:
-          cpu: 100m
           memory: 50Mi
         limits:
-          cpu: 100m
           memory: 100Mi
   chart:
     spec:


### PR DESCRIPTION
svc-cat-catalog-controller-manager pod in preview & sometimes demo keeps crashing with OOMkilled error, this can cause Service Instances to get into stuck states and has been failing a few PRs.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
