### PR TITLE
Upgrade oauth-proxy

### DIFF
--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -18,7 +18,6 @@ spec:
   interval: 1m
   values:
     image:
-      repository: "quay.io/oauth2-proxy/oauth2-proxy"
       tag: "v7.4.0"
       pullPolicy: "Always"
     extraArgs:

--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -19,7 +19,6 @@ spec:
   values:
     image:
       tag: "v7.4.0"
-      pullPolicy: "Always"
     extraArgs:
       cookie-domain: ".demo.platform.hmcts.net"
       session-cookie-minimal: true

--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: oauth2-proxy
-      version: 6.2.0
+      version: 6.3.0
       sourceRef:
         kind: HelmRepository
         name: oauth2-proxy

--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -17,6 +17,10 @@ spec:
         namespace: admin
   interval: 1m
   values:
+    image:
+      repository: "quay.io/oauth2-proxy/oauth2-proxy"
+      tag: "v7.4.0"
+      pullPolicy: "Always"
     extraArgs:
       cookie-domain: ".demo.platform.hmcts.net"
       session-cookie-minimal: true

--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: oauth2-proxy
-      version: 6.3.0
+      version: 6.2.0
       sourceRef:
         kind: HelmRepository
         name: oauth2-proxy


### PR DESCRIPTION
Error from pods:
```
[2022/11/10 17:05:33] [azure.go:227] unable to get claims from token: could not get claim "groups": failed to fetch claims from profile URL: error making request to profile URL: unexpected status "400": 
```

Github issue:
https://github.com/oauth2-proxy/oauth2-proxy/issues/1666

Helm manifest `6.3.0` moved to this breaking version for the azure provider

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
