### PR TITLE
Update perftest.yaml for deprecating cluster

### DIFF
--- a/k8s/namespaces/money-claims/cmc-claim-store/perftest.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/perftest.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
     name: cmc-claim-store
-    version: 4.1.28
+    version: 4.1.41
   values:
     java:
       image: hmctspublic.azurecr.io/cmc/claim-store:latest   #{"$imagepolicy": "flux-system:perftest-cmc-claim-store"}


### PR DESCRIPTION
For networking.k8s.io/v1beta1, which is being deprecated in cluster upgrades this month

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
