### PR TITLE
NFDIV-3214 - Disable in prod as we have the details needed from this cron

### DIFF
--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod/00.yaml
@@ -22,7 +22,6 @@ spec:
         NOTIFY_TEMPLATE_SIGN_IN_DIVORCE_URL: https://nfdiv-apply-for-divorce.prod.platform.hmcts.net/
         PRD_API_BASEURL: http://rd-professional-api-prod.service.core-compute-prod.internal
         SEND_LETTER_SERVICE_BASEURL: http://rpe-send-letter-service-prod.service.core-compute-prod.internal
-        MIGRATE_CREATE_DOUBLE_LINKED_LIST: true
     global:
       jobKind: CronJob
       enableKeyVaults: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/NFDIV-3214


### Change description ###
This cron was enabled in production to gather information on cases effected by a prod issue. We have that information and we don't need this running anymore.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
