### PR TITLE
Dtspo 8329 add demo oauth2

### DIFF
--- a/apps/admin/demo/00/kustomization.yaml
+++ b/apps/admin/demo/00/kustomization.yaml
@@ -2,6 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../traefik/traefik.yaml
+  - ../../traefik-auth
+  - ../../traefik-no-proxy
+  - ../../traefik-private
+  - ../../csi-secret-store-provider-v1.0.1
+  - ../../external-dns/
+  - ../../external-dns-public/
+  - ../base/external-dns.yaml
+  - ../base/traefik-values.yaml
 
 patchesStrategicMerge:
   - ../../external-dns/demo/00.yaml

--- a/apps/admin/demo/01/kustomization.yaml
+++ b/apps/admin/demo/01/kustomization.yaml
@@ -2,12 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-
-patchesStrategicMerge:
-  - ../../external-dns/demo/01.yaml
-  - ../../external-dns-public/demo/01.yaml
-  - ../../traefik/demo/01.yaml
-  - ../../traefik/demo/traefik.yaml
-  - ../../traefik-auth/demo/01.yaml
-  - ../../traefik-no-proxy/demo/01.yaml
-  - ../../traefik-private/demo/01.yaml

--- a/apps/admin/demo/base/kustomization.yaml
+++ b/apps/admin/demo/base/kustomization.yaml
@@ -2,18 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - external-dns.yaml
-  - traefik-values.yaml
   - kube-slack-values.yaml
   - ../../keda
-  - ../../external-dns/
-  - ../../external-dns-public/
-  - ../../traefik-auth
-  - ../../traefik-no-proxy
-  - ../../traefik-private
-  - ../../csi-secret-store-provider-v1.0.1
   - ../../../rbac/reader-clusterrole.yaml
-  - ../../traefik/traefik.yaml
   - ../../reply-urls-operator/demo
 patchesStrategicMerge:
   - keda-identity.yaml

--- a/apps/admin/oauth2-proxy/demo/01-oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/demo/01-oauth2-proxy.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+spec:
+  values:
+    extraArgs:
+      cookie-domain: ".demo.platform.hmcts.net"
+      redirect-url: https://cft-oauth-proxy-01.demo.platform.hmcts.net/oauth-proxy/callback
+      whitelist-domain: ".demo.platform.hmcts.net"
+    ingress:
+      hosts:
+        - cft-oauth-proxy-01.demo.platform.hmcts.net

--- a/apps/admin/oauth2-proxy/identity-binding.yaml
+++ b/apps/admin/oauth2-proxy/identity-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: oauth2-proxy-binding
+  namespace: admin
+spec:
+  azureIdentity: "aks-pod-identity-mi"
+  selector: oauth2-proxy

--- a/apps/admin/oauth2-proxy/kustomization.yaml
+++ b/apps/admin/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - oauth2-proxy.yaml
+  - secret-provider.yaml
+  - identity-binding.yaml
+  - oauth2-proxy-helmrepo.yaml

--- a/apps/admin/oauth2-proxy/oauth2-proxy-helmrepo.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy-helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+spec:
+  url: https://oauth2-proxy.github.io/manifests
+  interval: 10m

--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -1,0 +1,90 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: oauth2-proxy
+  chart:
+    spec:
+      chart: oauth2-proxy
+      version: 6.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: oauth2-proxy
+        namespace: admin
+  interval: 1m
+  values:
+    extraArgs:
+      email-domain: "*"
+      pass-basic-auth: false
+      pass-host-header: true
+      pass-user-headers: false
+      provider: "azure"
+      proxy-prefix: "/oauth-proxy"
+      reverse-proxy: true
+      show-debug-on-error: true
+      skip-provider-button: true
+      upstream: static://202
+    extraEnv:
+      - name: OAUTH2_PROXY_AZURE_TENANT
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: azure-tenant
+      - name: OAUTH2_PROXY_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: client-id
+      - name: OAUTH2_PROXY_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: client-secret
+      - name: OAUTH2_PROXY_COOKIE_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: cookie-secret
+      - name: OAUTH2_PROXY_EXTRA_JWT_ISSUERS
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: extra-jwt-issuers
+      - name: OAUTH2_PROXY_OIDC_ISSUER_URL
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: oidc-issuer-url
+    extraVolumes:
+      - name: oauth2-proxy-values
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: oauth2-proxy-values
+    extraVolumeMounts:
+      - mountPath: "/var/oauth2"
+        name: oauth2-proxy-values
+    ingress:
+      annotations:
+        kubernetes.io/ingress.class: traefik
+        traefik.ingress.kubernetes.io/router.tls: "true"
+      className: traefik
+      enabled: true
+    podLabels:
+      aadpodidbinding: oauth2-proxy
+    proxyVarsAsSecrets: true
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    valuesFrom:
+      - name: "oauth2-proxy-values"
+        kind: Secret

