### PR TITLE
Moving traefik across all envs to user nodepool

### DIFF
--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: admin
 spec:
   values:
-    deployment:
-      podLabels:
-        app: traefik
     service:
       spec:
         loadBalancerIP: "10.48.79.250"

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -11,15 +11,3 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.48.79.250"
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                    - traefik
-                    - konnectivity-agent
-            topologyKey: "kubernetes.io/hostname"
-            namespaces: ["admin", "kube-system"]

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: admin
 spec:
   values:
-    deployment:
-      podLabels:
-        app: traefik
     service:
       spec:
         loadBalancerIP: "10.48.95.250"

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -11,15 +11,3 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.48.95.250"
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                    - traefik
-                    - konnectivity-agent
-            topologyKey: "kubernetes.io/hostname"
-            namespaces: ["admin", "kube-system"]

--- a/apps/admin/traefik2/prod/00.yaml
+++ b/apps/admin/traefik2/prod/00.yaml
@@ -8,5 +8,3 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.90.79.250"
-    affinity:
-    tolerations:

--- a/apps/admin/traefik2/prod/01.yaml
+++ b/apps/admin/traefik2/prod/01.yaml
@@ -8,5 +8,3 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.90.95.250"
-    affinity:
-    tolerations:

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -61,18 +61,3 @@ spec:
       enabled: true
       minReplicas: 2
       maxReplicas: 4
-    tolerations:
-      - key: CriticalAddonsOnly
-        operator: Equal
-        value: "true"
-        effect: NoSchedule
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-                - key: kubernetes.azure.com/mode
-                  operator: In
-                  values:
-                    - system

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -61,3 +61,13 @@ spec:
       enabled: true
       minReplicas: 2
       maxReplicas: 4
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - traefik
+            topologyKey: "kubernetes.io/hostname"

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -66,7 +66,7 @@ spec:
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: app
+                - key: app.kubernetes.io/name
                   operator: In
                   values:
                     - traefik


### PR DESCRIPTION

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
