### PR TITLE
Move RPE namespace to prod

### DIFF
--- a/apps/rpe/identity/prod.yaml
+++ b/apps/rpe/identity/prod.yaml
@@ -4,16 +4,5 @@ metadata:
   name: rpe
   namespace: rpe
 spec:
-  type: 0
   resourceID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpe-shared-prod-mi
   clientID: 2ef55fc9-c912-4cad-8697-75e433829c6a
-
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentityBinding
-metadata:
-  name: rpe-binding
-  namespace: rpe
-spec:
-  azureIdentity: rpe
-  selector: rpe

--- a/apps/rpe/identity/send-letter-identity-prod.yaml
+++ b/apps/rpe/identity/send-letter-identity-prod.yaml
@@ -4,16 +4,5 @@ metadata:
   name: send-letter
   namespace: rpe
 spec:
-  type: 0
   resourceID: /subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/send-letter-prod-mi
   clientID: 17a5025d-6c15-4044-8c9f-ac2bfbb06ee7
-
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentityBinding
-metadata:
-  name: send-letter-binding
-  namespace: rpe
-spec:
-  azureIdentity: send-letter
-  selector: send-letter

--- a/apps/rpe/prod/base/kustomization.yaml
+++ b/apps/rpe/prod/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: rpe
+patchesStrategicMerge:
+  - ../../identity/prod.yaml
+  - ../../draft-store-service/prod.yaml
+  - ../../identity/send-letter-identity-prod.yaml

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ../../../apps/xui/base/kustomize.yaml
   - ../../../apps/civil/base/kustomize.yaml
   - ../../../apps/docmosis/base/kustomize.yaml
+  - ../../../apps/rpe/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:

--- a/k8s/prod/common-overlay/rpe/kustomization.yaml
+++ b/k8s/prod/common-overlay/rpe/kustomization.yaml
@@ -2,11 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: rpe
 bases:
-- ../../../namespaces/rpe
-- ../../../namespaces/rpe/draft-store-service/pdf-service-ingress.yaml
-- ../../../namespaces/rpe/namespace.yaml
-- ../../../namespaces/rpe/draft-store-service/draft-store-service.yaml
-- ../../../namespaces/rpe/rpe-service-auth-provider/rpe-service-auth-provider.yaml
+  - ../../../namespaces/rpe
+  - ../../../namespaces/rpe/draft-store-service/pdf-service-ingress.yaml
 patchesStrategicMerge:
-- ../../../namespaces/rpe/draft-store-service/prod.yaml
-- ../../../namespaces/rpe/rpe-send-letter-service/prod.yaml
+  - ../../../namespaces/rpe/rpe-send-letter-service/prod.yaml


### PR DESCRIPTION
Namespace migration also needs apps in https://github.com/hmcts/cnp-flux-config/blob/master/apps/rpe/base/kustomization.yaml#L5-L6  to  be migrated as `rpe/base` is applied across all envs. Only docmosis (already migrated last night ) and rpe are the only namespaces with such config. 

This caused flux v1 and v2 fighting over in AAT causing a brief outage (config wasn't patched/ updated in v2). 

Needs https://github.com/hmcts/cnp-flux-config/pull/19532 to be merged and rolebinding deleted.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
