### PR TITLE
Remove to temporary clean ccd demo

### DIFF
--- a/apps/ccd/demo/base/kustomization.yaml
+++ b/apps/ccd/demo/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - importer-creds.yaml
   - ccd-admin-web-oauth2-client-secret.yaml
   - ccd-api-gateway-oauth2-client-secret.yaml
-  - ../../ccd-int/ccd-int.yaml
   - ../../ccd-ac-int-api-gateway-web/ccd-ac-int-api-gateway-web.yaml
   - ../../ccd-ac-int-definition-store-api/ccd-ac-int-definition-store-api.yaml
   - ../../ccd-case-disposer/ccd-case-disposer.yaml


### PR DESCRIPTION
CCD kustomization in demo making endpoints unreachable
```
ccd                 65d   False   HelmRelease/ccd/ccd-int dry-run failed, error: failed to create typed patch object (ccd/ccd-int; helm.toolkit.fluxcd.io/v2beta1, Kind=HelmRelease): .spec.timeout: expected string, got &value.valueUnstructured{Value:900}...
```

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
