### PR TITLE
Code block missing

### DIFF
--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -27,8 +27,9 @@ spec:
         memory: 1Gi
     providers:
       kubernetesIngress:
-        publishedService:
-          enabled: true
+        ingressEndpoint:
+          publishedService:
+            enabled: true
     deployment:
       podLabels:
         aadpodidbinding: traefik


### PR DESCRIPTION
...

This was silently causing the ingressEndpoint to not assign correctly for all demo ingress Addresses. We're missing a code block as defined here https://doc.traefik.io/traefik/providers/kubernetes-ingress/#publishedservice. Probably explains why our kustomization wasn't working too cc @thomast1906.
Shouldn't be breaking as the code was never working anyway but demo is using the ingressEndpoints.

After fixing this locally, the ingress IP address is set correctly as the defined ingressEndpoints in the traefik patches


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
