### PR TITLE
Upgrade neuvector chart

### DIFF
--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -31,7 +31,3 @@ spec:
     spec:
       chart: neuvector-azure-keyvault
       version: 1.2.10-alpha
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -27,3 +27,11 @@ spec:
           - neuvector-license-dev
           - neuvector-slack-webhook
           - neuvector-new-admin-password
+  chart:
+    spec:
+      chart: neuvector-azure-keyvault
+      version: 1.2.10-alpha
+      sourceRef:
+        kind: HelmRepository
+        name: hmctspublic
+        namespace: flux-system


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-10284


### Change description ###

bump neuvector chart version to v1.2.10-alpha where dependent charts come from neuvector releases upstream
bump neuvector image version to 5.1.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
