### PR TITLE
CMC legal rep frontend service is closed

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -220,7 +220,7 @@ spec:
                     title: ETHOS
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(cmc-citizen-frontend|cmc-legal-rep-frontend|cmc-claim-store|cmc-shared-infrastructure|cmc-performance-test|cmc-ccd-e2e-tests)\/master
+                      ^HMCTS.*\/(cmc-citizen-frontend|cmc-claim-store|cmc-shared-infrastructure|cmc-performance-test|cmc-ccd-e2e-tests)\/master
                     name: CMC
                     recurse: true
                     title: CMC


### PR DESCRIPTION
CMC legal rep frontend service is closed. So, removing it from dashboard.
