### PR TITLE
Revert "Update draft-store-service.yaml"

### DIFF
--- a/apps/rpe/draft-store-service/draft-store-service.yaml
+++ b/apps/rpe/draft-store-service/draft-store-service.yaml
@@ -6,6 +6,7 @@ spec:
   releaseName: draft-store-service
   values:
     java:
+      disableTraefikTls: true
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/draft-store/service:prod-9776850-20220629155351 #{"$imagepolicy": "flux-system:draft-store-service"}


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#16705 to re-add the flag and remove the annotation for testing