### PR TITLE
Set up document ids for Welsh documents to be used in AAT

### DIFF
--- a/k8s/namespaces/nfdiv/nfdiv-case-api/aat.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-case-api/aat.yaml
@@ -42,3 +42,6 @@ spec:
         JOINT_APPLICANT2_APPLICANT1_CHANGES_MADE_NOTIFICATION_ID: aa5ae136-7004-46f6-81ad-606242f4a501
         CERTIFICATE_OF_SERVICE_TEMPLATE_ID: NFD_Certificate_Of_Service_CY.docx
         DIVORCE_APPLICATION_SOLE_WELSH_TEMPLATE_ID: NFD_CP_Application_Sole_Cy.docx
+        SERVICE_REFUSAL_TEMPLATE_ID: NFD_Refusal_Order_Deemed_Dispensed_Service_V2_Cy.docx
+        BAILIFF_APPLICATION_APPROVED_TEMPLATE_ID: NFD_Bailiff_Application_Approved_Cy.docx
+        RESPONDENT_ANSWERS_TEMPLATE_ID: NFD_Respondent_Answers_Cy.docx


### PR DESCRIPTION
Override Docmosis template ID in AAT so that the following user stories can be tested:
- NFDIV-2260
- NFDIV-2264
- NFDIV-2266