### PR TITLE
Remove demo specific flags from plum for active active testing

### DIFF
--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -7,5 +7,4 @@ spec:
   values:
     nodejs:
       ingressHost: plum.demo.platform.hmcts.net
-      enableOAuth: true
       disableTraefikTls: false

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -7,3 +7,5 @@ spec:
   values:
     nodejs:
       ingressHost: plum.demo.platform.hmcts.net
+      enableOAuth: true
+      disableTraefikTls: false

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     nodejs:
       ingressHost: plum.demo.platform.hmcts.net
-      disableTraefikTls: false

--- a/apps/cnp/plum-recipe-backend/demo.yaml
+++ b/apps/cnp/plum-recipe-backend/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: plum-recipe-backend.service.core-compute-demo.internal

--- a/apps/cnp/plum-recipe-backend/demo.yaml
+++ b/apps/cnp/plum-recipe-backend/demo.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressHost: plum-recipe-backend.service.core-compute-demo.internal
+      ingressHost: plum-recipe-backend-demo.service.core-compute-demo.internal


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12612
This change:
- Removes demo flags from plum for moving to active active



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
