### PR TITLE
Renovate for flux helm releases

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,7 +11,7 @@ tests/ @hmcts/platform-operations
 .github/  @hmcts/platform-operations
 docs/ @hmcts/platform-operations
 bin/ @hmcts/platform-operations
-
+renovate.json @hmcts/platform-operations
 
 ## application rules
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,28 +3,7 @@
   "kubernetes": {
     "fileMatch": ["\\.yaml$"]
   },
-  "regexManagers": [
-    {
-      "fileMatch": ["\\.yaml$"],
-      "matchStrings": [
-        "chart:\n *repository: .*?\n *name: (?<depName>.*?)\n *version: (?<currentValue>.*)\n"
-      ],
-      "datasourceTemplate": "helm"
-    }
-  ],
-  "packageRules": [
-    {
-      "datasources": ["helm"],
-      "managers": ["regex"],
-      "excludePackageNames": ["dynatrace-oneagent-operator"],
-      "registryUrls": ["https://hmctspublic.azurecr.io/helm/v1/repo/"]
-    },
-    {
-      "datasources": ["helm"],
-      "managers": ["regex"],
-      "matchPackageNames": ["dynatrace-operator"],
-      "separateMinorPatch": true,
-      "registryUrls": ["https://raw.githubusercontent.com/Dynatrace/helm-charts/master/repos/stable/"]
-    }
-  ]
+  "flux": {
+    "fileMatch": ["\\.yaml$"]
+  }
 }


### PR DESCRIPTION
Realised there is a new manager which simplifies this. 

 https://docs.renovatebot.com/modules/manager/flux/ 

Tried in https://github.com/adusumillipraveen/demo-flux-config/pulls 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
