### PR TITLE
Remove flag from demo

### DIFF
--- a/apps/aac/aac-ac-int-manage-case-assignment/demo.yaml
+++ b/apps/aac/aac-ac-int-manage-case-assignment/demo.yaml
@@ -6,6 +6,5 @@ spec:
   releaseName: aac-ac-int-manage-case-assignment
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/aac/manage-case-assignment:prod-21cc540-20230207160654 #{"$imagepolicy": "flux-system:manage-case-assignment"}

--- a/apps/aac/manage-case-assignment/demo.yaml
+++ b/apps/aac/manage-case-assignment/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/aac/manage-case-assignment:prod-21cc540-20230207160654 #{"$imagepolicy": "flux-system:manage-case-assignment"}
       keyVaults:
         aac:

--- a/apps/adoption/adoption-cos-api/demo.yaml
+++ b/apps/adoption/adoption-cos-api/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/adoption/cos-api:pr-677-831ffd1-20230209115325 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
         APP_INSIGHTS_KEY: '6c5278dd-ee76-4e7b-92f9-57b27ead382e'

--- a/apps/adoption/adoption-web/demo.yaml
+++ b/apps/adoption/adoption-web/demo.yaml
@@ -7,7 +7,6 @@ spec:
   interval: 1m
   values:
     nodejs:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-no-proxy
       disableTraefikTls: false
       readinessPeriod: 15

--- a/apps/am/am-judicial-booking-service/demo.yaml
+++ b/apps/am/am-judicial-booking-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       environment:
         AM_INFO: true

--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       environment:
         AM_INFO: true

--- a/apps/am/am-role-assignment-service/demo.yaml
+++ b/apps/am/am-role-assignment-service/demo.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       replicas: 5
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG

--- a/apps/bar/bar-api-int/demo.yaml
+++ b/apps/bar/bar-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: bar-api-int
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/bar/api:prod-191b5a4-20230202215434 #{"$imagepolicy": "flux-system:bar-api"}
       environment:

--- a/apps/bar/bar-api/demo.yaml
+++ b/apps/bar/bar-api/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/bar/api:prod-191b5a4-20230202215434 #{"$imagepolicy": "flux-system:bar-api"}
       environment:
         DUMMY_RESTART_VAR: false

--- a/apps/bsp/bulk-scan-orchestrator/demo.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         TRANSFORMATION_URL_SSCS: "http://sscs-bulk-scan-demo.service.core-compute-demo.internal/transform-scanned-data"
         AUTO_CASE_CREATION_ENABLED_SSCS: "false"

--- a/apps/bsp/bulk-scan-payment-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/demo.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       image: hmctspublic.azurecr.io/bulk-scan/payment-processor:pr-880-87124b8-20230209170140 #{"$imagepolicy": "flux-system:demo-bulk-scan-payment-processor"}
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       replicas: 2
       environment:
         REFRESH_PODS: "true"

--- a/apps/bsp/bulk-scan-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-processor/demo.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       image: hmctspublic.azurecr.io/bulk-scan/processor:pr-2859-bc0ef5d-20230207172201 #{"$imagepolicy": "flux-system:demo-bulk-scan-processor"}
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         #60 days in seconds
         SAS_TOKEN_VALIDITY: "5184000"

--- a/apps/bsp/bulk-scan-sample-app/demo.yaml
+++ b/apps/bsp/bulk-scan-sample-app/demo.yaml
@@ -6,5 +6,4 @@ spec:
   releaseName: bulk-scan-sample-app
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         LOGGING_LEVEL_COM_ZAXXER_HIKARI_HIKARICONFIG: DEBUG

--- a/apps/camunda/camunda-optimize/demo.yaml
+++ b/apps/camunda/camunda-optimize/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     ingressClass: traefik-private
-    disableIngressClassAnnotation: true
     environment:
       OPTIMIZE_ELASTICSEARCH_HOST: 10.96.216.253

--- a/apps/camunda/camunda-ui/demo.yaml
+++ b/apps/camunda/camunda-ui/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       disableTraefikTls: false

