### PR TITLE
Add traefik auth override

### DIFF
--- a/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
@@ -15,7 +15,7 @@ spec:
         redirectTo: websecure
     ingressClass:
       enabled: true
-      isDefaultClass: false
+      isDefaultClass: true
     logs:
       access:
         enabled: true

--- a/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
@@ -9,6 +9,7 @@ spec:
   releaseName: traefik-auth-proxy
   interval: 1m
   values:
+    fullnameOverride: traefik
     ports:
       web:
         redirectTo: websecure

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -9,4 +9,3 @@ spec:
       ingressHost: plum.demo.platform.hmcts.net
       disableIngressClassAnnotation: true
       disableTraefikTls: false
-      ingressClass: traefik-auth-proxy


### PR DESCRIPTION
This sets the ingressclass name to traefik instead of traefik-auth-proxy, which is needed as all apps use it this way and this line was missed before. 
Adds this ingressclass as default, so if apps don't define an ingressclass they pick traefik by default
Removes plum testing to revert back to default ingressclass



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
