### PR TITLE
Update demo.yaml

### DIFF
--- a/apps/adoption/adoption-web/demo.yaml
+++ b/apps/adoption/adoption-web/demo.yaml
@@ -7,6 +7,8 @@ spec:
   interval: 1m
   values:
     nodejs:
+      disableIngressClassAnnotation: true
+      ingressClass: traefik-no-proxy
       disableTraefikTls: false
       readinessPeriod: 15
       image: hmctspublic.azurecr.io/adoption/web:prod-4446c55-20221108104140 #{"$imagepolicy": "flux-system:adoption-web"}


### PR DESCRIPTION
confirmed with @AlokDatta that app should be reachable without vpn and with no auth - settting ingress class to accomplish this as per https://hmcts.github.io/ways-of-working/environments/external-access-in-demo.html#protecting-applications-with-hmcts-vpn


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
