### PR TITLE
Add ip for ingress to pick up for traefik-private

### DIFF
--- a/apps/admin/traefik2/demo/01-private.yaml
+++ b/apps/admin/traefik2/demo/01-private.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: admin
 spec:
   values:
+    additionalArguments:
+      - --providers.kubernetesingress.ingressendpoint.ip=10.50.95.221
     service:
       spec:
         loadBalancerIP: "10.50.95.221"

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -7,5 +7,5 @@ spec:
   values:
     nodejs:
       ingressHost: plum.demo.platform.hmcts.net
-      ingressClass: traefik-private
+      ingressClass: traefik
       disableTraefikTls: false


### PR DESCRIPTION
Adding this manually set the IP correctly - made plum reachable over only dns (traefik-private)

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
