### PR TITLE
Perftest - add private law namespace

### DIFF
--- a/k8s/perftest/common-overlay/private-law/kustomization.yaml
+++ b/k8s/perftest/common-overlay/private-law/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: private-law
 bases:
 - ../../../namespaces/private-law
+- ../../../namespaces/private-law/namespace.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/private-law/prl-cos/perftest.yaml


### PR DESCRIPTION
Fix flux errors - this is possibly slowing down deployments on perftest
Flux is continually trying and failing to deploy private-law resources without a namespace

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
