### PR TITLE
Remove RPTS from prod

### DIFF
--- a/k8s/prod/common-overlay/kustomization.yaml
+++ b/k8s/prod/common-overlay/kustomization.yaml
@@ -33,7 +33,6 @@ bases:
   - civil
   - cpo
   - nfdiv
-  - rpts
   - private-law
   - hmc
 patches:

--- a/k8s/prod/common-overlay/rpts/kustomization.yaml
+++ b/k8s/prod/common-overlay/rpts/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: rpts
-bases:
-- ../../../namespaces/rpts


### PR DESCRIPTION
Not live yet and app not got all relative permissions to upgrade java version, removing from prod so we can do AKS upgrades. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
