### PR TITLE
Remove civil citizen ui from prod

### DIFF
--- a/k8s/aat/common-overlay/civil/kustomization.yaml
+++ b/k8s/aat/common-overlay/civil/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: civil
 bases:
 - ../../../namespaces/civil
 - ../../../namespaces/civil/namespace.yaml
+- ../../../namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/aat.yaml

--- a/k8s/demo/common-overlay/civil/kustomization.yaml
+++ b/k8s/demo/common-overlay/civil/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: civil
 bases:
 - ../../../namespaces/civil
 - ../../../namespaces/civil/namespace.yaml
+- ../../../namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/demo.yaml

--- a/k8s/ithc/common-overlay/civil/kustomization.yaml
+++ b/k8s/ithc/common-overlay/civil/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: civil
 bases:
 - ../../../namespaces/civil
 - ../../../namespaces/civil/namespace.yaml
+- ../../../namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/ithc.yaml

--- a/k8s/namespaces/civil/kustomization.yaml
+++ b/k8s/namespaces/civil/kustomization.yaml
@@ -4,5 +4,4 @@ namespace: civil
 bases:
 # Warning : Adding a file here, adds to all environments to which you add your kustomization.
 - civil-service/civil-service.yaml
-- civil-citizen-ui/civil-citizen-ui.yaml
 - civil-general-applications/civil-general-applications.yaml

--- a/k8s/perftest/common-overlay/civil/kustomization.yaml
+++ b/k8s/perftest/common-overlay/civil/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: civil
 bases:
 - ../../../namespaces/civil
 - ../../../namespaces/civil/namespace.yaml
+- ../../../namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
 - ../../../namespaces/all-namespaces/nonprod-role.yaml
 patchesStrategicMerge:
 - ../../../namespaces/civil/civil-service/perftest.yaml


### PR DESCRIPTION
This app is not supposed to be in prod and is failing to install