### PR TITLE
Flux v1 gc back on, per ns rbac is in place for migration safety

### DIFF
--- a/k8s/namespaces/admin/flux/flux.yaml
+++ b/k8s/namespaces/admin/flux/flux.yaml
@@ -22,7 +22,7 @@ spec:
       secretName: flux-git-deploy
       timeout: "180s"
     syncGarbageCollection:
-      enabled: false
+      enabled: true
     registry:
       acr:
         enabled: true


### PR DESCRIPTION
This being off means when rbac is removed for migrations it then needs manually deleted - removing this to simplify process.
The rbac removal for flux v1 is what makes migrations safe, so setting this back.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