--- a/apps/admin/oauth2-proxy/secret-provider.yaml
+++ b/apps/admin/oauth2-proxy/secret-provider.yaml
@@ -1,0 +1,53 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: oauth2-proxy-values
+  namespace: admin
+spec:
+  parameters:
+    keyvaultName: acmedcdcftappsdemo
+    usePodIdentity: "true"
+    tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
+    objects: |
+      array:
+        - |
+          objectName: azure-tenant
+          objectType: secret
+          objectAlias: azure-tenant
+        - |
+          objectName: client-id
+          objectType: secret
+          objectAlias: client-id
+        - |
+          objectName: client-secret
+          objectType: secret
+          objectAlias: client-secret
+        - |
+          objectName: cookie-secret
+          objectType: secret
+          objectAlias: cookie-secret
+        - |
+          objectName: extra-jwt-issuers
+          objectType: secret
+          objectAlias: extra-jwt-issuers
+        - |
+          objectName: oidc-issuer-url
+          objectType: secret
+          objectAlias: oidc-issuer-url
+  provider: azure
+  secretObjects:
+  - secretName: oauth2-proxy-values
+    type: Opaque
+    data:
+    - objectName: azure-tenant
+      key: azure-tenant
+    - objectName: client-id
+      key: client-id
+    - objectName: client-secret
+      key: client-secret
+    - objectName: cookie-secret
+      key: cookie-secret
+    - objectName: extra-jwt-issuers
+      key: extra-jwt-issuers
+    - objectName: oidc-issuer-url
+      key: oidc-issuer-url

--- a/apps/adoption/adoption-cos-api/demo.yaml
+++ b/apps/adoption/adoption-cos-api/demo.yaml
@@ -7,6 +7,6 @@ spec:
   interval: 1m
   values:
     java:
-      image: hmctspublic.azurecr.io/adoption/cos-api:pr-249-600a9bb-20221005000343 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
+      image: hmctspublic.azurecr.io/adoption/cos-api:pr-249-410896e-20221006111114 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
         APP_INSIGHTS_KEY: '6c5278dd-ee76-4e7b-92f9-57b27ead382e'

--- a/apps/civil/civil-citizen-ui/civil-citizen-ui.yaml
+++ b/apps/civil/civil-citizen-ui/civil-citizen-ui.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: civil-citizen-ui
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-097eab1-20221005110337 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-453ce82-20221006094122 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
   chart:
     spec:
       chart: ./stable/civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/civil-citizen-ui.yaml
+++ b/apps/civil/civil-citizen-ui/civil-citizen-ui.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: civil-citizen-ui
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-453ce82-20221006094122 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-8b81996-20221006110050 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
   chart:
     spec:
       chart: ./stable/civil-citizen-ui

--- a/apps/civil/civil-service/demo-image-policy.yaml
+++ b/apps/civil/civil-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1477-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1530-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/et/et-cos/et-cos.yaml
+++ b/apps/et/et-cos/et-cos.yaml
@@ -8,7 +8,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/et/cos:prod-e508e42-20221003090133 #{"$imagepolicy": "flux-system:et-cos"}
+      image: hmctspublic.azurecr.io/et/cos:prod-54da441-20221006102352 #{"$imagepolicy": "flux-system:et-cos"}
   chart:
     spec:
       chart: ./stable/et-cos

