### PR TITLE
Remove provider config, pick correct ingress IPS

### DIFF
--- a/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
@@ -9,7 +9,7 @@ spec:
   releaseName: traefik-auth-proxy
   interval: 1m
   values:
-    provider: {}
+    providers: {}
     fullnameOverride: traefik
     ports:
       web:

--- a/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-auth-proxy/traefik-auth-proxy.yaml
@@ -9,6 +9,7 @@ spec:
   releaseName: traefik-auth-proxy
   interval: 1m
   values:
+    provider: {}
     fullnameOverride: traefik
     ports:
       web:

--- a/apps/admin/traefik2/traefik2-no-proxy/traefik2-no-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-no-proxy/traefik2-no-proxy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   releaseName: traefik-no-proxy
   values:
-    provider: {}
+    providers: {}
     ingressClass:
       enabled: true
       isDefaultClass: false

--- a/apps/admin/traefik2/traefik2-no-proxy/traefik2-no-proxy.yaml
+++ b/apps/admin/traefik2/traefik2-no-proxy/traefik2-no-proxy.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   releaseName: traefik-no-proxy
   values:
+    provider: {}
     ingressClass:
       enabled: true
       isDefaultClass: false

--- a/apps/admin/traefik2/traefik2-private/traefik2-private.yaml
+++ b/apps/admin/traefik2/traefik2-private/traefik2-private.yaml
@@ -7,10 +7,7 @@ spec:
   values:
     additionalArguments:
       - --providers.kubernetesingress.ingressclass=traefik-private
-    providers:
-      kubernetesIngress:
-        publishedService:
-          enabled: true
+    providers: {}
     nameOverride: private
     ingressClass:
       enabled: true


### PR DESCRIPTION
Setting this to an empty block allows the ingressEndpoint IP addresses to be assigned correctly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
