### PR TITLE
Revert "DTSPO-8699 - Add envVars for ptl in sbox"

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -73,12 +73,6 @@ spec:
                         value: cft-sbox-01-aks
                       - key: SANDBOX_AKS_RESOURCE_GROUP
                         value: cft-sbox-01-rg
-                      - key: PTL_AKS_CLUSTER_NAME
-                        value: cft-ptl-00-aks
-                      - key: PTL_AKS_RESOURCE_GROUP
-                        value: cft-ptl-00-rg
-                      - key: AKS_PTL_SUBSCRIPTION_NAME
-                        value: DTS-CFTPTL-INTSVC
                       - key: AKS_PREVIEW_SUBSCRIPTION_NAME
                         value: DCD-CFTAPPS-SBOX
                       - key: AKS_AAT_SUBSCRIPTION_NAME


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#17142

Ptlsbox identity doesn't have permissions on ptl cluster and image reconciliation not strictly necessary in sbox