--- a/apps/financial-remedy/finrem-cos/finrem-cos.yaml
+++ b/apps/financial-remedy/finrem-cos/finrem-cos.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/cos:prod-8b2f653-20221004142908 #{"$imagepolicy": "flux-system:finrem-cos"}
+      image: hmctspublic.azurecr.io/finrem/cos:prod-8f8be87-20221006103959 #{"$imagepolicy": "flux-system:finrem-cos"}
       environment:
         BSP_SERVICES_ALLOWED_TO_UPDATE: bulk_scan_orchestrator
         BSP_SERVICES_ALLOWED_TO_VALIDATE: bulk_scan_processor

--- a/apps/financial-remedy/finrem-dgcs/finrem-dgcs.yaml
+++ b/apps/financial-remedy/finrem-dgcs/finrem-dgcs.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/dgcs:prod-fd7fb7a-20220929135612 #{"$imagepolicy": "flux-system:finrem-dgcs"}
+      image: hmctspublic.azurecr.io/finrem/dgcs:prod-62a8d14-20221006103941 #{"$imagepolicy": "flux-system:finrem-dgcs"}
       environment:
         VAR_TA: trigger2
         FLUX_V2: yes3

--- a/apps/financial-remedy/finrem-emca/finrem-emca.yaml
+++ b/apps/financial-remedy/finrem-emca/finrem-emca.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/emca:prod-d5ce2e6-20220929105818 #{"$imagepolicy": "flux-system:finrem-emca"}
+      image: hmctspublic.azurecr.io/finrem/emca:prod-c26ac88-20221006105254 #{"$imagepolicy": "flux-system:finrem-emca"}
       environment:
         VAR_TA: trigger2
         FLUX_V2: base-2

--- a/apps/money-claims/cmc-citizen-frontend/demo-image-policy.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-3438-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-3383-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/money-claims/cmc-claim-store/demo-image-policy.yaml
+++ b/apps/money-claims/cmc-claim-store/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2636-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2632-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/nfdiv-cron-eligible-for-switch-to-sole.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/nfdiv-cron-eligible-for-switch-to-sole.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         TASK_NAME: SystemNotifyJointApplicantCanSwitchToSoleTask
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
     keyVaults:
       nfdiv:
         secrets:

--- a/k8s/namespaces/am/am-role-assignment-service/am-role-assignment-service.yaml
+++ b/k8s/namespaces/am/am-role-assignment-service/am-role-assignment-service.yaml
@@ -12,4 +12,4 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/am/role-assignment-service:prod-d5e12b9-20221005183150 #{"$imagepolicy": "flux-system:am-role-assignment-service"}
+      image: hmctspublic.azurecr.io/am/role-assignment-service:prod-17ad47a-20221006101735 #{"$imagepolicy": "flux-system:am-role-assignment-service"}

--- a/k8s/namespaces/ccd/ccd-int/ccd-int.yaml
+++ b/k8s/namespaces/ccd/ccd-int/ccd-int.yaml
@@ -140,7 +140,7 @@ spec:
         image: hmctspublic.azurecr.io/draft-store/service:prod-547c9ea-20220824092333 #{"$imagepolicy": "flux-system:draft-store-service"}
     em-anno:
       java:
-        image: hmctspublic.azurecr.io/em/anno:prod-492d3e0-20221005201824 #{"$imagepolicy": "flux-system:em-anno"}
+        image: hmctspublic.azurecr.io/em/anno:prod-04822f1-20221006110155 #{"$imagepolicy": "flux-system:em-anno"}
         ingressHost: em-anno-{{ .Release.Name }}.demo.platform.hmcts.net
         disableTraefikTls: false
     dm-store:

--- a/k8s/namespaces/ccd/ccd-int/ccd-int.yaml
+++ b/k8s/namespaces/ccd/ccd-int/ccd-int.yaml
@@ -132,7 +132,7 @@ spec:
               subscriptionNeeded: yes
     am-role-assignment-service:
       java:
-        image: hmctspublic.azurecr.io/am/role-assignment-service:prod-d5e12b9-20221005183150 #{"$imagepolicy": "flux-system:am-role-assignment-service"}
+        image: hmctspublic.azurecr.io/am/role-assignment-service:prod-17ad47a-20221006101735 #{"$imagepolicy": "flux-system:am-role-assignment-service"}
         environment:
           RUN_DB_MIGRATION_ON_STARTUP: true
     draft-store-service:

