### PR TITLE
ITHC fixes for aks upgrades

### DIFF
--- a/k8s/ithc/common-overlay/camunda/kustomization.yaml
+++ b/k8s/ithc/common-overlay/camunda/kustomization.yaml
@@ -7,4 +7,3 @@ bases:
 patchesStrategicMerge:
 - ../../../namespaces/camunda/camunda-api/ithc.yaml
 - ../../../namespaces/camunda/camunda-optimize/ithc.yaml
-- ../../../namespaces/camunda/camunda-ui/ithc.yaml

--- a/k8s/namespaces/aac/manage-case-assignment/ithc.yaml
+++ b/k8s/namespaces/aac/manage-case-assignment/ithc.yaml
@@ -2,10 +2,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   name: manage-case-assignment
-  annotations:
-    fluxcd.io/automated: "true"
-    fluxcd.io/tag.java: glob:prod-*
-    hmcts.github.com/prod-automated: disabled
 spec:
   values:
     java:

--- a/k8s/namespaces/camunda/camunda-ui/ithc.yaml
+++ b/k8s/namespaces/camunda/camunda-ui/ithc.yaml
@@ -1,9 +1,0 @@
-apiVersion: helm.fluxcd.io/v1
-kind: HelmRelease
-metadata:
-  name: camunda-ui
-spec:
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: camunda-release-testing-ithc
-    path: stable/camunda-bpm

--- a/k8s/namespaces/money-claims/cmc-claim-store/cmc-claim-store.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/cmc-claim-store.yaml
@@ -8,6 +8,10 @@ spec:
   rollback:
     enable: true
     retry: true
+  chart:
+    git: git@github.com:hmcts/hmcts-charts
+    ref: master
+    path: stable/cmc-claim-store
   values:
     java:
       replicas: 2

--- a/k8s/namespaces/money-claims/cmc-claim-store/demo.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/demo.yaml
@@ -4,10 +4,6 @@ metadata:
   name: cmc-claim-store
   namespace: money-claims
 spec:
-  chart:
-    git: git@github.com:hmcts/hmcts-charts
-    ref: master
-    path: stable/cmc-claim-store
   values:
     java:
       image: hmctspublic.azurecr.io/cmc/claim-store:prod-70a188b-20220722132341 #{"$imagepolicy": "flux-system:cmc-claim-store"}

--- a/k8s/namespaces/money-claims/cmc-claim-store/ithc.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/ithc.yaml
@@ -5,10 +5,6 @@ metadata:
   name: cmc-claim-store
   namespace: money-claims
 spec:
-  chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-claim-store
-    version: 4.1.9
   values:
     java:
       image: hmctspublic.azurecr.io/cmc/claim-store:pr-2459-dd7fbf7-20210722095059   #{"$imagepolicy": "flux-system:ithc-cmc-claim-store"}

--- a/k8s/namespaces/money-claims/cmc-claim-store/perftest.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/perftest.yaml
@@ -5,10 +5,6 @@ metadata:
   name: cmc-claim-store
   namespace: money-claims
 spec:
-  chart:
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
-    name: cmc-claim-store
-    version: 4.1.41
   values:
     java:
       image: hmctspublic.azurecr.io/cmc/claim-store:latest   #{"$imagepolicy": "flux-system:perftest-cmc-claim-store"}


### PR DESCRIPTION
Old annotation flux v2 image automation removed for aac 
Camunda fixed on ITHC
CMC - fix old pinned charts for ithc/perftest - cleanup duplication of chart setting demo


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
