### PR TITLE
Updated dm-store config

### DIFF
--- a/k8s/namespaces/dm-store/dm-store/demo.yaml
+++ b/k8s/namespaces/dm-store/dm-store/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 2
       disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/dm/store:prod-e15e0ce-20221114153753 #{"$imagepolicy": "flux-system:demo-dm-store"}

--- a/k8s/namespaces/dm-store/dm-store/dm-store.yaml
+++ b/k8s/namespaces/dm-store/dm-store/dm-store.yaml
@@ -10,10 +10,10 @@ spec:
     path: stable/dm-store
   values:
     java:
-      replicas: 7
-      memoryRequests: "2048Mi"
+      replicas: 2
+      memoryRequests: "2Gi"
       cpuRequests: "1000m"
-      memoryLimits: "4096Mi"
+      memoryLimits: "4Gi"
       cpuLimits: "2000m"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/dm/store:prod-e15e0ce-20221114153753 #{"$imagepolicy": "flux-system:dm-store"}

--- a/k8s/namespaces/dm-store/dm-store/ithc.yaml
+++ b/k8s/namespaces/dm-store/dm-store/ithc.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 4
       environment:
         ENABLE_TTL: false
       testsConfig:

--- a/k8s/namespaces/dm-store/dm-store/perftest.yaml
+++ b/k8s/namespaces/dm-store/dm-store/perftest.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   values:
     java:
+      replicas: 7
       memoryRequests: "3Gi"
+      cpuRequests: "1000m"
+      memoryLimits: "6Gi"
+      cpuLimits: "2000m"
       image: hmctspublic.azurecr.io/dm/store:pr-1515-0c6da21-20221031084848 #{"$imagepolicy": "flux-system:perftest-dm-store"}
       environment:
         ENABLE_TTL: false

--- a/k8s/namespaces/dm-store/dm-store/prod.yaml
+++ b/k8s/namespaces/dm-store/dm-store/prod.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   values:
     java:
+      replicas: 7
       memoryRequests: "3Gi"
+      cpuRequests: "1000m"
+      memoryLimits: "6Gi"
+      cpuLimits: "2000m"
       environment:
         FLAG: "refresh2"
         ENABLE_TTL: "false"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4700
### Change description ###
Updated dm-store config to ensure
- Only Prod & Perftest have more resource allocated.
- Default config is reduced to 2 replicas.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
