### PR TITLE
Removing non working apps for chart upgrades

### DIFF
--- a/k8s/namespaces/rpe/kustomization.yaml
+++ b/k8s/namespaces/rpe/kustomization.yaml
@@ -6,6 +6,6 @@ bases:
 - rpe-service-auth-provider/rpe-service-auth-provider.yaml
 - pdf-service/pdf-service.yaml
 - rpe-send-letter-service/rpe-send-letter-service.yaml
-- rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
-- rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
-- rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml
+# - rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
+# - rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
+# - rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml

--- a/k8s/perftest/common-overlay/rpe/kustomization.yaml
+++ b/k8s/perftest/common-overlay/rpe/kustomization.yaml
@@ -4,6 +4,6 @@ namespace: rpe
 bases:
 - ../../../namespaces/rpe
 - ../../../namespaces/rpe/namespace.yaml
-patchesStrategicMerge:
-- ../../../namespaces/rpe/rpe-send-letter-service-container-proc/perftest.yaml
-- ../../../namespaces/rpe/rpe-send-letter-service-container-zip/perftest.yaml
+# patchesStrategicMerge:
+# - ../../../namespaces/rpe/rpe-send-letter-service-container-proc/perftest.yaml
+# - ../../../namespaces/rpe/rpe-send-letter-service-container-zip/perftest.yaml


### PR DESCRIPTION
Since this application is not running in production and has incompatible versions for keda, it's stopping PlatOps from performing an AKS upgrade. For that reason, we will comment it for now until the team can fix the necessary issues.


### JIRA link https://tools.hmcts.net/jira/browse/DTSPO-8027 ###






**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
