### PR TITLE
Doubles replicas for services that require scaling for taking cluster…

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-0fa8fb6-20220701213815
-      replicas: 4
+      replicas: 8
       ingressHost: idam-api.platform.hmcts.net
       aadIdentityName: idam
       useInterpodAntiAffinity: true

--- a/k8s/namespaces/ccd/ccd-data-store-api/prod.yaml
+++ b/k8s/namespaces/ccd/ccd-data-store-api/prod.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      replicas: 15
+      replicas: 30
       autoscaling:
         enabled: false
       memoryLimits: "5120Mi"

--- a/k8s/namespaces/ccd/ccd-definition-store-api/prod.yaml
+++ b/k8s/namespaces/ccd/ccd-definition-store-api/prod.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-definition-store-api
   values:
     java:
-      replicas: 4
+      replicas: 8
       memoryRequests: "2048Mi"
       memoryLimits: "4096Mi"
       cpuRequests: "2000m"

--- a/k8s/namespaces/dm-store/dm-store/dm-store.yaml
+++ b/k8s/namespaces/dm-store/dm-store/dm-store.yaml
@@ -10,7 +10,7 @@ spec:
     path: stable/dm-store
   values:
     java:
-      replicas: 7
+      replicas: 14
       memoryRequests: "2048Mi"
       cpuRequests: "1000m"
       memoryLimits: "4096Mi"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-9318
https://tools.hmcts.net/jira/browse/DTSPO-9323

### Change description ###

Doubles replicas for services that require scaling for taking prod-01 out of AppGw to patch Flux for  API deprecation removal fixes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
