### PR TITLE
ASO Preview: fix for invalid name causing issues with sb

### DIFF
--- a/apps/bsp/azure-service-operator/aso-sb.yaml
+++ b/apps/bsp/azure-service-operator/aso-sb.yaml
@@ -21,7 +21,7 @@ spec:
   location: uksouth
   owner:
     name: bulk-scan-aks-rg
-  azureName: ${NAMESPACE}-${CLUSTER_FULL_NAME}-sb
+  azureName: ${NAMESPACE}-${CLUSTER_FULL_NAME}
   sku:
     name: Basic
   zoneRedundant: false

--- a/apps/bsp/azure-service-operator/aso-sb.yaml
+++ b/apps/bsp/azure-service-operator/aso-sb.yaml
@@ -21,7 +21,7 @@ spec:
   location: uksouth
   owner:
     name: bulk-scan-aks-rg
-  azureName: ${NAMESPACE}-${CLUSTER_FULL_NAME}
+  azureName: ${NAMESPACE}-sb-${CLUSTER_FULL_NAME}
   sku:
     name: Basic
   zoneRedundant: false

--- a/apps/chart-tests/azure-service-operator/aso-sb.yaml
+++ b/apps/chart-tests/azure-service-operator/aso-sb.yaml
@@ -21,7 +21,7 @@ spec:
   location: uksouth
   owner:
     name: aso-aks-rg
-  azureName: ${NAMESPACE}-${CLUSTER_FULL_NAME}
+  azureName: ${NAMESPACE}-sb-${CLUSTER_FULL_NAME}
   sku:
     name: Basic
   zoneRedundant: false

--- a/apps/chart-tests/azure-service-operator/aso-sb.yaml
+++ b/apps/chart-tests/azure-service-operator/aso-sb.yaml
@@ -21,7 +21,7 @@ spec:
   location: uksouth
   owner:
     name: aso-aks-rg
-  azureName: ${NAMESPACE}-${CLUSTER_FULL_NAME}-sb
+  azureName: ${NAMESPACE}-${CLUSTER_FULL_NAME}
   sku:
     name: Basic
   zoneRedundant: false


### PR DESCRIPTION
Are extra rules around naming https://learn.microsoft.com/en-us/rest/api/servicebus/create-namespace
I was hit by The name does not end with “-“, “-sb“ or “-mgmt“. here
Have verified this quickly in portal
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
