### PR TITLE
disable post flux func and smoke tests

### DIFF
--- a/k8s/namespaces/reform-scan/reform-scan-notification-service/aat.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-notification-service/aat.yaml
@@ -27,6 +27,6 @@ spec:
           SLACK_NOTIFY_SUCCESS: false
           TEST_S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
       smoketests:
-        enabled: true
+        enabled: false
       functionaltests:
-        enabled: true
+        enabled: false

--- a/k8s/namespaces/reform-scan/reform-scan-notification-service/prod.yaml
+++ b/k8s/namespaces/reform-scan/reform-scan-notification-service/prod.yaml
@@ -11,7 +11,6 @@ spec:
     java:
       environment:
         PENDING_NOTIFICATIONS_TASK_DELAY_IN_MS: "1800000"
-        DUMMY_VAR: "delete_me"
       testsConfig:
         memoryLimits: "3072Mi"
         serviceAccountName: tests-service-account
@@ -20,4 +19,4 @@ spec:
           SLACK_CHANNEL: "bsp-test-notices"
           SLACK_NOTIFY_SUCCESS: false
       smoketests:
-        enabled: true
+        enabled: false


### PR DESCRIPTION


### Change description ###

Java 17 does not supported for now.
disable post flux func and smoke tests for now 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
