### PR TITLE
Dfpl 744: Unable to add Blaneau Gwent as a secondary LA

### DIFF
--- a/k8s/namespaces/family-public-law/fpl-case-service/prod.yaml
+++ b/k8s/namespaces/family-public-law/fpl-case-service/prod.yaml
@@ -7,7 +7,7 @@ spec:
     java:
       ingressHost: fpl-case-service-prod.service.core-compute-prod.internal
       environment:
-        RELEASE: NOW
+        RELEASE: AGAIN
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         MANAGE_CASE_UI_BASE_URL: https://manage-case.platform.hmcts.net
         DOCMOSIS_TORNADO_URL: https://docmosis.platform.hmcts.net

--- a/k8s/namespaces/family-public-law/fpl-case-service/prod.yaml
+++ b/k8s/namespaces/family-public-law/fpl-case-service/prod.yaml
@@ -7,7 +7,7 @@ spec:
     java:
       ingressHost: fpl-case-service-prod.service.core-compute-prod.internal
       environment:
-        RELEASE: AGAIN
+        RELEASE: NOW
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         MANAGE_CASE_UI_BASE_URL: https://manage-case.platform.hmcts.net
         DOCMOSIS_TORNADO_URL: https://docmosis.platform.hmcts.net


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DFPL-744


### Change description ###
Unable to add Blaneau Gwent as a secondary LA


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
