### PR TITLE
remove pin to chart in branch

### DIFF
--- a/k8s/namespaces/fees-pay/ccpay-callback-function/prod.yaml
+++ b/k8s/namespaces/fees-pay/ccpay-callback-function/prod.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: ccpay-callback-function
 spec:
-  chart:
-    ref: keda-v2-test
   values:
     function:
       aadIdentityName: ccpay


### PR DESCRIPTION
**JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8487**

Clean up chart pin to branch since now the chart was deployed after the latest fix were merged https://github.com/hmcts/ccpay-functions-node/pull/82

Main chart on master branch is now pointing at the same version as the keda-v2-test branch. So no change in behaviour is expected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
