### PR TITLE
Dtspo 8027 traefikv2 mig ithc

### DIFF
--- a/apps/admin/aad-pod-id/mi/ithc/azure-identity-patch.yaml
+++ b/apps/admin/aad-pod-id/mi/ithc/azure-identity-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: admin
+spec:
+  resourceID: "/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ithc-mi"
+  clientID: "0f44a6f0-4da1-433f-a298-4fa50072ea2c"

--- a/apps/admin/ithc/00/kustomization.yaml
+++ b/apps/admin/ithc/00/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - traefik-values.yaml
   - ../../traefik/traefik.yaml
 
 patchesStrategicMerge:

--- a/apps/admin/ithc/00/kustomization.yaml
+++ b/apps/admin/ithc/00/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - traefik-values.yaml
+  - ../base/traefik-values.yaml
   - ../../traefik/traefik.yaml
 
 patchesStrategicMerge:

--- a/apps/admin/ithc/00/kustomization.yaml
+++ b/apps/admin/ithc/00/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../traefik/traefik.yaml
 
 patchesStrategicMerge:
   - ../../traefik/ithc/00.yaml

--- a/apps/admin/ithc/01/kustomization.yaml
+++ b/apps/admin/ithc/01/kustomization.yaml
@@ -2,6 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../secrets-csi-driver-crds
+  - ../../secrets-csi-driver
+  - ../../traefik2
+  - ../../aad-pod-id/mi
 
 patchesStrategicMerge:
-  - ../../traefik/ithc/01.yaml
+  - ../../traefik2/ithc/01.yaml
+  - ../../traefik2/ithc/secret-provider.yaml
+  - ../../aad-pod-id/mi/ithc/azure-identity-patch.yaml

--- a/apps/admin/ithc/01/kustomization.yaml
+++ b/apps/admin/ithc/01/kustomization.yaml
@@ -2,8 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - ../../secrets-csi-driver-crds
-  - ../../secrets-csi-driver
   - ../../traefik2
   - ../../aad-pod-id/mi
 

--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -4,7 +4,8 @@ resources:
   - ../../base
   - kube-slack-values.yaml
   - traefik-values.yaml
-  - ../../csi-secret-store-provider-v1.0.1
+  - ../../secrets-csi-driver-crds
+  - ../../secrets-csi-driver
   - ../../../rbac/edit-clusterrole.yaml
   - ../../keda
   - ../../traefik/traefik.yaml

--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -8,6 +8,5 @@ resources:
   - ../../secrets-csi-driver
   - ../../../rbac/edit-clusterrole.yaml
   - ../../keda
-  - ../../traefik/traefik.yaml
 patchesStrategicMerge:
   - keda-identity.yaml

--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - kube-slack-values.yaml
-  - traefik-values.yaml
   - ../../secrets-csi-driver-crds
   - ../../secrets-csi-driver
   - ../../../rbac/edit-clusterrole.yaml

--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik2
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.11.207.250"

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik2
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.11.223.250"

--- a/apps/admin/traefik2/ithc/secret-provider.yaml
+++ b/apps/admin/traefik2/ithc/secret-provider.yaml
@@ -9,7 +9,7 @@ spec:
     objects: |
       array:
         - |
-          objectName: wildcard-sandbox-platform-hmcts-net
+          objectName: wildcard-ithc-platform-hmcts-net
           objectType: secret
           objectAlias: tls-cert
           objectVersion: ""

--- a/apps/admin/traefik2/ithc/secret-provider.yaml
+++ b/apps/admin/traefik2/ithc/secret-provider.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: admin
 spec:
   parameters:
-    keyvaultName: acmedcdcftappssithc
+    keyvaultName: acmedcdcftappsithc
     objects: |
       array:
         - |

--- a/apps/admin/traefik2/ithc/secret-provider.yaml
+++ b/apps/admin/traefik2/ithc/secret-provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-default-cert
+  namespace: admin
+spec:
+  parameters:
+    keyvaultName: acmedcdcftappssithc
+    objects: |
+      array:
+        - |
+          objectName: wildcard-sandbox-platform-hmcts-net
+          objectType: secret
+          objectAlias: tls-cert
+          objectVersion: ""


### PR DESCRIPTION
### JIRA link (if applicable) ###

DTSPO-8027 Traefikv2 migration ithc

### Change description ###

PR will add Traefikv2 to ithc01 after aks 1.23 upgrade.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
