### PR TITLE
imageautomation from v1alpha2 to v1beta1 testing docmosis

### DIFF
--- a/apps/docmosis/docmosis/aat-image-policy.yaml
+++ b/apps/docmosis/docmosis/aat-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: aat-docmosis

--- a/apps/docmosis/docmosis/demo-image-policy.yaml
+++ b/apps/docmosis/docmosis/demo-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-docmosis

--- a/apps/docmosis/docmosis/image-policy.yaml
+++ b/apps/docmosis/docmosis/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/image-repo.yaml
+++ b/apps/docmosis/docmosis/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImageRepository
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/ithc-image-policy.yaml
+++ b/apps/docmosis/docmosis/ithc-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: ithc-docmosis

--- a/apps/docmosis/docmosis/perftest-image-policy.yaml
+++ b/apps/docmosis/docmosis/perftest-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: perftest-docmosis

--- a/apps/docmosis/docmosis/sandbox-image-policy.yaml
+++ b/apps/docmosis/docmosis/sandbox-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: sandbox-docmosis


### PR DESCRIPTION
### Change description ###
Recent PR looks to have broken imageAutomation
https://github.com/hmcts/cnp-flux-config/commit/6f1c0adbba3d48d0b8a6f16ff911ceb6ea812e22#diff-1dde3434ff026a864182e4b1e493c6758fd831d85c94a2854438104b820c408dR30 

Error in logs: 
`{"level":"error","ts":"2022-12-08T22:29:02.493Z","msg":"Reconciliation failed after 38.720019639s, next try in 1m0s","controller":"kustomization","controllerGroup":"kustomize.toolkit.fluxcd.io","controllerKind":"Kustomization","Kustomization":{"name":"flux-system","namespace":"flux-system"},"namespace":"flux-system","name":"flux-system","reconcileID":"94562faa-3e9d-4aca-b492-4d55da765b00","revision":"master/6c569dc8a605801981ffc3c1a17c08ce2b0a8e4d","error":"ImagePolicy/flux-system/aat-docmosis dry-run failed, error: no matches for kind \"ImagePolicy\" in version \"image.toolkit.fluxcd.io/v1alpha2\"\n"}
`

Testing this as may have to rollback PR to resolve for now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
