### PR TITLE
detach on delete to prevent sb/rg being cleared, renaming

### DIFF
--- a/apps/bsp/azure-service-operator/aso.yaml
+++ b/apps/bsp/azure-service-operator/aso.yaml
@@ -3,6 +3,8 @@ kind: ResourceGroup
 metadata:
   name: bulk-scan-aks-rg
   namespace: bsp
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   location: uksouth
 ---
@@ -11,6 +13,8 @@ kind: Namespace
 metadata:
   name: bsp-servicebus
   namespace: bsp
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   tags:
     app.kubernetes.io_name: bulk-scan-print
@@ -21,7 +25,7 @@ spec:
   location: uksouth
   owner:
     name: bulk-scan-aks-rg
-  azureName: ${NAMESPACE}-sb-${CLUSTER_FULL_NAME}
+  azureName: ${NAMESPACE}-sb-${ENVIRONMENT}
   sku:
     name: Basic
   zoneRedundant: false

--- a/apps/bsp/azure-service-operator/aso.yaml
+++ b/apps/bsp/azure-service-operator/aso.yaml
@@ -1,12 +1,22 @@
+# TODO: update resource group name in bulk scan processor and clean up
 apiVersion: resources.azure.com/v1beta20200601
 kind: ResourceGroup
 metadata:
   name: bulk-scan-aks-rg
   namespace: bsp
+spec:
+  location: uksouth
+---
+apiVersion: resources.azure.com/v1beta20200601
+kind: ResourceGroup
+metadata:
+  name: bulk-scan-aso-rg
+  namespace: bsp
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   location: uksouth
+  azureName: bulk-scan-aso-${ENVIRONMENT}-rg
 ---
 apiVersion: servicebus.azure.com/v1beta20210101preview
 kind: Namespace
@@ -24,7 +34,7 @@ spec:
     environment: development
   location: uksouth
   owner:
-    name: bulk-scan-aks-rg
+    name: bulk-scan-aso-rg
   azureName: ${NAMESPACE}-sb-${ENVIRONMENT}
   sku:
     name: Basic

--- a/apps/bsp/preview/base/kustomization.yaml
+++ b/apps/bsp/preview/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base   # This is apps/base instead of apps/bsp/base as preview doesn't install everything
   - ../../identity/identity.yaml
-  - ../../azure-service-operator/aso-sb.yaml
+  - ../../azure-service-operator/aso.yaml
 namespace: bsp
 patchesStrategicMerge:
   - ../../identity/aat.yaml

--- a/apps/chart-tests/azure-service-operator/aso.yaml
+++ b/apps/chart-tests/azure-service-operator/aso.yaml
@@ -1,12 +1,22 @@
+# TODO: update resource group name in storage chart and clean up
 apiVersion: resources.azure.com/v1beta20200601
 kind: ResourceGroup
 metadata:
-  name: chart-tests-aks-rg
+  name: aso-aks-rg
+  namespace: chart-tests   
+spec:
+  location: uksouth
+---
+apiVersion: resources.azure.com/v1beta20200601
+kind: ResourceGroup
+metadata:
+  name: chart-tests-aso-rg
   namespace: chart-tests
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete   
 spec:
   location: uksouth
+  azureName: chart-tests-aso-${ENVIRONMENT}-rg
 ---
 apiVersion: servicebus.azure.com/v1beta20210101preview
 kind: Namespace
@@ -24,7 +34,7 @@ spec:
     environment: development
   location: uksouth
   owner:
-    name: chart-tests-aks-rg
+    name: chart-tests-aso-rg
   azureName: ${NAMESPACE}-sb-${ENVIRONMENT}
   sku:
     name: Basic

--- a/apps/chart-tests/azure-service-operator/aso.yaml
+++ b/apps/chart-tests/azure-service-operator/aso.yaml
@@ -1,8 +1,10 @@
 apiVersion: resources.azure.com/v1beta20200601
 kind: ResourceGroup
 metadata:
-  name: aso-aks-rg
+  name: chart-tests-aks-rg
   namespace: chart-tests
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete   
 spec:
   location: uksouth
 ---
@@ -11,6 +13,8 @@ kind: Namespace
 metadata:
   name: chart-tests-servicebus
   namespace: chart-tests
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   tags:
     app.kubernetes.io_name: chart-servicebus
@@ -20,8 +24,8 @@ spec:
     environment: development
   location: uksouth
   owner:
-    name: aso-aks-rg
-  azureName: ${NAMESPACE}-sb-${CLUSTER_FULL_NAME}
+    name: chart-tests-aks-rg
+  azureName: ${NAMESPACE}-sb-${ENVIRONMENT}
   sku:
     name: Basic
   zoneRedundant: false

--- a/apps/chart-tests/azure-service-operator/aso.yaml
+++ b/apps/chart-tests/azure-service-operator/aso.yaml
@@ -3,7 +3,7 @@ apiVersion: resources.azure.com/v1beta20200601
 kind: ResourceGroup
 metadata:
   name: aso-aks-rg
-  namespace: chart-tests   
+  namespace: chart-tests
 spec:
   location: uksouth
 ---
@@ -13,7 +13,7 @@ metadata:
   name: chart-tests-aso-rg
   namespace: chart-tests
   annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete   
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   location: uksouth
   azureName: chart-tests-aso-${ENVIRONMENT}-rg

--- a/apps/chart-tests/preview/base/kustomization.yaml
+++ b/apps/chart-tests/preview/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ../../../bsp/identity/identity.yaml
   - ../../../money-claims/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../azure-service-operator/aso-sb.yaml
+  - ../../azure-service-operator/aso.yaml
 namespace: chart-tests
 patchesStrategicMerge:
   - ../../../bsp/identity/aat.yaml


### PR DESCRIPTION
Detach-on-delete: https://azure.github.io/azure-service-operator/introduction/annotations/#serviceoperatorazurecomreconcile-policy - to prevent issues with preview cluster switchovers
Renaming - 00/01 not needed because of detach, sb naming changed to <namespace>-servicebus for k8s resource to be used in the chart in 'owner:'
Want to change rg names so they're clearer in Azure (some will need clearing up after storage chart changes)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
