### PR TITLE
Revert "DTSBPS-1172: Enable encryption in send-letter-service demo"

### DIFF
--- a/k8s/namespaces/rpe/rpe-send-letter-service/demo.yaml
+++ b/k8s/namespaces/rpe/rpe-send-letter-service/demo.yaml
@@ -8,8 +8,8 @@ spec:
       ingressClass: traefik-private
       disableIngressClassAnnotation: true
       environment:
-        ENCRYPTION_ENABLED: true
+        ENCRYPTION_ENABLED: false
         FILE_CLEANUP_ENABLED: "false"
         OLD_LETTER_CONTENT_CLEANUP_ENABLED: "false"
         CIVIL_SERVICE_ENABLED: true
-        REFRESH_PODS: "true"
+        REFRESH_PODS: "yes"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#19569 
Encryption need to be disabled for services to test documents