### PR TITLE
Removing non working apps for traefik upgrade

### DIFF
--- a/k8s/namespaces/rpe/kustomization.yaml
+++ b/k8s/namespaces/rpe/kustomization.yaml
@@ -1,11 +1,11 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: rpe
-bases:
-- draft-store-service/draft-store-service.yaml
-- rpe-service-auth-provider/rpe-service-auth-provider.yaml
-- pdf-service/pdf-service.yaml
-- rpe-send-letter-service/rpe-send-letter-service.yaml
-- rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
-- rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
-- rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml
+# apiVersion: kustomize.config.k8s.io/v1beta1
+# kind: Kustomization
+# namespace: rpe
+# bases:
+# - draft-store-service/draft-store-service.yaml
+# - rpe-service-auth-provider/rpe-service-auth-provider.yaml
+# - pdf-service/pdf-service.yaml
+# - rpe-send-letter-service/rpe-send-letter-service.yaml
+# - rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
+# - rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
+# - rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml

--- a/k8s/namespaces/rpe/kustomization.yaml
+++ b/k8s/namespaces/rpe/kustomization.yaml
@@ -1,11 +1,11 @@
-# apiVersion: kustomize.config.k8s.io/v1beta1
-# kind: Kustomization
-# namespace: rpe
-# bases:
-# - draft-store-service/draft-store-service.yaml
-# - rpe-service-auth-provider/rpe-service-auth-provider.yaml
-# - pdf-service/pdf-service.yaml
-# - rpe-send-letter-service/rpe-send-letter-service.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: rpe
+bases:
+- draft-store-service/draft-store-service.yaml
+- rpe-service-auth-provider/rpe-service-auth-provider.yaml
+- pdf-service/pdf-service.yaml
+- rpe-send-letter-service/rpe-send-letter-service.yaml
 # - rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
 # - rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
 # - rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml


### PR DESCRIPTION

### JIRA https://tools.hmcts.net/jira/browse/DTSPO-8027 ###



### Change description ###
Since this application is not running in production and has incompatible versions for keda, it's stopping PlatOps from performing an AKS upgrade. For that reason, we will comment it for now until the team can fix the necessary issues.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