--- a/k8s/namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
+++ b/k8s/namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
@@ -22,6 +22,6 @@ spec:
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-097eab1-20221005110337 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-453ce82-20221006094122 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       environment:
         TEST_PROPERTY: TEST_VALUE_OVERIDDEN

--- a/k8s/namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
+++ b/k8s/namespaces/civil/civil-citizen-ui/civil-citizen-ui.yaml
@@ -22,6 +22,6 @@ spec:
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-453ce82-20221006094122 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-8b81996-20221006110050 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       environment:
         TEST_PROPERTY: TEST_VALUE_OVERIDDEN

--- a/k8s/namespaces/civil/civil-citizen-ui/demo.yaml
+++ b/k8s/namespaces/civil/civil-citizen-ui/demo.yaml
@@ -14,7 +14,7 @@ spec:
       useInterpodAntiAffinity: true
       ingressClass: traefik-no-proxy
       ingressHost: civil-citizen-ui.demo.platform.hmcts.net
-      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-097eab1-20221005110337 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-453ce82-20221006094122 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       environment:
         GA_TRACKING_ID: UA-97111056-1
         FEATURE_TESTING_SUPPORT: true

--- a/k8s/namespaces/civil/civil-citizen-ui/demo.yaml
+++ b/k8s/namespaces/civil/civil-citizen-ui/demo.yaml
@@ -14,7 +14,7 @@ spec:
       useInterpodAntiAffinity: true
       ingressClass: traefik-no-proxy
       ingressHost: civil-citizen-ui.demo.platform.hmcts.net
-      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-453ce82-20221006094122 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-8b81996-20221006110050 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       environment:
         GA_TRACKING_ID: UA-97111056-1
         FEATURE_TESTING_SUPPORT: true

--- a/k8s/namespaces/civil/civil-service/civil-service.yaml
+++ b/k8s/namespaces/civil/civil-service/civil-service.yaml
@@ -12,4 +12,4 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/civil/service:prod-f917070-20221005083045 #{"$imagepolicy": "flux-system:civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-fb9a595-20221006100408 #{"$imagepolicy": "flux-system:civil-service"}

--- a/k8s/namespaces/civil/civil-service/demo.yaml
+++ b/k8s/namespaces/civil/civil-service/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-1477-37c4099-20221005141610 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:pr-1530-026d724-20221006090722 #{"$imagepolicy": "flux-system:demo-civil-service"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/k8s/namespaces/civil/civil-service/demo.yaml
+++ b/k8s/namespaces/civil/civil-service/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-1530-026d724-20221006090722 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:pr-1477-37c4099-20221005141610 #{"$imagepolicy": "flux-system:demo-civil-service"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/k8s/namespaces/em/em-anno/demo.yaml
+++ b/k8s/namespaces/em/em-anno/demo.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/em/anno:prod-492d3e0-20221005201824 #{"$imagepolicy": "flux-system:demo-em-anno"}
+      image: hmctspublic.azurecr.io/em/anno:prod-04822f1-20221006110155 #{"$imagepolicy": "flux-system:demo-em-anno"}
       environment:
         TEST_VAR: value1

--- a/k8s/namespaces/em/em-anno/em-anno.yaml
+++ b/k8s/namespaces/em/em-anno/em-anno.yaml
@@ -12,7 +12,7 @@ spec:
     java:
       useInterpodAntiAffinity: true
       replicas: 2
-      image: hmctspublic.azurecr.io/em/anno:prod-492d3e0-20221005201824 #{"$imagepolicy": "flux-system:em-anno"}
+      image: hmctspublic.azurecr.io/em/anno:prod-04822f1-20221006110155 #{"$imagepolicy": "flux-system:em-anno"}
       environment:
         ENABLE_METADATA_ENDPOINT: true
         TEST_VAR: value1

--- a/k8s/namespaces/em/em-ccd-orchestrator/demo.yaml
+++ b/k8s/namespaces/em/em-ccd-orchestrator/demo.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     java:
       ingressHost: em-ccdorc-demo.service.core-compute-demo.internal
