### PR TITLE
SSCS Prod Cronjob: fix invalid cron schedule

### DIFF
--- a/k8s/namespaces/sscs/sscs-case-loader/prod-00.yaml
+++ b/k8s/namespaces/sscs/sscs-case-loader/prod-00.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 2-7/1 * *"
+      schedule: "0 2-7/1 * * *"
       startingDeadlineSeconds: 1800
       concurrencyPolicy: Forbid
       memoryRequests: "768Mi"


### PR DESCRIPTION
release 'sscs-case-loader' in namespace 'sscs' failed: installation failed: CronJob.batch "sscs-case-loader-job" is invalid: spec.schedule: Invalid value: "0 2-7/1 * *": expected exactly 5 fields, found 4: [0 2-7/1 * *]

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
