### PR TITLE
Fix idam-api config in Sandbox

### DIFF
--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -16,7 +16,7 @@ spec:
         MANAGEMENT_HEALTH_IDAMSERVICEAUTH_ENABLED: false
         TESTING_SUPPORT_ENABLED: true
         STRATEGIC_ADMIN_URL: http://idam-web-admin
-        STRATEGIC_WEBPUBLIC_URL: http://idam-web-public
+        STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.sandbox.platform.hmcts.net
         STRATEGIC_API_URL: http://idam-api
         IDAM_SPI_FORGEROCK_AM_ROOT: https://forgerock-am.service.core-compute-idam-sandbox.internal:8443/openam
         IDAM_SPI_FORGEROCK_AM_TOPLEVELHOST: forgerock-am.service.core-compute-idam-sandbox.internal:8443

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -15,7 +15,7 @@ spec:
         LOG_AND_AUDIT_IDAM_ENABLED: false
         MANAGEMENT_HEALTH_IDAMSERVICEAUTH_ENABLED: false
         TESTING_SUPPORT_ENABLED: true
-        STRATEGIC_ADMIN_URL: http://idam-web-admin
+        STRATEGIC_ADMIN_URL: https://idam-web-admin.sandbox.platform.hmcts.net
         STRATEGIC_WEBPUBLIC_URL: https://idam-web-public.sandbox.platform.hmcts.net
         STRATEGIC_API_URL: http://idam-api
         IDAM_SPI_FORGEROCK_AM_ROOT: https://forgerock-am.service.core-compute-idam-sandbox.internal:8443/openam


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7966


### Change description ###
idam-api has wrong URL for idam-web-public in sandbox,


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