--- a/apps/ccd/ccd-ac-int-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-ac-int-data-store-api/demo.yaml
@@ -6,6 +6,5 @@ spec:
   releaseName: ccd-ac-int-data-store-api
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-f773a2c-20230206102245 #{"$imagepolicy": "flux-system:demo-ccd-ac-int-data-store-api"}

--- a/apps/ccd/ccd-ac-int-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-ac-int-definition-store-api/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-56ffa5d-20230206141156 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}

--- a/apps/ccd/ccd-case-activity-api/demo.yaml
+++ b/apps/ccd/ccd-case-activity-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-case-activity-api
   values:
     nodejs:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       java:
       image: hmctspublic.azurecr.io/ccd/case-activity-api:prod-2a50409-20230126163420 #{"$imagepolicy": "flux-system:demo-ccd-case-activity-api"}

--- a/apps/ccd/ccd-case-document-am-api/demo.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/case-document-am-api:prod-6836852-20230201130920 #{"$imagepolicy": "flux-system:ccd-case-document-am-api"}
       environment:

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-f773a2c-20230206102245 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
       replicas: 4

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-definition-store-api
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-56ffa5d-20230206141156 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
       environment:

--- a/apps/ccd/ccd-test-stubs-service/demo.yaml
+++ b/apps/ccd/ccd-test-stubs-service/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/ccd/ccd-user-profile-api/demo.yaml
+++ b/apps/ccd/ccd-user-profile-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-user-profile-api
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       environment:
         USER_PROFILE_DB_HOST: ccd-user-profile-api-postgres-db-v11-demo.postgres.database.azure.com

--- a/apps/ccd/message-publisher/demo.yaml
+++ b/apps/ccd/message-publisher/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         DATA_STORE_DB_HOST: ccd-data-store-api-postgres-db-v11-demo.postgres.database.azure.com
         DATA_STORE_DB_USERNAME: ccd@ccd-data-store-api-postgres-db-v11-demo

--- a/apps/civil/civil-general-applications/demo.yaml
+++ b/apps/civil/civil-general-applications/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/civil/general-applications:prod-66dfe27-20230210100959 #{"$imagepolicy": "flux-system:civil-general-applications"}
       keyVaults:
         civil:

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/civil/service:pr-2181-9c6af5e-20230213091346 #{"$imagepolicy": "flux-system:demo-civil-service"}
       keyVaults:
         civil:

--- a/apps/cnp/plum-frontend/plum-frontend-demo-publicaccess.yaml
+++ b/apps/cnp/plum-frontend/plum-frontend-demo-publicaccess.yaml
@@ -15,7 +15,6 @@ spec:
   values:
     nodejs:
       ingressHost: plum-public.demo.platform.hmcts.net
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/plum/frontend:prod-c262de8-20230210125204 # {"$imagepolicy": "flux-system:plum-frontend"}
       startupPeriod: 120

--- a/apps/cpo/case-payment-orders-api-int/demo.yaml
+++ b/apps/cpo/case-payment-orders-api-int/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/cpo/case-payment-orders-api:prod-215cd75-20230207160904 #{"$imagepolicy": "flux-system:case-payment-orders-api"}
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/cpo/case-payment-orders-api/demo.yaml
+++ b/apps/cpo/case-payment-orders-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       environment:
         CPO_S2S_AUTHORISED_SERVICES: xui_webapp,payment_app,service_request_cpo_update_service,ccpay_cpo_function_node

--- a/apps/dg/dg-docassembly/demo.yaml
+++ b/apps/dg/dg-docassembly/demo.yaml
@@ -8,6 +8,5 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         VAR_FV2: value1

--- a/apps/divorce/div-cfs/demo.yaml
+++ b/apps/divorce/div-cfs/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/div/cfs:prod-a805f5d-20230207162619 #{"$imagepolicy": "flux-system:demo-div-cfs"}

--- a/apps/divorce/div-cms/demo.yaml
+++ b/apps/divorce/div-cms/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/div/cms:prod-873e7ee-20230206152221 #{"$imagepolicy": "flux-system:demo-div-cms"}
       environment:
         IDAM_API_BASEURL: "https://idam-api.demo.platform.hmcts.net"

