### PR TITLE
Update demo-image-policy.yaml

### DIFF
--- a/apps/rd/rd-judicial-data-load/demo-image-policy.yaml
+++ b/apps/rd/rd-judicial-data-load/demo-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-rd-judicial-data-load


### PR DESCRIPTION
flux-system                     297d   False   ImagePolicy/flux-system/demo-rd-judicial-data-load dry-run failed, error: no matches for kind "ImagePolicy" in version "image.toolkit.fluxcd.io/v1alpha2"...

seeing this issue in flux system