### PR TITLE
Updates to remove home office mock from namespaces

### DIFF
--- a/k8s/namespaces/ia/kustomization.yaml
+++ b/k8s/namespaces/ia/kustomization.yaml
@@ -11,4 +11,3 @@ bases:
 - ia-case-api/ia-case-api.yaml
 - ia-bail-case-api/ia-bail-case-api.yaml
 - ia-aip-frontend/ia-aip-frontend.yaml
-- ia-home-office-mock-api/ia-home-office-mock-api.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
This is to remove home office mock api from scope of aat and prod


### Change description ###
This is to remove home office mock api  from scope of aat and prod


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