--- a/apps/divorce/div-cos/demo.yaml
+++ b/apps/divorce/div-cos/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/div/cos:prod-6f88fed-20230206152455 #{"$imagepolicy": "flux-system:demo-div-cos"}
       environment:
         IDAM_API_URL: "https://idam-api.demo.platform.hmcts.net"

--- a/apps/divorce/div-dgs/demo.yaml
+++ b/apps/divorce/div-dgs/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/div/dgs:prod-9a27073-20230206143859 #{"$imagepolicy": "flux-system:demo-div-dgs"}
       environment:
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/apps/divorce/div-emca/demo.yaml
+++ b/apps/divorce/div-emca/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/emca:prod-4370fd1-20230206144806 #{"$imagepolicy": "flux-system:demo-div-emca"}
       environment:

--- a/apps/divorce/div-fps/demo.yaml
+++ b/apps/divorce/div-fps/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/fps:prod-0df9f9d-20230206113707 #{"$imagepolicy": "flux-system:demo-div-fps"}
       environment:

--- a/apps/dm-store/dm-store-cdam/demo.yaml
+++ b/apps/dm-store/dm-store-cdam/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/dm-store/dm-store/demo.yaml
+++ b/apps/dm-store/dm-store/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/dm/store:prod-ec37d24-20230213072849 #{"$imagepolicy": "flux-system:demo-dm-store"}
       environment:

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -7,5 +7,4 @@ spec:
     ingressClass: traefik-private
     ingressHost: docmosis.demo.platform.hmcts.net
     disableTraefikTls: false
-    disableIngressClassAnnotation: true
     image: hmctsprivate.azurecr.io/docmosis:demo-7b20ed4-336504 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/apps/em/em-anno/demo.yaml
+++ b/apps/em/em-anno/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/anno:prod-a77d665-20230210081409 #{"$imagepolicy": "flux-system:em-anno"}
       environment:

--- a/apps/em/em-ccd-orchestrator/demo.yaml
+++ b/apps/em/em-ccd-orchestrator/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressHost: em-ccdorc-demo.service.core-compute-demo.internal
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/ccdorc:pr-1091-3f1ac3a-20230210082046 #{"$imagepolicy": "flux-system:demo-em-ccd-orchestrator"}
       environment:

--- a/apps/em/em-hrs-api/demo.yaml
+++ b/apps/em/em-hrs-api/demo.yaml
@@ -6,5 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
-      environment:

--- a/apps/em/em-npa/demo.yaml
+++ b/apps/em/em-npa/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/em/npa:prod-c5193ca-20230206231628 #{"$imagepolicy": "flux-system:demo-em-npa"}
       environment:
         TEST_VAR: value1

--- a/apps/em/em-showcase/demo.yaml
+++ b/apps/em/em-showcase/demo.yaml
@@ -6,6 +6,5 @@ spec:
   values:
     nodejs:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       replicas: 0
 

--- a/apps/em/em-stitching/demo.yaml
+++ b/apps/em/em-stitching/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/stitching:prod-5a32744-20230210121439 #{"$imagepolicy": "flux-system:demo-em-stitching"}
       environment:

--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: et-cos
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/et/cos:pr-576-bd75fcc-20230209160614 #{"$imagepolicy": "flux-system:demo-et-cos"}
       environment:

--- a/apps/et/et-msg-handler/demo.yaml
+++ b/apps/et/et-msg-handler/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/et/msg-handler:prod-54e1026-20230104111551 #{"$imagepolicy": "flux-system:et-msg-handler"}

--- a/apps/et/et-sya-api/demo.yaml
+++ b/apps/et/et-sya-api/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/et/sya-api:pr-193-41895e4-20230210103846 #{"$imagepolicy": "flux-system:demo-et-sya-api"}
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       environment:
         SUBMIT_CASE_EMAIL_TEMPLATE_ID: 10c31d51-c518-4d73-b2c3-1c02771ef41e

--- a/apps/ethos/ecm-consumer/demo.yaml
+++ b/apps/ethos/ecm-consumer/demo.yaml
@@ -7,6 +7,5 @@ spec:
   releaseName: ecm-consumer
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ethos/ecm-consumer:prod-b1f32fa-20221213173142 #{"$imagepolicy": "flux-system:ecm-consumer"}

