### PR TITLE
overriding affinity on traefik pods

### DIFF
--- a/apps/admin/traefik2/prod/00.yaml
+++ b/apps/admin/traefik2/prod/00.yaml
@@ -8,13 +8,4 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.90.79.250"
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: kubernetes.azure.com/mode
-                  operator: In
-                  values:
-                    - linux
+    affinity: {}


### PR DESCRIPTION
Traefik is still getting scheduled on system nodepool as its preference , but not required. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
