### PR TITLE
Revert "Temporarily disable AAT neuvector"

### DIFF
--- a/clusters/aat/base/kustomization.yaml
+++ b/clusters/aat/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../apps/kube-system/base/kustomize.yaml
   - ../../../apps/kured/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml
+  - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/labs/base/kustomize.yaml
   - ../../../apps/fis/base/kustomize.yaml
   - ../../../apps/cnp/base/kustomize.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#17691 -- 504 issue has been replicated after this PR was merged, adding neuvector back to AAT