### PR TITLE
Refactor to match SDS format, test picking up

### DIFF
--- a/apps/admin/traefik2/demo/01-auth-proxy.yaml
+++ b/apps/admin/traefik2/demo/01-auth-proxy.yaml
@@ -5,13 +5,11 @@ metadata:
   namespace: admin
 spec:
   values:
+    additionalArguments:
+      - --providers.kubernetesingress.ingressendpoint.ip=51.142.81.236
     service:
       spec:
         loadBalancerIP: "10.50.95.251"
-    providers:
-      kubernetesIngress:
-        ingressEndpoint:
-          ip: 51.142.81.236
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware

--- a/apps/admin/traefik2/demo/01-no-proxy.yaml
+++ b/apps/admin/traefik2/demo/01-no-proxy.yaml
@@ -7,10 +7,8 @@ metadata:
   namespace: admin
 spec:
   values:
+    additionalArguments:
+      - --providers.kubernetesingress.ingressendpoint.ip=51.142.80.151
     service:
       spec:
         loadBalancerIP: "10.50.95.250"
-    providers:
-      kubernetesIngress:
-        ingressEndpoint:
-          ip: 51.142.80.151


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8329


### Change description ###
Ingress IPs on cluster are picking up the LB IPS and not the ingress endpoints. Hoping this change to how SDS implement https://github.com/hmcts/sds-flux-config/blob/master/apps/admin/traefik-auth-proxy/traefik-auth-proxy.yaml#L23 may get this to be picked up.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
