### PR TITLE
SDT-5: Add configuration for civil-sdt-gateway

### DIFF
--- a/apps/civil/automation/kustomization.yaml
+++ b/apps/civil/automation/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - ../civil-citizen-ui/demo-image-policy.yaml
   - ../civil-general-applications/demo-image-policy.yaml
   - ../civil-service/ithc-image-policy.yaml
+  - ../civil-sdt-gateway/image-repo.yaml
+  - ../civil-sdt-gateway/image-policy.yaml

--- a/apps/civil/civil-sdt-gateway/civil-sdt-gateway.yaml
+++ b/apps/civil/civil-sdt-gateway/civil-sdt-gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: civil-sdt-gateway
+  namespace: civil
+spec:
+  releaseName: civil-sdt-gateway
+  values:
+    java:
+      replicas: 2
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/civil/sdt-gateway:prod-73ae513-20221103093256  #{"$imagepolicy": "flux-system:civil-sdt-gateway"}
+      environment:
+  chart:
+    spec:
+      chart: ./stable/civil-sdt-gateway
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/civil/civil-sdt-gateway/image-policy.yaml
+++ b/apps/civil/civil-sdt-gateway/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImagePolicy
+metadata:
+  name: civil-sdt-gateway
+spec:
+  imageRepositoryRef:
+    name: civil-sdt-gateway

--- a/apps/civil/civil-sdt-gateway/image-repo.yaml
+++ b/apps/civil/civil-sdt-gateway/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImageRepository
+metadata:
+  name: civil-sdt-gateway
+spec:
+  image: hmctspublic.azurecr.io/civil/sdt-gateway

--- a/apps/civil/demo/base/kustomization.yaml
+++ b/apps/civil/demo/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../civil-general-applications/civil-general-applications.yaml
   - ../../civil-citizen-ui/civil-citizen-ui.yaml
+  - ../../civil-sdt-gateway/civil-sdt-gateway.yaml
 patchesStrategicMerge:
   - ../../identity/demo.yaml
   - ../../../xui/identity/aat.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
SDT-5 (https://tools.hmcts.net/jira/browse/SDT-5)


### Change description ###
Added configuration for civil-sdt-gateway.  Configuration currently set up so that application is only deployed to demo environment.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
