### PR TITLE
Disable external-dns in CFT Demo

### DIFF
--- a/apps/admin/demo/00/kustomization.yaml
+++ b/apps/admin/demo/00/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../base
 
 patchesStrategicMerge:
-  - ../../external-dns-2/demo/00-external-dns.yaml
-  - ../../external-dns-2/demo/00-external-dns-private.yaml
   - ../../traefik2/demo/00-private.yaml
   - ../../traefik2/demo/00-no-proxy.yaml
   - ../../traefik2/demo/00-auth-proxy.yaml

--- a/apps/admin/demo/01/kustomization.yaml
+++ b/apps/admin/demo/01/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../base
 
 patchesStrategicMerge:
-  - ../../external-dns-2/demo/01-external-dns.yaml
-  - ../../external-dns-2/demo/01-external-dns-private.yaml
   - ../../traefik2/demo/01-private.yaml
   - ../../traefik2/demo/01-no-proxy.yaml
   - ../../traefik2/demo/01-auth-proxy.yaml

--- a/apps/admin/demo/base/kustomization.yaml
+++ b/apps/admin/demo/base/kustomization.yaml
@@ -8,9 +8,6 @@ resources:
   - ../../traefik2/traefik2-private
   - ../../traefik2/traefik2-no-proxy
   - ../../traefik2/traefik2-auth-proxy
-  - ../../external-dns-2/
-  - ../../external-dns-2/external-dns-public
-  - ../../external-dns-2/external-dns-private
   - ../../aad-pod-id/mi
   - ../../oauth2-proxy
   - ../../traefik2/traefik2-auth-middlewares
@@ -21,8 +18,6 @@ resources:
   - oauth2-client-secret.yaml
 patchesStrategicMerge:
   - keda-identity.yaml
-  - ../../external-dns-2/demo/external-dns-private.yaml
-  - ../../external-dns-2/demo/external-dns.yaml
   - ../../traefik2/demo/secret-provider.yaml
   - ../../aad-pod-id/mi/demo/azure-identity-patch.yaml
   - ../../aad-pod-id/mi/ds-patch.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12611
First step in migrating CFT Demo to active/active, to allow us to rebuild the second cluster and begin managing DNS records through other components.

This change:
- Disables External-DNS on CFT demo, to stop DNS records being managed by the external dns app on the clusters.

Similar change done in SDS: https://github.com/hmcts/sds-flux-config/pull/2539


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
