### PR TITLE
Remove annotation filter from external dns

### DIFF
--- a/apps/admin/external-dns-2/external-dns-public/external-dns-public.yaml
+++ b/apps/admin/external-dns-2/external-dns-public/external-dns-public.yaml
@@ -9,7 +9,6 @@ spec:
   releaseName: external-dns
   values:
     provider: azure
-    annotationFilter: "kubernetes.io/ingress.class=traefik"
     azure:
       resourceGroup: reformMgmtRG
       tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -7,5 +7,5 @@ spec:
   values:
     nodejs:
       ingressHost: plum.demo.platform.hmcts.net
-      ingressClass: traefik-no-proxy
+      ingressClass: traefik-private
       disableTraefikTls: false


### PR DESCRIPTION
External dns ignores non default ingress classes - may be something we can add in the future https://github.com/kubernetes-sigs/external-dns/issues/1716 ? 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
