### PR TITLE
CI check is skipping  prod image check when config has a unknown image policy

### DIFF
--- a/apps/financial-remedy/finrem-cos/finrem-cos.yaml
+++ b/apps/financial-remedy/finrem-cos/finrem-cos.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/cos:pr-695-4fe3100-20220527084333 #{"$imagepolicy": "flux-system:demo-image-policy"}
+      image: hmctspublic.azurecr.io/finrem/cos:pr-695-4fe3100-20220527084333 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
       environment:
         FEATURE_RESPONDENT_JOURNEY: true
         BSP_SERVICES_ALLOWED_TO_UPDATE: bulk_scan_orchestrator

--- a/apps/financial-remedy/finrem-cos/finrem-cos.yaml
+++ b/apps/financial-remedy/finrem-cos/finrem-cos.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/cos:prod-9b523a8-20220609111026 #{"$imagepolicy": "flux-system:finrem-cos"}
+      image: hmctspublic.azurecr.io/finrem/cos:pr-695-4fe3100-20220527084333 #{"$imagepolicy": "flux-system:demo-image-policy"}
       environment:
         FEATURE_RESPONDENT_JOURNEY: true
         BSP_SERVICES_ALLOWED_TO_UPDATE: bulk_scan_orchestrator

--- a/apps/financial-remedy/finrem-cos/finrem-cos.yaml
+++ b/apps/financial-remedy/finrem-cos/finrem-cos.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/cos:pr-695-4fe3100-20220527084333 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
+      image: hmctspublic.azurecr.io/finrem/cos:prod-9b523a8-20220609111026 #{"$imagepolicy": "flux-system:finrem-cos"}
       environment:
         FEATURE_RESPONDENT_JOURNEY: true
         BSP_SERVICES_ALLOWED_TO_UPDATE: bulk_scan_orchestrator

--- a/apps/flux-system/automation/kustomization.yaml
+++ b/apps/flux-system/automation/kustomization.yaml
@@ -31,6 +31,7 @@ resources:
   - ../../hmc/automation
   - ../../ia/automation
   - ../../idam/automation
+  - ../../idam-slack-help-bot/automation
   - ../../lau/automation
   - ../../money-claims/automation
   - ../../nfdiv/automation

--- a/apps/labs/labs-matthewsearle01-v3/labs-matthewsearle01-v3.yaml
+++ b/apps/labs/labs-matthewsearle01-v3/labs-matthewsearle01-v3.yaml
@@ -16,5 +16,5 @@ spec:
       interval: 1m
   values:
     java:
-      image: hmctssandbox.azurecr.io/labs/matthewsearle01:latest # {"$imagepolicy": "flux-system:labs-matthewsearle01"}
+      image: hmctssandbox.azurecr.io/labs/matthewsearle01:latest # {"$imagepolicy": "flux-system:labs-matthewsearle01-v3"}
       disableTraefikTls: true

--- a/k8s/namespaces/ia/ia-aip-frontend/aat.yaml
+++ b/k8s/namespaces/ia/ia-aip-frontend/aat.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     nodejs:
       ingressHost: immigration-appeal.aat.platform.hmcts.net
-      image: hmctspublic.azurecr.io/ia/aip-frontend:pr-752-d8c3e35-20220511103026 #{"$imagepolicy": "flux-system:aat-ia-aip-frontend"}
       environment:
         IDAM_WEB_URL: "https://idam-web-public.aat.platform.hmcts.net"
         IDAM_API_URL: "https://idam-api.aat.platform.hmcts.net"

--- a/k8s/namespaces/rse/rse-check/rse-check.yaml
+++ b/k8s/namespaces/rse/rse-check/rse-check.yaml
@@ -12,5 +12,5 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/rse/check:prod-ef7a7848   #{"$imagepolicy": "flux-system:rse-check"}
+      image: hmctspublic.azurecr.io/rse/check:prod-ef7a7848
       ingressHost: rse-check-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -64,14 +64,9 @@ for FILE_LOCATION in $(echo ${FILE_LOCATIONS}); do
 
             if [ "$IMAGE_AUTOMATION" == "" ]
             then
-                echo "No ImagePolicy for $IMAGE_POLICY in clusters/ptl-intsvc/base"
-                IMAGE_AUTOMATION=false
-            else
-                IMAGE_AUTOMATION=true
+                echo "No ImagePolicy for $IMAGE_POLICY in clusters/ptl-intsvc/base" && exit 1
             fi
             
-            if [ "$IMAGE_AUTOMATION" == true ]
-            then
             IMAGE_AUTOMATION_CHECK=$(cat imagepolicies_list.yaml  | \
             IMAGE_POLICY_NAME="${IMAGE_POLICY}" yq eval 'select(.metadata and .kind == "ImagePolicy" and .metadata.name == env(IMAGE_POLICY_NAME) )' - | yq eval '.spec.filterTags.pattern == "^prod-[a-f0-9]+-(?P<ts>[0-9]+)"' -)
 
@@ -79,9 +74,6 @@ for FILE_LOCATION in $(echo ${FILE_LOCATIONS}); do
             then
                 echo "Non whitelisted pattern found in ImagePolicy: $IMAGE_POLICY it should be ^prod-[a-f0-9]+-(?P<ts>[0-9]+)" && exit 1
             fi
-        
-            fi
-        
         done
 
     done


### PR DESCRIPTION
- This bug has let PR https://github.com/hmcts/cnp-flux-config/pull/15998/files to go to prod with a pr image
- Had to fix a couple of apps which were misconfigured.
- ia-aip-frontend shouldnt be pointing to PR tag in AAT

**Failure scenario test:**

commit : https://github.com/adusumillipraveen/cnp-flux-config/pull/1/commits/e14f8d4cc78e015d1a9eeedc47819d52c80734c9 
failure logs : https://github.com/adusumillipraveen/cnp-flux-config/runs/6813458305?check_suite_focus=true#step:11:1068 

**Original pr image scenario test where policy exists but its not prod-* :** 

Commit: https://github.com/adusumillipraveen/cnp-flux-config/pull/1/commits/b8e2ce748b0e7cb0405f7f41529b42558c725846
Failure logs : https://github.com/adusumillipraveen/cnp-flux-config/runs/6813550628?check_suite_focus=true#step:11:1105

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
