### PR TITLE
Update to use correct private ip

### DIFF
--- a/apps/admin/traefik2/demo/01-private.yaml
+++ b/apps/admin/traefik2/demo/01-private.yaml
@@ -7,14 +7,4 @@ spec:
   values:
     service:
       spec:
-        loadBalancerIP: "10.50.95.246"
-    # ssl:
-    #   enabled: true
-    # debug:
-    #   enabled: true
-    # forwardedHeaders:
-    #   enabled: true
-    #   trustedIPs:
-    #     - 0.0.0.0
-    # dashboard:
-    #   domain: traefik01.demo.platform.hmcts.net
+        loadBalancerIP: "10.50.95.221"


### PR DESCRIPTION
Use correct IP for 01 cluster as per https://tools.hmcts.net/confluence/display/~thomas.thornton/CFT+Demo+Traefik+Setup documentation


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
