### PR TITLE
DTSPO-8139 Add SBOX patch for env-injector

### DIFF
--- a/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
+++ b/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
@@ -7,4 +7,3 @@ spec:
   chart:
     spec:
       version: 0.1.8
-      

--- a/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
+++ b/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: env-injector-webhook
+  namespace: admin
+spec:
+  chart:
+    spec:
+      version: 0.1.8

--- a/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
+++ b/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
@@ -7,3 +7,4 @@ spec:
   chart:
     spec:
       version: 0.1.8
+      

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
 
 patchesStrategicMerge:
   - ../../env-injector/upgrade-patch/api-upgrade.yaml
-  

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 
 patchesStrategicMerge:
   - ../../env-injector/upgrade-patch/api-upgrade.yaml
+  

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
   - ../../csi-secret-store-provider-v1.0.1
   - traefik-values.yaml
   - ../../../rbac/edit-clusterrole.yaml
+
+patchesStrategicMerge:
+  - ../../env-injector/upgrade-patch/api-upgrade.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-8139

### Change description ###

Adding an SBOX patch in flux to test the new env-injector chart release that will include a fix for `no matches for kind "MutatingWebhookConfiguration" in version "admissionregistration.k8s.io/v1beta1"`. PR in draft for now until env-injector release `0.1.8`  is created.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
