### PR TITLE
Remove published service from config

### DIFF
--- a/apps/admin/traefik2/traefik2-private/traefik2-private.yaml
+++ b/apps/admin/traefik2/traefik2-private/traefik2-private.yaml
@@ -7,10 +7,6 @@ spec:
   values:
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
-    providers:
-      kubernetesIngress:
-        publishedService:
-          enabled: true
     nameOverride: private
     ingressClass:
       enabled: true

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -25,10 +25,6 @@ spec:
       limits:
         cpu: 1000m
         memory: 1Gi
-    providers:
-      kubernetesIngress:
-        publishedService:
-          enabled: true
     deployment:
       podLabels:
         aadpodidbinding: traefik


### PR DESCRIPTION
We may need this in demo as per https://doc.traefik.io/traefik/providers/kubernetes-ingress/#publishedservice so that each ingress picks up the ingressEndpoint correctly so that DNS records are correct. Have just manually edited in demo and IPs where picked up fine, so this may be the only change needed

Previously not working anyway in all envs, when fixed in code, likely broke preview as we don't use the published service there so no IPs set for new ingress types 


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