--- a/apps/ethos/repl-docmosis-service/demo.yaml
+++ b/apps/ethos/repl-docmosis-service/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ethos/repl-docmosis-backend:pr-2014-970075c-20230208091852 #{"$imagepolicy": "flux-system:demo-repl-docmosis-service"}
       environment:
         SECURE_DOC_STORE_FEATURE: true

--- a/apps/fact/fact-api/demo.yaml
+++ b/apps/fact/fact-api/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/family-public-law/fpl-case-service/demo.yaml
+++ b/apps/family-public-law/fpl-case-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressHost: fpl-case-service-demo.service.core-compute-demo.internal
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/fpl/case-service:pr-4035-68ed7d5-20230202161914 #{"$imagepolicy": "flux-system:demo-fpl-case-service"}
       environment:

--- a/apps/fees-pay/ccpay-bulkscanning-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccpay-bulkscanning-api-int
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/bulkscanning-api:pr-434-6410710-20230203114903 #{"$imagepolicy": "flux-system:demo-int-ccpay-bulkscanning-api"}
       imagePullPolicy: Always

--- a/apps/fees-pay/ccpay-bulkscanning-api/demo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ccpay/bulkscanning-api:pr-442-bd9b720-20230207171319 #{"$imagepolicy": "flux-system:demo-ccpay-bulkscanning-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/ccpay-cpo-update-service-int/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service-int/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/cpo-update-service:prod-f3021e2-20230202225214 #{"$imagepolicy": "flux-system:demo-int-ccpay-cpo-update-service"}
       environment:

--- a/apps/fees-pay/ccpay-cpo-update-service/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/cpo-update-service:prod-f3021e2-20230202225214 #{"$imagepolicy": "flux-system:ccpay-cpo-update-service"}
       environment:

--- a/apps/fees-pay/ccpay-notifications-service-int/demo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service-int/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/notifications-service:pr-100-295197f-20230210131625 #{"$imagepolicy": "flux-system:demo-int-ccpay-notifications-service"}
       environment:

--- a/apps/fees-pay/ccpay-notifications-service/demo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/notifications-service:pr-100-295197f-20230210131625 #{"$imagepolicy": "flux-system:demo-ccpay-notifications-service"}
       environment:

--- a/apps/fees-pay/ccpay-payment-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccpay-payment-api-int
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/payment/api:pr-1248-d688885-20230208140818 #{"$imagepolicy": "flux-system:demo-int-ccpay-payment-app"}
       imagePullPolicy: Always

--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccpay-payment-api
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/payment/api:pr-1248-d688885-20230208140818 #{"$imagepolicy": "flux-system:demo-ccpay-payment-app"}
       imagePullPolicy: Always

--- a/apps/fees-pay/ccpay-paymentoutcome-web/demo.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-no-proxy
       disableTraefikTls: false
       replicas: 2

--- a/apps/fees-pay/ccpay-refunds-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ccpay/refunds-api:pr-158-0bad537-20230210183110 #{"$imagepolicy": "flux-system:demo-int-ccpay-refunds-api"}
       environment:
         DUMMY_VARIABLE: false

--- a/apps/fees-pay/ccpay-refunds-api/demo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/refunds-api:pr-158-0bad537-20230210183110 #{"$imagepolicy": "flux-system:demo-ccpay-refunds-api"}
       environment:

--- a/apps/fees-pay/fees-register-api-int/demo.yaml
+++ b/apps/fees-pay/fees-register-api-int/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/fees-register/api:prod-5237a76-20230202224624 #{"$imagepolicy": "flux-system:demo-int-fees-register-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/fees-register-api/demo.yaml
+++ b/apps/fees-pay/fees-register-api/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/fees-register/api:prod-5237a76-20230202224624 #{"$imagepolicy": "flux-system:fees-register-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/financial-remedy/finrem-cos/demo.yaml
+++ b/apps/financial-remedy/finrem-cos/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/finrem/cos:pr-859-b5a6269-20230206144642 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
       environment:

