### PR TITLE
Restrict creation of PVCs on cnp and rpe namespace

### DIFF
--- a/apps/base/resourcequota-pvc.yaml
+++ b/apps/base/resourcequota-pvc.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pvc-quota
+spec:
+  hard:
+    persistentvolumeclaims: "0"

--- a/apps/cnp/base/kustomization.yaml
+++ b/apps/cnp/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../base/resourcequota-pvc.yaml
   - ../plum-frontend/plum-frontend.yaml
   - ../plum-recipe-backend/plum-recipe-backend.yaml
   - ../identity/identity.yaml

--- a/apps/rpe/base/kustomization.yaml
+++ b/apps/rpe/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../base/resourcequota-pvc.yaml
   - ../draft-store-service/draft-store-service.yaml
   - ../rpe-service-auth-provider/rpe-service-auth-provider.yaml
   - ../identity/identity.yaml


### PR DESCRIPTION
- Though this is needed only on preview, i don't see a reason why this cannot be across all envs.
- Not adding to root base as we have a couple of namespaces like Jenkins, Artifactory which would need PVC

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
