### PR TITLE
Dtspo 8139 upgrade env injector all envs

### DIFF
--- a/apps/admin/demo/base/kustomization.yaml
+++ b/apps/admin/demo/base/kustomization.yaml
@@ -16,4 +16,3 @@ resources:
 
 patchesStrategicMerge:
   - keda-identity.yaml
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml

--- a/apps/admin/env-injector/env-injector.yaml
+++ b/apps/admin/env-injector/env-injector.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: env-injector-webhook
-      version: 0.1.7
+      version: 0.1.13
       sourceRef:
         kind: HelmRepository
         name: hmctspublic

--- a/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
+++ b/apps/admin/env-injector/upgrade-patch/api-upgrade.yaml
@@ -1,9 +1,0 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
-metadata:
-  name: env-injector-webhook
-  namespace: admin
-spec:
-  chart:
-    spec:
-      version: 0.1.13

--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -10,4 +10,3 @@ resources:
 
 patchesStrategicMerge:
   - keda-identity.yaml
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml

--- a/apps/admin/perftest/base/kustomization.yaml
+++ b/apps/admin/perftest/base/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
 
 patchesStrategicMerge:
   - keda-identity.yaml
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml

--- a/apps/admin/preview/base/kustomization.yaml
+++ b/apps/admin/preview/base/kustomization.yaml
@@ -12,4 +12,3 @@ resources:
   - ../../keda
 patchesStrategicMerge:
   - ../../aat/base/keda-identity.yaml
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml

--- a/apps/admin/ptl-intsvc/base/kustomization.yaml
+++ b/apps/admin/ptl-intsvc/base/kustomization.yaml
@@ -6,6 +6,3 @@ resources:
   - ../../csi-secret-store-provider-v1.0.1
   - traefik-values.yaml
   - ../../../rbac/reader-clusterrole.yaml
-
-patchesStrategicMerge:
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml

--- a/apps/admin/sbox-intsvc/base/kustomization.yaml
+++ b/apps/admin/sbox-intsvc/base/kustomization.yaml
@@ -6,6 +6,3 @@ resources:
   - ../../csi-secret-store-provider-v1.0.1
   - traefik-values.yaml
   - ../../../rbac/reader-clusterrole.yaml
-
-patchesStrategicMerge:
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -6,6 +6,3 @@ resources:
   - ../../csi-secret-store-provider-v1.0.1
   - traefik-values.yaml
   - ../../../rbac/edit-clusterrole.yaml
-
-patchesStrategicMerge:
-  - ../../env-injector/upgrade-patch/api-upgrade.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-8139

Tested in patches through each of the lower environments and encountered no issues, env-injector deploys and runs, and new releases are created and verified that status shows injected where applicable. This PR removes the patches and upgrades the base chart to https://github.com/hmcts/k8s-env-injector/releases/tag/0.1.13 which includes the API upgrades for env-injector before v1.22.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
