### PR TITLE
Remove traefik2 from base

### DIFF
--- a/apps/admin/base/kustomization.yaml
+++ b/apps/admin/base/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
   - ../traefik/traefik.yaml
   - ../env-injector/env-injector.yaml
   - ../aad-pod-id
-  - ../traefik2

--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
 patchesStrategicMerge:
   - ../../traefik/sbox/00.yaml
   - env-injector.yaml
-  - ../../traefik2/sbox/00-traefik2.yaml


### PR DESCRIPTION
Aware that this is already in PR https://github.com/hmcts/cnp-flux-config/pull/16245 to re-add traefik2 in a different way, but traefik2 resource is blocking https://tools.hmcts.net/jira/browse/DTSPO-8139 in SBOX due to 
```
4m26s       Warning   error    kustomization/admin                  TLSOption/admin/min-tls-version dry-run failed, error: no matches for kind "TLSOption" in version "traefik.containo.us/v1alpha1"
```

After removing this, SBOX kustomization patches in https://github.com/hmcts/cnp-flux-config/pull/16252 should be applied.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
