### PR TITLE
Pointing the RD-ProfessionalAPI Perftest image to PR Image instead of master

### DIFF
--- a/apps/rd/automation/kustomization.yaml
+++ b/apps/rd/automation/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ../rd-profile-sync-integration/image-policy.yaml
   - ../rd-professional-api/image-repo.yaml
   - ../rd-professional-api/image-policy.yaml
+  - ../rd-professional-api/perftest-image-policy.yaml
   - ../rd-user-profile-api/image-repo.yaml
   - ../rd-user-profile-api/image-policy.yaml
   - ../rd-location-ref-api/image-repo.yaml

--- a/apps/rd/rd-professional-api/perftest-image-policy.yaml
+++ b/apps/rd/rd-professional-api/perftest-image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+  kind: ImagePolicy
+  metadata:
+    name: perftest-rd-professional-api
+    annotations:
+      hmcts.github.com/prod-automated: disabled
+  spec:
+    filterTags:
+      pattern: '^pr-1292-[a-f0-9]+-(?P<ts>[0-9]+)'
+      extract: '$ts'
+    policy:
+      alphabetical:
+        order: asc
+    imageRepositoryRef:
+      name: rd-professional-api

--- a/apps/rd/rd-professional-api/perftest-image-policy.yaml
+++ b/apps/rd/rd-professional-api/perftest-image-policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: image.toolkit.fluxcd.io/v1alpha2
-  kind: ImagePolicy
-  metadata:
-    name: perftest-rd-professional-api
-    annotations:
-      hmcts.github.com/prod-automated: disabled
-  spec:
-    filterTags:
-      pattern: '^pr-1292-[a-f0-9]+-(?P<ts>[0-9]+)'
-      extract: '$ts'
-    policy:
-      alphabetical:
-        order: asc
-    imageRepositoryRef:
-      name: rd-professional-api
+kind: ImagePolicy
+metadata:
+  name: perftest-rd-professional-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: '^pr-1292-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: rd-professional-api

--- a/k8s/namespaces/rd/rd-professional-api/perftest.yaml
+++ b/k8s/namespaces/rd/rd-professional-api/perftest.yaml
@@ -6,6 +6,7 @@ spec:
   releaseName: rd-professional-api
   values:
     java:
+      image: hmctspublic.azurecr.io/rd/professional-api:pr-1292-0a34029-20220709214651 #{"$imagepolicy": "flux-system:perftest-rd-professional-api"}
       memoryLimits: "2048Mi"
       memoryRequests: "1024Mi"
       cpuLimits: "2000m"


### PR DESCRIPTION
### Change description ###
Pointing the RD-ProfessionalAPI Perftest image to PR Image instead of master


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
