### PR TITLE
Enable ingressClass resource

### DIFF
--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -29,6 +29,9 @@ spec:
       kubernetesIngress:
         publishedService:
           enabled: true
+    ingressClass:
+      enabled: true
+      isDefaultClass: false
     deployment:
       podLabels:
         aadpodidbinding: traefik


### PR DESCRIPTION
[DTSPO-11401](https://tools.hmcts.net/jira/browse/DTSPO-11401)

Chart-Library change: https://github.com/hmcts/chart-library/releases/tag/1.1.3-alpha

After adding 

```
ingressClass:
  enabled: true
  isDefaultClass: false
```

Manually to Plum HR, you can see ingressClass is now created, and the plum ingress then gets assigned an address. After this, svc was reachable and PR ran green (which was red before, as no address was being assigned after the chart-library update) https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcnp-plum-frontend/detail/PR-179/3/pipeline/106. Looking to add this to base traefik file.

![image](https://user-images.githubusercontent.com/47995122/202722279-28beebf0-1582-40d1-a4eb-a5ad167d3971.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
