### PR TITLE
Removed probate_backend from dm-store prod whitelist

### DIFF
--- a/k8s/namespaces/dm-store/dm-store/prod.yaml
+++ b/k8s/namespaces/dm-store/dm-store/prod.yaml
@@ -14,7 +14,7 @@ spec:
         FLAG: "refresh2"
         ENABLE_TTL: "false"
         ENABLE_TESTING: "false"
-        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,jui_webapp,pui_webapp,cmc_claim_store,em_npa_app,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,nfdiv_case_api,adoption_web,adoption_cos_api,ccd_case_disposer,et_cos
+        S2S_NAMES_WHITELIST: divorce,ccd,em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,jui_webapp,pui_webapp,cmc_claim_store,em_npa_app,fpl_case_service,finrem_document_generator,iac,em_stitching_api,dg_docassembly_api,ethos_repl_service,employment_tribunals,xui_webapp,ccd_case_document_am_api,nfdiv_case_api,adoption_web,adoption_cos_api,ccd_case_disposer,et_cos
       testsConfig:
         environment:
           TEST_URL: http://dm-store-java


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-4780. CHG5010228
### Change description ###
Removed probate_backend from dm-store prod whitelist.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
