### PR TITLE
CIV-1610: Utilise aac identity in preview

### DIFF
--- a/apps/civil/preview/base/kustomization.yaml
+++ b/apps/civil/preview/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../../am/identity/identity.yaml
   - ../../../money-claims/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
+  - ../../../aac/identity/identity.yaml
   - resource-limits.yaml
 namespace: civil
 patchesStrategicMerge:
@@ -16,3 +17,4 @@ patchesStrategicMerge:
   - ../../../am/identity/aat.yaml
   - ../../../money-claims/identity/aat.yaml
   - ../../../ccd/identity/aat.yaml
+  - ../../../aac/identity/aat.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1610


### Change description ###
- As we are integrating with Notice of Change common component, we need to utilise the AAC API. Adding configuration in flux for us to use AAC

Linked to:
-> https://github.com/hmcts/civil-ccd-definition/pull/1076

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
