### PR TITLE
Adds flux config for traefik2 on perftest for rebuild of 01

### DIFF
--- a/apps/admin/aad-pod-id/mi/perftest/azure-identity-patch.yaml
+++ b/apps/admin/aad-pod-id/mi/perftest/azure-identity-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: admin
+spec:
+  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-perftest-mi"
+  clientID: "7734e33b-4bb6-44eb-89c4-0dca2b6d351c"

--- a/apps/admin/perftest/00/kustomization.yaml
+++ b/apps/admin/perftest/00/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../base/traefik-values.yaml
+  - ../../traefik/traefik.yaml
 
 patchesStrategicMerge:
   - ../../traefik/perftest/00.yaml

--- a/apps/admin/perftest/00/kustomization.yaml
+++ b/apps/admin/perftest/00/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - ../base/traefik-values.yaml
   - ../../traefik/traefik.yaml
 
 patchesStrategicMerge:

--- a/apps/admin/perftest/01/kustomization.yaml
+++ b/apps/admin/perftest/01/kustomization.yaml
@@ -2,6 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../traefik2
+  - ../../aad-pod-id/mi
 
 patchesStrategicMerge:
-  - ../../traefik/perftest/01.yaml
+  - ../../traefik2/perftest/01.yaml
+  - ../../traefik2/perftest/secret-provider.yaml
+  - ../../aad-pod-id/mi/perftest/azure-identity-patch.yaml

--- a/apps/admin/perftest/base/kustomization.yaml
+++ b/apps/admin/perftest/base/kustomization.yaml
@@ -3,9 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - kube-slack-values.yaml
-  - ../../csi-secret-store-provider-v1.0.1
+  - ../../secrets-csi-driver-crds
+  - ../../secrets-csi-driver
   - ../../../rbac/edit-clusterrole.yaml
   - ../../keda
-  - ../../traefik/traefik.yaml
+
 patchesStrategicMerge:
   - keda-identity.yaml

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik2
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.48.79.250"

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik2
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.48.95.250"

--- a/apps/admin/traefik2/perftest/secret-provider.yaml
+++ b/apps/admin/traefik2/perftest/secret-provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-default-cert
+  namespace: admin
+spec:
+  parameters:
+    keyvaultName: acmedcdcftappstest
+    objects: |
+      array:
+        - |
+          objectName: wildcard-perftest-platform-hmcts-net
+          objectType: secret
+          objectAlias: tls-cert
+          objectVersion: ""


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-8033

### Change description ###

Adds flux config for traefik2 on perftest for rebuild of 01 cluster

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
