### PR TITLE
Update rbac api version

### DIFF
--- a/apps/admin/external-dns/external-dns-clusterrole.yaml
+++ b/apps/admin/external-dns/external-dns-clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-dns

--- a/apps/admin/external-dns/external-dns-clusterrolebinding.yaml
+++ b/apps/admin/external-dns/external-dns-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer

--- a/apps/admin/preview/base/manage-configmaps-clusterrole.yaml
+++ b/apps/admin/preview/base/manage-configmaps-clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: manage-configmaps
@@ -9,7 +9,7 @@ rules:
     verbs: ["get", "list", "create", "patch", "update"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: manage-configmaps-binding

--- a/apps/monitoring/aat/base/list-all-pods-clusterrole.yaml
+++ b/apps/monitoring/aat/base/list-all-pods-clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: list-all-pods
@@ -8,7 +8,7 @@ rules:
     verbs: ["get", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: list-all-pods-binding

--- a/k8s/aat/common/admin/manage-configmaps-clusterrole.yaml
+++ b/k8s/aat/common/admin/manage-configmaps-clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: manage-configmaps
@@ -9,7 +9,7 @@ rules:
     verbs: ["get", "list", "create", "patch", "update"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: manage-configmaps-binding

--- a/k8s/namespaces/admin/helm-operator/helm-operator-role-binding.yaml
+++ b/k8s/namespaces/admin/helm-operator/helm-operator-role-binding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:

--- a/k8s/namespaces/admin/helm-operator/helm-operator-role.yaml
+++ b/k8s/namespaces/admin/helm-operator/helm-operator-role.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:

--- a/k8s/prod/common/admin/manage-configmaps-clusterrole.yaml
+++ b/k8s/prod/common/admin/manage-configmaps-clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: manage-configmaps
@@ -9,7 +9,7 @@ rules:
     verbs: ["get", "list", "create", "patch", "update"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: manage-configmaps-binding


### PR DESCRIPTION
Found 8 of these old api versions still remaining via - https://cs.github.com/hmcts/cnp-flux-config?q=%22rbac.authorization.k8s.io%2Fv1beta1%22. No notable updates to change according to docs - https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
