### PR TITLE
CHG5009122: Address CVE-2022-31197.

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-d63bd12-20220726155514
+      image: hmctspublic.azurecr.io/idam/api:prod-922d399-20220815062537
       replicas: 4
       ingressHost: idam-api.platform.hmcts.net
       aadIdentityName: idam


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7994


### Change description ###
Deploy latest idam-api image to Prod. Includes an upgrade to postgresql version 42.4.1 in order to address CVE-2022-31197.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
