### PR TITLE
Revert "Update Helm release azure-service-operator to v2.0.0-beta.4"

### DIFF
--- a/apps/azureserviceoperator-system/aso/aso.yaml
+++ b/apps/azureserviceoperator-system/aso/aso.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: azure-service-operator
-      version: v2.0.0-beta.4
+      version: v2.0.0-beta.3
       sourceRef:
         kind: HelmRepository
         name: azure-service-operator


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#20235
To test - because of issues in https://tools.hmcts.net/jira/browse/DTSPO-12123