### PR TITLE
Enable private ingressclass, update traefik ingressclass name

### DIFF
--- a/apps/admin/traefik2/demo/01-auth-proxy.yaml
+++ b/apps/admin/traefik2/demo/01-auth-proxy.yaml
@@ -7,6 +7,9 @@ spec:
   values:
     additionalArguments:
       - --providers.kubernetesingress.ingressendpoint.ip=51.142.81.236
+      - --providers.kubernetesingress.ingressclass=traefik
+      - --entryPoints.web.forwardedHeaders.insecure
+      - --entryPoints.websecure.forwardedHeaders.insecure
     service:
       spec:
         loadBalancerIP: "10.50.95.251"

--- a/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
@@ -12,10 +12,6 @@ spec:
     ports:
       web:
         redirectTo: websecure
-    additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik
-      - --entryPoints.web.forwardedHeaders.insecure
-      - --entryPoints.websecure.forwardedHeaders.insecure
     ingressClass:
       enabled: true
       isDefaultClass: false

--- a/apps/admin/traefik2/traefik2-private/traefik2-private.yaml
+++ b/apps/admin/traefik2/traefik2-private/traefik2-private.yaml
@@ -13,4 +13,5 @@ spec:
           enabled: true
     nameOverride: private
     ingressClass:
+      enabled: true
       isDefaultClass: false


### PR DESCRIPTION
**enable flag added so traefik-private shows as an ingress class**

**moving additional arguments as name overwrite for traefik ingress class not working, currently showing as traefik-auth-proxy which we don't have set**



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
