### PR TITLE
Add doc and script for adding MI access from another project

### DIFF
--- a/bin/v2/add-identity-from-another-project.sh
+++ b/bin/v2/add-identity-from-another-project.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ex
+declare -A SUBMAP
+
+SUBMAP[aat]="DCD-CNP-DEV"
+SUBMAP[perftest]="DCD-CNP-QA"
+SUBMAP[demo]="DCD-CNP-DEV"
+SUBMAP[ithc]="DCD-CNP-QA"
+SUBMAP[prod]="DCD-CNP-Prod"
+SUBMAP[sbox]="DCD-CFT-Sandbox"
+
+NAMESPACE="$1"
+CALLING_NAMESPACE="$2"
+ENV="$3"
+
+function usage() {
+  echo "usage: ./add-identity-to-env.sh <namespace> <calling-namespace> <env>"
+}
+
+if [ -z "${NAMESPACE}" ] || [ -z "${CALLING_NAMESPACE}" ] || [ -z "${ENV}" ]
+then
+  usage
+  exit 1
+fi
+
+MI_ENV=${ENV}
+if [ "${ENV}"  == "preview" ]
+then
+    MI_ENV="aat"
+fi
+
+
+IDENTITY_PATH="../../../${CALLING_NAMESPACE}/identity/identity.yaml" yq eval -i '.resources += [env(IDENTITY_PATH)]' apps/${NAMESPACE}/${ENV}/base/kustomization.yaml
+IDENTITY_PATH="../../../${CALLING_NAMESPACE}/identity/${MI_ENV}.yaml" yq eval -i '.patchesStrategicMerge += [env(IDENTITY_PATH)]' apps/${NAMESPACE}/${ENV}/base/kustomization.yaml
+
+

--- a/docs/app-deployment-v2.md
+++ b/docs/app-deployment-v2.md
@@ -51,6 +51,19 @@ We use Managed Identity to access keyvaults secrets in application. This should 
     #example
     ./bin/v2/add-identity-to-env.sh divorce div div aat
    ```
+### Add managed identity to another project
+
+Sometimes you may need your pods to connect to another projects resources like Key Vaults. You can use the below to add their Managed Identity to your configuration which will allow it access.
+
+- Please note Preview applications use AAT key vaults and thus AAT managed identities, you can reuse identity created for AAT by adding it to preview kustomization.
+
+- Run [add-identity-from-another-project.sh](/bin/v2/add-identity-from-another-project.sh) with your namespace, Other Teams namespace, environment
+
+ ```bash
+    ./bin/v2/add-identity-from-another-project.sh <your namespace> <calling teams namespace> <environment>
+    #example
+    ./bin/v2/add-identity-from-another-project.sh divorce aac aat
+   ```
 
 ## Application
 


### PR DESCRIPTION
### Change description ###
Adding documentation and script on how to give your project access to another projects resources via their Managed Identity

A few developers have questions how to configure this on flux and I find this the best place.
the example is/was the civil teams civil-service is connecting to the aac vault aac-aat. For their pod to have access it needs to use the Managed Identity aac-aat-mi. 
This documentation will enable developers/engineers to config on their own without assistance.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
