### PR TITLE
RIA-5969 - Initial setup for ia-hearings-api

### DIFF
--- a/k8s/aat/common-overlay/ia/kustomization.yaml
+++ b/k8s/aat/common-overlay/ia/kustomization.yaml
@@ -9,6 +9,7 @@ patchesStrategicMerge:
 - ../../../namespaces/ia/ia-home-office-integration-api/aat.yaml
 - ../../../namespaces/ia/ia-case-api/aat.yaml
 - ../../../namespaces/ia/ia-bail-case-api/aat.yaml
+- ../../../namespaces/ia/ia-hearings-api/aat.yaml
 - ../../../namespaces/ia/ia-case-payments-api/aat.yaml
 - ../../../namespaces/ia/ia-case-notifications-api/aat.yaml
 - ../../../namespaces/ia/ia-case-documents-api/aat.yaml

--- a/k8s/demo/common-overlay/ia/kustomization.yaml
+++ b/k8s/demo/common-overlay/ia/kustomization.yaml
@@ -11,6 +11,7 @@ patchesStrategicMerge:
 - ../../../namespaces/ia/ia-case-documents-api/demo.yaml
 - ../../../namespaces/ia/ia-case-api/demo.yaml
 - ../../../namespaces/ia/ia-bail-case-api/demo.yaml
+- ../../../namespaces/ia/ia-hearings-api/demo.yaml
 - ../../../namespaces/ia/ia-case-notifications-api/demo.yaml
 - ../../../namespaces/ia/ia-case-access-api/demo.yaml
 - ../../../namespaces/ia/ia-timed-event-service/demo.yaml

--- a/k8s/ithc/common-overlay/ia/kustomization.yaml
+++ b/k8s/ithc/common-overlay/ia/kustomization.yaml
@@ -12,6 +12,7 @@ patchesStrategicMerge:
 - ../../../namespaces/ia/ia-case-api/ithc.yaml
 - ../../../namespaces/ia/ia-case-payments-api/ithc.yaml
 - ../../../namespaces/ia/ia-bail-case-api/ithc.yaml
+- ../../../namespaces/ia/ia-hearings-api/ithc.yaml
 - ../../../namespaces/ia/ia-case-notifications-api/ithc.yaml
 - ../../../namespaces/ia/ia-case-access-api/ithc.yaml
 - ../../../namespaces/ia/ia-timed-event-service/ithc.yaml

--- a/k8s/namespaces/ia/ia-hearings-api/aat.yaml
+++ b/k8s/namespaces/ia/ia-hearings-api/aat.yaml
@@ -1,0 +1,4 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-hearings-api

--- a/k8s/namespaces/ia/ia-hearings-api/demo.yaml
+++ b/k8s/namespaces/ia/ia-hearings-api/demo.yaml
@@ -1,0 +1,4 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-hearings-api

--- a/k8s/namespaces/ia/ia-hearings-api/ia-bail-case-api.yaml
+++ b/k8s/namespaces/ia/ia-hearings-api/ia-bail-case-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-hearings-api
+spec:
+  releaseName: ia-hearings-api
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/ia-hearings-api
+  values:
+    java:
+      replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 5
+        targetCPUUtilizationPercentage: 80
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/ia/hearings-api:latest

--- a/k8s/namespaces/ia/ia-hearings-api/ithc.yaml
+++ b/k8s/namespaces/ia/ia-hearings-api/ithc.yaml
@@ -1,0 +1,4 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-bail-case-api

--- a/k8s/namespaces/ia/ia-hearings-api/perftest.yaml
+++ b/k8s/namespaces/ia/ia-hearings-api/perftest.yaml
@@ -1,0 +1,4 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-bail-case-api

--- a/k8s/namespaces/ia/ia-hearings-api/prod.yaml
+++ b/k8s/namespaces/ia/ia-hearings-api/prod.yaml
@@ -1,0 +1,4 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ia-bail-case-api

--- a/k8s/perftest/common-overlay/ia/kustomization.yaml
+++ b/k8s/perftest/common-overlay/ia/kustomization.yaml
@@ -8,6 +8,7 @@ bases:
 patchesStrategicMerge:
 - ../../../namespaces/ia/ia-case-api/perftest.yaml
 - ../../../namespaces/ia/ia-bail-case-api/perftest.yaml
+- ../../../namespaces/ia/ia-hearings-api/perftest.yaml
 - ../../../namespaces/ia/ia-case-payments-api/perftest.yaml
 - ../../../namespaces/ia/ia-case-notifications-api/perftest.yaml
 - ../../../namespaces/ia/ia-case-documents-api/perftest.yaml

--- a/k8s/prod/common-overlay/ia/kustomization.yaml
+++ b/k8s/prod/common-overlay/ia/kustomization.yaml
@@ -13,4 +13,5 @@ patchesStrategicMerge:
 - ../../../namespaces/ia/ia-case-notifications-api/prod.yaml
 - ../../../namespaces/ia/ia-case-api/prod.yaml
 - ../../../namespaces/ia/ia-bail-case-api/prod.yaml
+- ../../../namespaces/ia/ia-hearings-api/prod.yaml
 - ../../../namespaces/ia/ia-aip-frontend/prod.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-5969


### Change description ###
RIA-5969 - Adding initial setup for a new component "ia-hearings-api" to the cnp-flux-config repo


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
