### PR TITLE
DTSPO-8699 - Rename plum-frontend image repo

### DIFF
--- a/apps/cnp/plum-frontend/image-policy.yaml
+++ b/apps/cnp/plum-frontend/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1alpha2
 kind: ImagePolicy
 metadata:
-  name: cnp-plum-frontend
+  name: plum-frontend
 spec:
   imageRepositoryRef:
-    name: cnp-plum-frontend
+    name: plum-frontend

--- a/apps/cnp/plum-frontend/image-repo.yaml
+++ b/apps/cnp/plum-frontend/image-repo.yaml
@@ -1,6 +1,6 @@
 apiVersion: image.toolkit.fluxcd.io/v1alpha2
 kind: ImageRepository
 metadata:
-  name: cnp-plum-frontend
+  name: plum-frontend
 spec:
   image: hmctspublic.azurecr.io/plum/frontend

--- a/apps/cnp/plum-frontend/plum-frontend.yaml
+++ b/apps/cnp/plum-frontend/plum-frontend.yaml
@@ -14,7 +14,7 @@ spec:
       interval: 1m
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/plum/frontend:prod-b3c8fc6-20220805092906 # {"$imagepolicy": "flux-system:cnp-plum-frontend"}
+      image: hmctspublic.azurecr.io/plum/frontend:prod-b3c8fc6-20220805092906 # {"$imagepolicy": "flux-system:plum-frontend"}
       startupPeriod: 120
       startupFailureThreshold: 3
       environment:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8699

### Change description ###
Rename image repo for plum-frontend
Current name does not match `${product}-${component}` naming scheme


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
