### PR TITLE
Move traefik from base to 00

### DIFF
--- a/apps/admin/demo/00/kustomization.yaml
+++ b/apps/admin/demo/00/kustomization.yaml
@@ -2,6 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../traefik/traefik.yaml
+  - ../../traefik-auth
+  - ../../traefik-no-proxy
+  - ../../traefik-private
+  - ../../csi-secret-store-provider-v1.0.1
+  - ../../external-dns/
+  - ../../external-dns-public/
+  - ../base/external-dns.yaml
+  - ../base/traefik-values.yaml
 
 patchesStrategicMerge:
   - ../../external-dns/demo/00.yaml

--- a/apps/admin/demo/01/kustomization.yaml
+++ b/apps/admin/demo/01/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../base
 
 patchesStrategicMerge:
-  - ../../external-dns/demo/01.yaml
-  - ../../external-dns-public/demo/01.yaml
   - ../../traefik/demo/01.yaml
   - ../../traefik/demo/traefik.yaml
   - ../../traefik-auth/demo/01.yaml

--- a/apps/admin/demo/01/kustomization.yaml
+++ b/apps/admin/demo/01/kustomization.yaml
@@ -2,10 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-
-patchesStrategicMerge:
-  - ../../traefik/demo/01.yaml
-  - ../../traefik/demo/traefik.yaml
-  - ../../traefik-auth/demo/01.yaml
-  - ../../traefik-no-proxy/demo/01.yaml
-  - ../../traefik-private/demo/01.yaml

--- a/apps/admin/demo/base/kustomization.yaml
+++ b/apps/admin/demo/base/kustomization.yaml
@@ -2,18 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - external-dns.yaml
-  - traefik-values.yaml
   - kube-slack-values.yaml
   - ../../keda
-  - ../../external-dns/
-  - ../../external-dns-public/
-  - ../../traefik-auth
-  - ../../traefik-no-proxy
-  - ../../traefik-private
-  - ../../csi-secret-store-provider-v1.0.1
   - ../../../rbac/reader-clusterrole.yaml
-  - ../../traefik/traefik.yaml
   - ../../reply-urls-operator/demo
 patchesStrategicMerge:
   - keda-identity.yaml


### PR DESCRIPTION
[DTSPO-8329](https://tools.hmcts.net/jira/browse/DTSPO-8329)

Extracting some of the file changes from https://github.com/hmcts/cnp-flux-config/pull/17695/files. Moving traefik to active demo cluster in this PR to focus on upgrades to inactive cluster in 17695.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
