### PR TITLE
Adds gotk path back to aat

### DIFF
--- a/apps/flux-system/aat/base/kustomization.yaml
+++ b/apps/flux-system/aat/base/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../base/gotk-components.yaml
   - git-credentials.yaml


### PR DESCRIPTION
### Change description ###

Path for gotk file removed due to typo. Adding correct path back in to fix flux issues on aat

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
