### PR TITLE
Update traefik2 version

### DIFF
--- a/apps/admin/traefik-crds/kustomization.yaml
+++ b/apps/admin/traefik-crds/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/ingressroute.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/ingressroutetcp.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/ingressrouteudp.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/middlewares.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/middlewarestcp.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/serverstransports.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/tlsoptions.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/tlsstores.yaml
-  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.6.0/traefik/crds/traefikservices.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/ingressroute.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/ingressroutetcp.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/ingressrouteudp.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/middlewarestcp.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v10.24.0/traefik/crds/traefikservices.yaml

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 10.6.0
+      version: 10.24.0
       sourceRef:
         kind: HelmRepository
         name: traefik


### PR DESCRIPTION
```
admin            False   TLSStore/admin/default dry-run failed, error: failed to create typed patch object (admin/default; traefik.containo.us/v1alpha1, Kind=TLSStore): .spec.certificates: field not declared in schema
```

Issue in sbox when trying to use two certs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
