### PR TITLE
Add standard label for node-local-dns podmonitor

### DIFF
--- a/apps/kube-system/nodelocaldns/nodelocaldns.yaml
+++ b/apps/kube-system/nodelocaldns/nodelocaldns.yaml
@@ -118,6 +118,7 @@ spec:
     metadata:
       labels:
         k8s-app: node-local-dns
+        app.kubernetes.io/name: node-local-dns
       annotations:
         prometheus.io/port: "9253"
         prometheus.io/scrape: "true"

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -44,22 +44,11 @@ spec:
                 values:
                   - system
     prometheus:
-      additionalServiceMonitors:
-        - name: "flux-monitor"
-          selector:
-            matchLabels:
-              app: flux
-          namespaceSelector:
-            matchNames:
-              - admin
-          endpoints:
-            - targetPort: 3030
-          path: /metrics
       additionalPodMonitors:
         - name: "nodelocaldns"
           selector:
             matchLabels:
-              k8s-app: node-local-dns
+              app.kubernetes.io/name: node-local-dns
           namespaceSelector:
             matchNames:
               - kube-system


### PR DESCRIPTION
Removed unused flux monitor

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
