### PR TITLE
test-stubs-service added twice in aat kustomization.yaml and demo.yam…

### DIFF
--- a/apps/ccd/aat/base/kustomization.yaml
+++ b/apps/ccd/aat/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - probatemandb.yaml
   - ../../message-publisher/message-publisher.yaml
   - ../../ccd-case-disposer/ccd-case-disposer.yaml
+  - ../../ccd-test-stubs-service/ccd-test-stubs-service.yaml
 patchesStrategicMerge:
   - ../../identity/aat.yaml
   - ../../ccd-logstash-indexer/aat.yaml
@@ -17,3 +18,4 @@ patchesStrategicMerge:
   - ../../ccd-data-store-api/aat.yaml
   - ../../ccd-case-document-am-api/aat.yaml
   - ../../ccd-api-gateway-web/aat.yaml
+  - ../../ccd-test-stubs-service/aat.yaml

--- a/apps/ccd/ccd-test-stubs-service/aat.yaml
+++ b/apps/ccd/ccd-test-stubs-service/aat.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: ccd-test-stubs-service
+  namespace: ccd
+spec:
+  values:
+    java:
+      ingressClass: traefik-private
+      disableIngressClassAnnotation: true

--- a/apps/ccd/ccd-test-stubs-service/aat.yaml
+++ b/apps/ccd/ccd-test-stubs-service/aat.yaml
@@ -6,5 +6,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
-      disableIngressClassAnnotation: true


### PR DESCRIPTION
Changes to make ccd-test-stubs-service deployed in AAT as part of the Master build.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