--- a/apps/financial-remedy/finrem-dgcs/demo.yaml
+++ b/apps/financial-remedy/finrem-dgcs/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/financial-remedy/finrem-emca/demo.yaml
+++ b/apps/financial-remedy/finrem-emca/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/financial-remedy/finrem-ns/demo.yaml
+++ b/apps/financial-remedy/finrem-ns/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private
       image: hmctspublic.azurecr.io/finrem/ns:prod-f236d3c-20230206104815 #{"$imagepolicy": "flux-system:finrem-ns"}
       environment:

--- a/apps/fis/fis-bulk-scan-api/demo.yaml
+++ b/apps/fis/fis-bulk-scan-api/demo.yaml
@@ -6,5 +6,4 @@ spec:
   releaseName: fis-bulk-scan-api
   values:
     java:
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/fis/fis-hmc-api/demo.yaml
+++ b/apps/fis/fis-hmc-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/fis/hmc-api:prod-2a50409-20230126163420 #{"$imagepolicy": "flux-system:demo-fis-hmc-api"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1

--- a/apps/hmc/hmc-cft-hearing-service-int/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service-int/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-644b491-20230209190520 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/hmc/hmc-cft-hearing-service/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-644b491-20230209190520 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_REPOSITORY: DEBUG

--- a/apps/hmc/hmc-hmi-inbound-adapter-int/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter-int/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:prod-b7a4f00-20230209190631 #{"$imagepolicy": "flux-system:demo-hmc-hmi-inbound-adapter"}
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/hmc/hmc-hmi-outbound-adapter-int/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter-int/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-aba8f87-20230209190741 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -6,6 +6,5 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_REPOSITORY: DEBUG

--- a/apps/ia/ia-aip-frontend/demo.yaml
+++ b/apps/ia/ia-aip-frontend/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     nodejs:
       disableTraefikTls: false
-      disableIngressClassAnnotation: true
       ingressClass: traefik-no-proxy
       ingressHost: immigration-appeal.demo.platform.hmcts.net
       image: hmctspublic.azurecr.io/ia/aip-frontend:pr-891-7452137-20230209183153 #{"$imagepolicy": "flux-system:demo-ia-aip-frontend"}

--- a/apps/ia/ia-aip-frontend/perftest.yaml
+++ b/apps/ia/ia-aip-frontend/perftest.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     nodejs:
       disableTraefikTls: false
-      disableIngressClassAnnotation: true
       ingressClass: traefik-no-proxy
       ingressHost: immigration-appeal.perftest.platform.hmcts.net
       environment:

--- a/apps/ia/ia-bail-case-api/demo.yaml
+++ b/apps/ia/ia-bail-case-api/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/bail-case-api:prod-9298ef1-20230208153731 #{"$imagepolicy": "flux-system:demo-ia-bail-case-api"}

--- a/apps/ia/ia-case-access-api/demo.yaml
+++ b/apps/ia/ia-case-access-api/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/case-api:pr-1238-c8fb97b-20230209112212 #{"$imagepolicy": "flux-system:demo-ia-case-api"}
       environment:
         IA_HOME_OFFICE_INTEGRATION_ENABLED: "true"

--- a/apps/ia/ia-case-documents-api/demo.yaml
+++ b/apps/ia/ia-case-documents-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/case-documents-api:prod-2e60867-20230208154348 #{"$imagepolicy": "flux-system:ia-case-documents-api"}
       environment:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net

--- a/apps/ia/ia-case-notifications-api/demo.yaml
+++ b/apps/ia/ia-case-notifications-api/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/case-notifications-api:pr-740-372385f-20230203141954 #{"$imagepolicy": "flux-system:demo-ia-case-notifications-api"}

--- a/apps/ia/ia-case-payments-api/demo.yaml
+++ b/apps/ia/ia-case-payments-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/case-payments-api:prod-29ab94a-20230208155735 #{"$imagepolicy": "flux-system:ia-case-payments-api"}
       ingressHost: ia-case-payments-api-demo.service.core-compute-demo.internal
       environment:

--- a/apps/ia/ia-home-office-integration-api/demo.yaml
+++ b/apps/ia/ia-home-office-integration-api/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/home-office-integration-api:prod-d17f8f6-20230208164411 #{"$imagepolicy": "flux-system:ia-home-office-integration-api"}

