### PR TITLE
DTSPO-9830 - fix to allow demo-00 names - and cleanup repetition

### DIFF
--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -7,27 +7,19 @@ kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" -o install_kustomize
 EXCLUSIONS_LIST=(
   apps/docmosis/docmosis/docmosis.yaml
   apps/docmosis/docmosis/aat.yaml
-  apps/docmosis/docmosis/demo.yaml
-  apps/docmosis/docmosis/ithc.yaml
-  apps/docmosis/docmosis/perftest.yaml
-  apps/docmosis/docmosis/sbox.yaml
   apps/flux-system/base/image-automation-components.yaml
-  apps/idam/idam-api/preview.yaml
-  apps/idam/idam-api/sbox.yaml
-  apps/idam/idam-web-admin/preview.yaml
-  apps/idam/idam-web-admin/ithc.yaml
-  apps/idam/idam-web-admin/sbox.yaml
-  apps/idam/idam-web-public/preview.yaml
-  apps/idam/idam-web-public/sbox.yaml
-  apps/idam/idam-testing-support-api/preview.yaml
-  apps/idam/idam-testing-support-api/sbox.yaml
   k8s/namespaces/docmosis/docmosis/aat.yaml
   *demo.yaml
+  *demo-0*.yaml
   k8s/demo/*
   *perftest.yaml
+  *perftest-0*.yaml
   k8s/perftest/*
   k8s/ithc/*
   *ithc.yaml
+  *ithc-0*.yaml
+  *preview.yaml
+  *sbox.yaml
 )
 
 EXCLUSIONS=$(IFS="|" ; echo "${EXCLUSIONS_LIST[*]}")


### PR DESCRIPTION
Added in for -00 and -01 names to be allowed if teams need different 00/01 patches.
The use case for this is for jobs with different schedules on different clusters. eg. nfdiv jobs - fixing this so they can use pr images on perf/ithc/demo envs if needed.
I have also cleaned this up by removing some idam and docmosis ones which are already covered

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
