### PR TITLE
added idam_user_dashboard_url for fact-admin

### DIFF
--- a/k8s/namespaces/fact/fact-admin/prod.yaml
+++ b/k8s/namespaces/fact/fact-admin/prod.yaml
@@ -9,6 +9,7 @@ spec:
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net/o/token
         IDAM_WEB_URL: https://hmcts-access.service.gov.uk/login
+        IDAM_USER_DASHBOARD_URL: https://idam-user-dashboard.platform.hmcts.net
         IDAM_ADD_USER_URL: https://idam-api.platform.hmcts.net/api/v1/users/registration
         IDAM_UPDATE_USER_URL: https://idam-api.platform.hmcts.net/api/v1/users/
         OAUTH_CLIENT_REDIRECT: https://admin.find-court-tribunal.service.gov.uk/oauth2/callback


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FACT-1212


### Change description ###
users link in fact-admin is being forwarded to idam user dashboard so for prod this url was added so it forwards to the correct env in prod 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
