### PR TITLE
Revert "Add disabletraefiktls flag to cft jenkins"

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -64,8 +64,6 @@ spec:
                         value: dcdcftappsstgkv
                       - key: BUSINESS_AREA_TAG
                         value: CFT
-                      - key: DISABLE_TRAEFIK_TLS
-                        value: true
           auth: |
             jenkins:
               authorizationStrategy:

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -87,8 +87,6 @@ spec:
                         value: CFT
                       - key: PIPELINE_METRICS_URL
                         value: https://sandbox-pipeline-metrics.documents.azure.com/
-                      - key: DISABLE_TRAEFIK_TLS
-                        value: true
           views: |
             jenkins:
               views:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#16592, no longer needed to be set via jenkins as CFT and SDS don't differ