-      image: hmctspublic.azurecr.io/em/ccdorc:prod-83d3f67-20221005191545 #{"$imagepolicy": "flux-system:demo-em-ccd-orchestrator"}
+      image: hmctspublic.azurecr.io/em/ccdorc:prod-af56edc-20221006105332 #{"$imagepolicy": "flux-system:demo-em-ccd-orchestrator"}
       environment:
         CALLBACK_DOMAIN: em-ccdorc-demo.service.core-compute-demo.internal
         FLAG: "refresh"

--- a/k8s/namespaces/em/em-ccd-orchestrator/em-ccd-orchestrator.yaml
+++ b/k8s/namespaces/em/em-ccd-orchestrator/em-ccd-orchestrator.yaml
@@ -12,6 +12,6 @@ spec:
     java:
       useInterpodAntiAffinity: true
       replicas: 2
-      image: hmctspublic.azurecr.io/em/ccdorc:prod-83d3f67-20221005191545 #{"$imagepolicy": "flux-system:em-ccd-orchestrator"}
+      image: hmctspublic.azurecr.io/em/ccdorc:prod-af56edc-20221006105332 #{"$imagepolicy": "flux-system:em-ccd-orchestrator"}
       environment:
         TEST: "REFRESH"

--- a/k8s/namespaces/em/em-ccd-orchestrator/prod.yaml
+++ b/k8s/namespaces/em/em-ccd-orchestrator/prod.yaml
@@ -8,3 +8,4 @@ spec:
       environment:
         IDAM_API_BASE_URI: https://idam-api.platform.hmcts.net
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
+        S2S_NAMES_WHITELIST: sscs,divorce,ccd,em_gw,ccd_data,iac,em_stitching_api,ia,xui_webapp,civil_service

--- a/k8s/namespaces/financial-remedy/finrem-ns/demo.yaml
+++ b/k8s/namespaces/financial-remedy/finrem-ns/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/finrem/ns:prod-ab8dba2-20220929102414 #{"$imagepolicy": "flux-system:demo-finrem-ns"}
+      image: hmctspublic.azurecr.io/finrem/ns:prod-5289e89-20221006103925 #{"$imagepolicy": "flux-system:demo-finrem-ns"}
       environment:
         SWAGGER_ENABLED: false
         VAR_TA: demo-t1

--- a/k8s/namespaces/financial-remedy/finrem-ns/finrem-ns.yaml
+++ b/k8s/namespaces/financial-remedy/finrem-ns/finrem-ns.yaml
@@ -19,6 +19,6 @@ spec:
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/finrem/ns:prod-ab8dba2-20220929102414 #{"$imagepolicy": "flux-system:finrem-ns"}
+      image: hmctspublic.azurecr.io/finrem/ns:prod-5289e89-20221006103925 #{"$imagepolicy": "flux-system:finrem-ns"}
       environment:
         VAR_TA: trigger3

--- a/k8s/namespaces/ia/ia-case-api/demo.yaml
+++ b/k8s/namespaces/ia/ia-case-api/demo.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/case-api:pr-1082
+      image: hmctspublic.azurecr.io/ia/case-api:pr-1115
       environment:
         IA_HOME_OFFICE_INTEGRATION_ENABLED: "true"

--- a/k8s/namespaces/money-claims/cmc-citizen-frontend/demo.yaml
+++ b/k8s/namespaces/money-claims/cmc-citizen-frontend/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-3438-ebbaae1-20220921111230 #{"$imagepolicy": "flux-system:demo-cmc-citizen-frontend"}
+      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-3383-09c64b1-20220920180043 #{"$imagepolicy": "flux-system:demo-cmc-citizen-frontend"}
       ingressClass: traefik-no-proxy
       ingressHost: moneyclaims.demo.platform.hmcts.net
       disableTraefikTls: false

--- a/k8s/namespaces/money-claims/cmc-citizen-frontend/demo.yaml
+++ b/k8s/namespaces/money-claims/cmc-citizen-frontend/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-3383-09c64b1-20220920180043 #{"$imagepolicy": "flux-system:demo-cmc-citizen-frontend"}
+      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-3438-ebbaae1-20220921111230 #{"$imagepolicy": "flux-system:demo-cmc-citizen-frontend"}
       ingressClass: traefik-no-proxy
       ingressHost: moneyclaims.demo.platform.hmcts.net
       disableTraefikTls: false

