### PR TITLE
Remove demo flags for plum

### DIFF
--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -7,5 +7,3 @@ spec:
   values:
     nodejs:
       ingressHost: plum.demo.platform.hmcts.net
-      enableOAuth: true
-      disableTraefikTls: false


### PR DESCRIPTION
This change:
- Removes demo specific flags for plum to allow it to work with azfd

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
