### PR TITLE
Double civil quota

### DIFF
--- a/apps/civil/preview/base/resource-limits.yaml
+++ b/apps/civil/preview/base/resource-limits.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: civil
 spec:
   hard:
-    requests.cpu: "100"
-    requests.memory: 280Gi
+    requests.cpu: "200"
+    requests.memory: 560Gi


### PR DESCRIPTION
They were using almost 20% of the cluster capacity when this was set, but now that we are running larger V5 VMs and they keep hitting the quota frequently with ccd/ xui per pods taking lot of cpu, it makes sense to temporarily increase to see if they are causing any bottleneck to others.

Cluster full capacity is :

```
Maximum cores
1440 vCPUs
Maximum memory
5760 GiB
```

It is still high for a namespace to take 1/7th of the cluster, but its fine given its not utilised fully with latest VMs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
