### PR TITLE
Revert two certs removal

### DIFF
--- a/apps/admin/traefik2/sbox/secret-provider.yaml
+++ b/apps/admin/traefik2/sbox/secret-provider.yaml
@@ -9,7 +9,7 @@ spec:
     objects: |
       array:
         - |
-          objectName: wildcard-service-core-compute-internal
+          objectName: wildcard-sandbox-platform-hmcts-net
           objectType: secret
           objectAlias: tls-cert
           objectVersion: ""

--- a/apps/admin/traefik2/sbox/tlsstore-patch.yaml
+++ b/apps/admin/traefik2/sbox/tlsstore-patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: default
   namespace: admin
 spec:
-  defaultCertificate:
-    secretName: traefik-internal-cert
   certificates:
     - secretName: traefik-internal-cert
+  defaultCertificate:
+    secretName: traefik-default-cert


### PR DESCRIPTION
Discovered in sbox it's using the appgw cert (won't be happening in preview), so reverting all of these changes we were testing with to get back to a base approach to move forward on.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