--- a/apps/ia/ia-home-office-mock-api/demo.yaml
+++ b/apps/ia/ia-home-office-mock-api/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/ia/ia-timed-event-service/demo.yaml
+++ b/apps/ia/ia-timed-event-service/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/ia/timed-event-service:pr-90 #{"$imagepolicy": "flux-system:demo-ia-timed-event-service"}

--- a/apps/lau/lau-case-backend-int/demo.yaml
+++ b/apps/lau/lau-case-backend-int/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/lau/lau-case-backend/demo.yaml
+++ b/apps/lau/lau-case-backend/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/lau/lau-idam-backend-int/demo.yaml
+++ b/apps/lau/lau-idam-backend-int/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/lau/lau-idam-backend/demo.yaml
+++ b/apps/lau/lau-idam-backend/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/money-claims/cmc-claim-store/demo.yaml
+++ b/apps/money-claims/cmc-claim-store/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/cmc/claim-store:pr-2689-18a70b6-20230208144657 #{"$imagepolicy": "flux-system:demo-cmc-claim-store"}
       keyVaults:
         cmc:

--- a/apps/nfdiv/nfdiv-case-api/demo.yaml
+++ b/apps/nfdiv/nfdiv-case-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/nfdiv/case-api:prod-b934450-20230213082405 #{"$imagepolicy": "flux-system:demo-nfdiv-case-api"}
       environment:
         CASE_HOLDING_WEEKS: 20

--- a/apps/pcq/pcq-backend-int/demo.yaml
+++ b/apps/pcq/pcq-backend-int/demo.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       ingressHost: pcq-backend-int-demo.service.core-compute-demo.internal
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
         DB_ALLOW_DELETE_RECORD: "false"

--- a/apps/pcq/pcq-backend/demo.yaml
+++ b/apps/pcq/pcq-backend/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/private-law/prl-citizen-frontend/demo.yaml
+++ b/apps/private-law/prl-citizen-frontend/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     nodejs:
       ingressClass: traefik-no-proxy
-      disableIngressClassAnnotation: true
       disableTraefikTls: false
       image: hmctspublic.azurecr.io/prl/citizen-frontend:pr-796-6f97f0d-20230203184700 #{"$imagepolicy": "flux-system:demo-prl-citizen-frontend"}
       cpuLimits: "1000m"

--- a/apps/private-law/prl-cos/demo.yaml
+++ b/apps/private-law/prl-cos/demo.yaml
@@ -9,7 +9,6 @@ spec:
     java:
       replicas: 2
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       memoryRequests: "768Mi"
       cpuRequests: "1000m"
       memoryLimits: "3072Mi"

--- a/apps/private-law/prl-dgs/demo.yaml
+++ b/apps/private-law/prl-dgs/demo.yaml
@@ -11,7 +11,6 @@ spec:
       readinessDelay: 45
       readinessTimeout: 10
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       readinessPeriod: 10
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/prl/dgs:prod-4697901-20230206121925 #{"$imagepolicy": "flux-system:prl-dgs"}

--- a/apps/probate/probate-back-office/demo.yaml
+++ b/apps/probate/probate-back-office/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/probate/back-office:pr-2185-32bf7ea-20230209151649 #{"$imagepolicy": "flux-system:demo-probate-back-office"}
       environment:
         CCD_GATEWAY_HOST: https://manage-case.demo.platform.hmcts.net

--- a/apps/probate/probate-business-service/demo.yaml
+++ b/apps/probate/probate-business-service/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/probate/probate-orchestrator-service/demo.yaml
+++ b/apps/probate/probate-orchestrator-service/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/probate/orchestrator-service:prod-47501f2-20230209152313 #{"$imagepolicy": "flux-system:probate-orchestrator-service"}
       ingressHost: probate-orchestrator-service-demo.service.core-compute-demo.internal
       environment:

--- a/apps/probate/probate-submit-service/demo.yaml
+++ b/apps/probate/probate-submit-service/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/rd/rd-caseworker-ref-api-integration/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api-integration/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       ingressHost: rd-caseworker-ref-api-int-demo.service.core-compute-demo.internal
       environment:
         DELETE_CWR: true