--- a/k8s/namespaces/money-claims/cmc-claim-store/demo.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/cmc/claim-store:pr-2632-dfce857-20221006090420 #{"$imagepolicy": "flux-system:demo-cmc-claim-store"}
+      image: hmctspublic.azurecr.io/cmc/claim-store:pr-2636-4677089-20221004103048 #{"$imagepolicy": "flux-system:demo-cmc-claim-store"}
       keyVaults:
         cmc:
           resourceGroup: cmc

--- a/k8s/namespaces/money-claims/cmc-claim-store/demo.yaml
+++ b/k8s/namespaces/money-claims/cmc-claim-store/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/cmc/claim-store:pr-2636-4677089-20221004103048 #{"$imagepolicy": "flux-system:demo-cmc-claim-store"}
+      image: hmctspublic.azurecr.io/cmc/claim-store:pr-2632-dfce857-20221006090420 #{"$imagepolicy": "flux-system:demo-cmc-claim-store"}
       keyVaults:
         cmc:
           resourceGroup: cmc

--- a/k8s/namespaces/nfdiv/nfdiv-case-api/nfdiv-case-api.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-case-api/nfdiv-case-api.yaml
@@ -12,6 +12,6 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       environment:
         VAR_TA: trigger22

--- a/k8s/namespaces/nfdiv/nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/nfdiv-cron-notify-applicant-dispute-form-overdue.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/nfdiv-cron-notify-applicant-dispute-form-overdue.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-notify-applicants-apply-co/nfdiv-cron-notify-applicants-apply-co.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-notify-applicants-apply-co/nfdiv-cron-notify-applicants-apply-co.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/nfdiv-cron-process-cases-to-be-removed.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-cases-to-be-removed/nfdiv-cron-process-cases-to-be-removed.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/nfdiv-cron-process-failed-pronounced-cases.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-pronounced-cases/nfdiv-cron-process-failed-pronounced-cases.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-scheduled-cases/nfdiv-cron-process-failed-scheduled-cases.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-scheduled-cases/nfdiv-cron-process-failed-scheduled-cases.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/nfdiv-cron-process-failed-to-unlink-cases.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/nfdiv-cron-process-failed-to-unlink-cases.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/nfdiv-cron-progress-cases-to-aos-overdue.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/nfdiv-cron-progress-cases-to-aos-overdue.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-progress-held-cases/nfdiv-cron-progress-held-cases.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-progress-held-cases/nfdiv-cron-progress-held-cases.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-remind-applicant2/nfdiv-cron-remind-applicant2.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-remind-applicant2/nfdiv-cron-remind-applicant2.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
+++ b/k8s/namespaces/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
@@ -10,7 +10,7 @@ spec:
     path: nfdiv-cron
   values:
     job:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-f50e585-20221006094235 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-495ba08-20221006111309 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       keyVaults:
         nfdiv:
           secrets:

--- a/k8s/namespaces/xui/xui-webapp-wa-integration/demo.yaml
+++ b/k8s/namespaces/xui/xui-webapp-wa-integration/demo.yaml
@@ -27,4 +27,4 @@ spec:
         SERVICES_CASE_JUDICIAL_API: http://rd-judicial-api-demo.service.core-compute-demo.internal
         SERVICES_JUDICIAL_BOOKING_API_PATH: http://am-judicial-booking-service-demo.service.core-compute-demo.internal
         SERVICES_WA_WORKFLOW_API_URL: http://wa-workflow-api-demo.service.core-compute-demo.internal
-      image: hmctspublic.azurecr.io/xui/webapp:pr-1774-d5dc2d2-20221005162008 #{"$imagepolicy": "flux-system:demo-xui-webapp-wa-integration"}
+      image: hmctspublic.azurecr.io/xui/webapp:pr-1774-8d30893-20221006104550 #{"$imagepolicy": "flux-system:demo-xui-webapp-wa-integration"}


### PR DESCRIPTION
Splitting https://github.com/hmcts/cnp-flux-config/pull/17695/files PR up into more manageable parts. This PR adds the oauth2-proxy HR code, which will be added to Demo01 at a later point. This code currently is not included anywhere as a patch



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
