### PR TITLE
Update helmrepo url

### DIFF
--- a/apps/admin/secrets-csi-driver/secrets-csi-driver-helmrepo.yaml
+++ b/apps/admin/secrets-csi-driver/secrets-csi-driver-helmrepo.yaml
@@ -4,5 +4,5 @@ metadata:
   name: csi-secrets-store-provider-azure
   namespace: admin
 spec:
-  url: https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+  url: https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
   interval: 10m


### PR DESCRIPTION
As mentioned in PR description here - https://github.com/Azure/secrets-store-csi-driver-provider-azure/pull/924#issue-1282724051. Due to this error in AAT 
```
 failed to download repository index: failed to fetch https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/index.yaml : 404 Not Found
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
