### PR TITLE
EM-4666 remove app-insight debug

### DIFF
--- a/k8s/namespaces/em/em-npa/prod.yaml
+++ b/k8s/namespaces/em/em-npa/prod.yaml
@@ -8,4 +8,3 @@ spec:
       environment:
         IDAM_API_BASE_URI: "https://idam-api.platform.hmcts.net"
         OPEN_ID_API_BASE_URI: "https://hmcts-access.service.gov.uk/o"
-        APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION


### JIRA link (if applicable) ###

[EM-4666](https://tools.hmcts.net/jira/browse/EM-4666) remove app-insight debug, it is default debug in chart
