### PR TITLE
Add namespace through flux kustomize to non prod rbac

### DIFF
--- a/apps/rbac/nonprod-role.yaml
+++ b/apps/rbac/nonprod-role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nonprod-team-permissions
+  namespace: ${NAMESPACE}
 rules:
 - apiGroups: ['']
   resources: ['pods']
@@ -26,6 +27,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nonprod-team-permissions
+  namespace: ${NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
This saves us from adding namespace: field in every apps/`ns`/`env`/kustomization.yaml

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