--- a/apps/rd/rd-caseworker-ref-api/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         DELETE_CWR: true
         CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api

--- a/apps/rd/rd-commondata-api/demo.yaml
+++ b/apps/rd/rd-commondata-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         DELETE_ORG: true
         CRD_S2S_AUTHORISED_SERVICES: rd_commondata_api,xui_webapp,fis_hmc_api,ccd_data,sscs,sscs_bulkscan,iac,civil_service

--- a/apps/rd/rd-judicial-api-integration/demo.yaml
+++ b/apps/rd/rd-judicial-api-integration/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       ingressHost: rd-judicial-api-int-demo.service.core-compute-demo.internal
       environment:
         DELETE_ORG: false

--- a/apps/rd/rd-judicial-api/demo.yaml
+++ b/apps/rd/rd-judicial-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/rd/judicial-api:prod-5f8cf13-20230209105751 #{"$imagepolicy": "flux-system:rd-judicial-api"}
       environment:
         DELETE_ORG: true

--- a/apps/rd/rd-location-ref-api-integration/demo.yaml
+++ b/apps/rd/rd-location-ref-api-integration/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       ingressHost: rd-location-ref-api-int-demo.service.core-compute-demo.internal
       environment:
         LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api

--- a/apps/rd/rd-location-ref-api/demo.yaml
+++ b/apps/rd/rd-location-ref-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api,ccd_data,xui_webapp,prl_cos_api,sscs,sscs_bulkscan,adoption_web,rd_judicial_api,civil_service,civil_general_applications,sptribs_case_api,fis_hmc_api
         DELETE_ORG: true

--- a/apps/rd/rd-professional-api-integration/demo.yaml
+++ b/apps/rd/rd-professional-api-integration/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       ingressHost: rd-professional-api-int-demo.service.core-compute-demo.internal
       environment:
         USER_PROFILE_URL: http://rd-user-profile-api-int-demo.service.core-compute-demo.internal

--- a/apps/rd/rd-professional-api/demo.yaml
+++ b/apps/rd/rd-professional-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         DELETE_ORG: true
         ACTIVE_ORG_EXT: true

--- a/apps/rd/rd-profile-sync-integration/demo.yaml
+++ b/apps/rd/rd-profile-sync-integration/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       ingressHost: rd-profile-sync-int-demo.service.core-compute-demo.internal
       environment:
         USER_PROFILE_URL: http://rd-user-profile-api-int-demo.service.core-compute-demo.internal

--- a/apps/rd/rd-profile-sync/demo.yaml
+++ b/apps/rd/rd-profile-sync/demo.yaml
@@ -6,6 +6,5 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         DELETE_ORG: true

--- a/apps/rd/rd-user-profile-api-integration/demo.yaml
+++ b/apps/rd/rd-user-profile-api-integration/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       ingressHost: rd-user-profile-api-int-demo.service.core-compute-demo.internal
       environment:
         DELETE_ORG: true

--- a/apps/rd/rd-user-profile-api/demo.yaml
+++ b/apps/rd/rd-user-profile-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         DELETE_ORG: true
         PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api

--- a/apps/reform-scan/reform-scan-blob-router/demo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       memoryLimits: "1024Mi"
       environment:
         TASK_SCAN_DELAY: 300000

--- a/apps/reform-scan/reform-scan-notification-service/demo.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         PENDING_NOTIFICATIONS_SEND_DELAY_IN_MINUTE: 0
         REFRESH_PODS: "true"

--- a/apps/rpe/draft-store-service/demo.yaml
+++ b/apps/rpe/draft-store-service/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/rpe/pdf-service/demo.yaml
+++ b/apps/rpe/pdf-service/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/rpe/rpe-send-letter-service/demo.yaml
+++ b/apps/rpe/rpe-send-letter-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         ENCRYPTION_ENABLED: false
         CIVIL_SERVICE_ENABLED: true

--- a/apps/rpe/rpe-service-auth-provider/demo.yaml
+++ b/apps/rpe/rpe-service-auth-provider/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/rpts/rpts-api/demo.yaml
+++ b/apps/rpts/rpts-api/demo.yaml
@@ -6,6 +6,5 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         ORDINANCE_SURVEY_KEY: todo

