### PR TITLE
Remove "Added annotation test to pact-broker."

### DIFF
--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: pact-broker
   namespace: pact-broker
-  annotations:
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   values:
     ingressHost: pact-broker.sandbox.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#16675, need chart to be updated to allow for new annotation.