### PR TITLE
Add oauth2-proxy files

### DIFF
--- a/apps/admin/oauth2-proxy/demo/01-oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/demo/01-oauth2-proxy.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+spec:
+  values:
+    extraArgs:
+      cookie-domain: ".demo.platform.hmcts.net"
+      redirect-url: https://cft-oauth-proxy-01.demo.platform.hmcts.net/oauth-proxy/callback
+      whitelist-domain: ".demo.platform.hmcts.net"
+    ingress:
+      hosts:
+        - cft-oauth-proxy-01.demo.platform.hmcts.net

--- a/apps/admin/oauth2-proxy/identity-binding.yaml
+++ b/apps/admin/oauth2-proxy/identity-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: oauth2-proxy-binding
+  namespace: admin
+spec:
+  azureIdentity: "aks-pod-identity-mi"
+  selector: oauth2-proxy

--- a/apps/admin/oauth2-proxy/kustomization.yaml
+++ b/apps/admin/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - oauth2-proxy.yaml
+  - secret-provider.yaml
+  - identity-binding.yaml
+  - oauth2-proxy-helmrepo.yaml

--- a/apps/admin/oauth2-proxy/oauth2-proxy-helmrepo.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy-helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+spec:
+  url: https://oauth2-proxy.github.io/manifests
+  interval: 10m

--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -1,0 +1,90 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: oauth2-proxy
+  chart:
+    spec:
+      chart: oauth2-proxy
+      version: 6.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: oauth2-proxy
+        namespace: admin
+  interval: 1m
+  values:
+    extraArgs:
+      email-domain: "*"
+      pass-basic-auth: false
+      pass-host-header: true
+      pass-user-headers: false
+      provider: "azure"
+      proxy-prefix: "/oauth-proxy"
+      reverse-proxy: true
+      show-debug-on-error: true
+      skip-provider-button: true
+      upstream: static://202
+    extraEnv:
+      - name: OAUTH2_PROXY_AZURE_TENANT
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: azure-tenant
+      - name: OAUTH2_PROXY_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: client-id
+      - name: OAUTH2_PROXY_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: client-secret
+      - name: OAUTH2_PROXY_COOKIE_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: cookie-secret
+      - name: OAUTH2_PROXY_EXTRA_JWT_ISSUERS
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: extra-jwt-issuers
+      - name: OAUTH2_PROXY_OIDC_ISSUER_URL
+        valueFrom:
+          secretKeyRef:
+            name: oauth2-proxy-values
+            key: oidc-issuer-url
+    extraVolumes:
+      - name: oauth2-proxy-values
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: oauth2-proxy-values
+    extraVolumeMounts:
+      - mountPath: "/var/oauth2"
+        name: oauth2-proxy-values
+    ingress:
+      annotations:
+        kubernetes.io/ingress.class: traefik
+        traefik.ingress.kubernetes.io/router.tls: "true"
+      className: traefik
+      enabled: true
+    podLabels:
+      aadpodidbinding: oauth2-proxy
+    proxyVarsAsSecrets: true
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    valuesFrom:
+      - name: "oauth2-proxy-values"
+        kind: Secret

--- a/apps/admin/oauth2-proxy/secret-provider.yaml
+++ b/apps/admin/oauth2-proxy/secret-provider.yaml
@@ -1,0 +1,53 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: oauth2-proxy-values
+  namespace: admin
+spec:
+  parameters:
+    keyvaultName: acmedcdcftappsdemo
+    usePodIdentity: "true"
+    tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
+    objects: |
+      array:
+        - |
+          objectName: azure-tenant
+          objectType: secret
+          objectAlias: azure-tenant
+        - |
+          objectName: client-id
+          objectType: secret
+          objectAlias: client-id
+        - |
+          objectName: client-secret
+          objectType: secret
+          objectAlias: client-secret
+        - |
+          objectName: cookie-secret
+          objectType: secret
+          objectAlias: cookie-secret
+        - |
+          objectName: extra-jwt-issuers
+          objectType: secret
+          objectAlias: extra-jwt-issuers
+        - |
+          objectName: oidc-issuer-url
+          objectType: secret
+          objectAlias: oidc-issuer-url
+  provider: azure
+  secretObjects:
+  - secretName: oauth2-proxy-values
+    type: Opaque
+    data:
+    - objectName: azure-tenant
+      key: azure-tenant
+    - objectName: client-id
+      key: client-id
+    - objectName: client-secret
+      key: client-secret
+    - objectName: cookie-secret
+      key: cookie-secret
+    - objectName: extra-jwt-issuers
+      key: extra-jwt-issuers
+    - objectName: oidc-issuer-url
+      key: oidc-issuer-url


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-8329

Splitting https://github.com/hmcts/cnp-flux-config/pull/17695 PR down -- this PR adds the code for Oauth2-proxy configuration. Not included as a patch or resource until merging all the Traefik2 patches in Demo01 at a later point in https://github.com/hmcts/cnp-flux-config/pull/17695


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