--- a/apps/sscs/sscs-ccd-callback-orchestrator/demo.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/demo.yaml
@@ -9,7 +9,6 @@ spec:
     java:
       replicas: 2
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/ccd-callback-orchestrator:prod-b776a49-20230206160154 #{"$imagepolicy": "flux-system:sscs-ccd-callback-orchestrator"}
       environment:

--- a/apps/sscs/sscs-evidence-share/demo.yaml
+++ b/apps/sscs/sscs-evidence-share/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/sscs/evidence-share:pr-1465-d4b83b6-20230207100146 #{"$imagepolicy": "flux-system:demo-sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: venkata.akepati@hmcts.net

--- a/apps/sscs/sscs-hearings-api/demo.yaml
+++ b/apps/sscs/sscs-hearings-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       image: hmctspublic.azurecr.io/sscs/hearings-api:prod-6101e6b-20230210141648 #{"$imagepolicy": "flux-system:sscs-hearings-api"}
       environment:
         TRIBUNALS_HEARINGS_LISTENING_ENABLED: true

--- a/apps/sscs/sscs-tribunals-api/demo.yaml
+++ b/apps/sscs/sscs-tribunals-api/demo.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       aadIdentityName: sscs
       image: hmctspublic.azurecr.io/sscs/tribunals-api:pr-3133-2911733-20230210102354 #{"$imagepolicy": "flux-system:demo-sscs-tribunals-api"}
       environment:

--- a/apps/sscs/sscs-tya-notif/demo.yaml
+++ b/apps/sscs/sscs-tya-notif/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       replicas: 2
       enableOAuth: true
       useInterpodAntiAffinity: true

--- a/apps/ts/ts-translation-service-int/demo.yaml
+++ b/apps/ts/ts-translation-service-int/demo.yaml
@@ -6,5 +6,4 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/ts/translation-service:prod-fb6c05a-20230201160609 #{"$imagepolicy": "flux-system:ts-translation-service"}
-      disableIngressClassAnnotation: true
       ingressClass: traefik-private

--- a/apps/ts/ts-translation-service/demo.yaml
+++ b/apps/ts/ts-translation-service/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true

--- a/apps/wa/wa-case-event-handler/demo.yaml
+++ b/apps/wa/wa-case-event-handler/demo.yaml
@@ -7,7 +7,6 @@ spec:
     java:
       image: hmctspublic.azurecr.io/wa/case-event-handler:prod-8a20585-20230206100631 #{"$imagepolicy": "flux-system:wa-case-event-handler"}
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         AZURE_SERVICE_BUS_FEATURE_TOGGLE: true
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG

--- a/apps/wa/wa-task-management-api/demo.yaml
+++ b/apps/wa/wa-task-management-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG
         LOGGING_LEVEL_ORG_HIBERNATE_SQL: DEBUG

--- a/apps/wa/wa-task-monitor/demo.yaml
+++ b/apps/wa/wa-task-monitor/demo.yaml
@@ -6,6 +6,5 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG

--- a/apps/wa/wa-workflow-api/demo.yaml
+++ b/apps/wa/wa-workflow-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressClass: traefik-private
-      disableIngressClassAnnotation: true
       environment:
         REFRESH_FLAG: ""
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG

--- a/apps/xui/xui-ao-webapp/demo.yaml
+++ b/apps/xui/xui-ao-webapp/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     nodejs:
       disableTraefikTls: false
-      disableIngressClassAnnotation: true
       ingressClass: traefik-no-proxy
       ingressHost: administer-orgs.demo.platform.hmcts.net
       environment:

--- a/apps/xui/xui-mo-webapp/demo.yaml
+++ b/apps/xui/xui-mo-webapp/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     nodejs:
       disableTraefikTls: false
-      disableIngressClassAnnotation: true
       ingressClass: traefik-no-proxy
       ingressHost: manage-org.demo.platform.hmcts.net
       startupPeriod: 20


### PR DESCRIPTION
[DTSPO-11573](https://tools.hmcts.net/jira/browse/DTSPO-11573)
This change:

- Removes a deprecated chart-library flag from cnp-flux demo configuration



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
