### PR TITLE
 CCD-3728: revert Redis infrastructure deploy master in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2161-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -43,34 +43,3 @@ spec:
         TTL_GUARD: 0
         HTTP_CLIENT_READ_TIMEOUT: 29000
         FEIGN_CLIENT_READ_TIMEOUT: 29000
-        CACHE_TYPE: redis
-        REDIS_PORT: 6380
-        REDIS_HOST: ccd-redis-perftest.redis.cache.windows.net
-      keyVaults:
-        ccd:
-          secrets:
-            - name: data-store-api-POSTGRES-USER
-              alias: DATA_STORE_DB_USERNAME
-            - name: data-store-api-POSTGRES-PASS
-              alias: DATA_STORE_DB_PASSWORD
-            - name: data-store-api-draft-key
-              alias: CCD_DRAFT_ENCRYPTION_KEY
-            - name: ccd-data-s2s-secret
-              alias: DATA_STORE_IDAM_KEY
-            - name: ccd-ELASTIC-SEARCH-URL
-              alias: ELASTIC_SEARCH_HOSTS
-            - name: ccd-ELASTIC-SEARCH-DATA-NODES-URL
-              alias: ELASTIC_SEARCH_DATA_NODES_HOSTS
-            - name: ccd-ELASTIC-SEARCH-PASSWORD
-              alias: ELASTIC_SEARCH_PASSWORD
-            - name: AppInsightsInstrumentationKey
-              alias: azure.application-insights.instrumentation-key
-            - name: idam-data-store-client-secret
-              alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
-            - name: idam-data-store-system-user-username
-              alias: IDAM_DATA_STORE_SYSTEM_USER_USERNAME
-            - name: idam-data-store-system-user-password
-              alias: IDAM_DATA_STORE_SYSTEM_USER_PASSWORD
-            - name: ccd-redis-password
-              alias: SPRING_REDIS_PASSWORD
-


### PR DESCRIPTION
  CCD-3728: revert Redis infrastructure deploy master in perftest
          [CCD-3728] (https://tools.hmcts.net/jira/browse/CCD-3728).
