### PR TITLE
Revert et-msg-handler to use prod image in demo

### DIFF
--- a/apps/et/et-msg-handler/demo-image-policy.yaml
+++ b/apps/et/et-msg-handler/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-175-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/k8s/namespaces/et/et-msg-handler/demo.yaml
+++ b/k8s/namespaces/et/et-msg-handler/demo.yaml
@@ -7,4 +7,4 @@ spec:
   releaseName: et-msg-handler
   values:
     java:
-      image: hmctspublic.azurecr.io/et/msg-handler:pr-175-e072c87-20220610113205 #{"$imagepolicy": "flux-system:demo-et-msg-handler"}
+      image: hmctspublic.azurecr.io/et/msg-handler:prod-7376af5-20220628150401 #{"$imagepolicy": "flux-system:demo-et-msg-handler"}


### PR DESCRIPTION
### Change description ###
Revert et-msg-handler to use prod image in demo


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
