### PR TITLE
Revert "Test under vaules"

### DIFF
--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -9,6 +9,3 @@ spec:
     postgresqlHost: pact-broker-mgmt-sandbox.postgres.database.azure.com
     postgresqlServerName: pact-broker-mgmt-sandbox
     vaultName: dtscftptlsbox
-    ingress:
-      annotations:
-      traefik.ingress.kubernetes.io/router.tls: "true"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#16702 - Remove adding TLS true setting, being added to chart. See https://github.com/hmcts/chart-pact-broker/pull/26 