### PR TITLE
Remove traefiktls flag

### DIFF
--- a/apps/camunda/camunda-ui/demo.yaml
+++ b/apps/camunda/camunda-ui/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
-      disableTraefikTls: false
+      ingressClass: traefik


### PR DESCRIPTION
Remove from camunda, pointing to FD

This change:
- Removes demo specific flags to point camunda to demo front door and let the health probes pass

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
