### PR TITLE
Docmosis Flux v2 - base chart upgrade

### DIFF
--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -18,7 +18,7 @@ spec:
   chart:
     spec:
       chart: base
-      version: 0.1.2
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: hmctspublic

--- a/apps/docmosis/docmosis/sbox.yaml
+++ b/apps/docmosis/docmosis/sbox.yaml
@@ -9,3 +9,6 @@ spec:
     environment:
       DOCMOSIS_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
       DOCMOSIS_TORNADO_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
+  chart:
+    spec:
+      version: 0.2.0

--- a/apps/docmosis/docmosis/sbox.yaml
+++ b/apps/docmosis/docmosis/sbox.yaml
@@ -9,6 +9,3 @@ spec:
     environment:
       DOCMOSIS_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
       DOCMOSIS_TORNADO_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
-  chart:
-    spec:
-      version: 0.2.0


### PR DESCRIPTION
DTSPO-8140, base chart update
To fix issue for AKS upgrade - no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"
Already updated for flux v1 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
