### PR TITLE
Remove broken flux v2 patch (aat)

### DIFF
--- a/apps/flux-system/aat/base/kustomization.yaml
+++ b/apps/flux-system/aat/base/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../base.gotk-components.yaml
   - git-credentials.yaml


### PR DESCRIPTION
```
flux-system   flux-system        False     kustomize build failed: accumulating resources: accumulation err='accumulating resources from '../base': read /tmp/flux-system245679679/clusters/aat/base: is a directory': recursed accumulation of path '/tmp/flux-system245679679/clusters/aat/base': accumulating resources: accumulation err='accumulating resources from '../../../apps/flux-system/aat/base': read /tmp/flux-system245679679/apps/flux-system/aat/base: is a directory': recursed accumulation of path '/tmp/flux-system245679679/apps/flux-system/aat/base': accumulating resources: accumulation err='accumulating resources from '../../base.gotk-components.yaml': open /tmp/flux-system245679679/apps/flux-system/base.gotk-components.yaml: no such file or directory': evalsymlink failure on '/tmp/flux-system245679679/apps/flux-system/base.gotk-components.yaml' : lstat /tmp/flux-system245679679/apps/flux-system/base.gotk-components.yaml: no such file or directory   94d
```

i've pinged @ciaranca on slack