### PR TITLE
utilise aac identity in aat

### DIFF
--- a/apps/civil/aat/base/kustomization.yaml
+++ b/apps/civil/aat/base/kustomization.yaml
@@ -5,8 +5,10 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../money-claims/identity/identity.yaml
+  - ../../../aac/identity/identity.yaml
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../../xui/identity/aat.yaml
   - ../../../am/identity/aat.yaml
   - ../../../money-claims/identity/aat.yaml
+  - ../../../aac/identity/identity.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-1610


### Change description ###
- As we are integrating with Notice of Change common component, we need to utilise the AAC API.
Adding configuration in flux for us to use AAC in AAT env

Linked to:
-> https://github.com/hmcts/civil-ccd-definition/pull/1380

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
