### PR TITLE
Flux helm operator - correct clusterrole api version

### DIFF
--- a/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
@@ -20,7 +20,6 @@ rules:
   - nonResourceURLs: ['*']
     verbs: ['*']
 ---
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
+++ b/k8s/namespaces/admin/flux-helm-operator/rbac/read-only-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   name: flux-helm-operator
   namespace: admin
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:


### PR DESCRIPTION
Issue spotted in ithc upgrade.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
