### PR TITLE
Move traefik to linux nodepool

### DIFF
--- a/apps/admin/traefik2/prod/00.yaml
+++ b/apps/admin/traefik2/prod/00.yaml
@@ -8,3 +8,13 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.90.79.250"
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: kubernetes.azure.com/mode
+                  operator: In
+                  values:
+                    - linux


### PR DESCRIPTION
Currently nodes on system nodepool running traefik are throttling on network bytes/ seconds. system nodepool has lesser network threshold, so moving to linux nodepool till we create a new nodepool to move them across. 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
