### PR TITLE
Remove traefikTls flag from app for moving over to a/a

### DIFF
--- a/apps/idam/idam-testing-support-api/demo.yaml
+++ b/apps/idam/idam-testing-support-api/demo.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: idam-testing-support-api
   values:
     java:
-      disableTraefikTls: false
       ingressHost: idam-testing-support-api.demo.platform.hmcts.net
       ingressClass: traefik-private
       environment:


### PR DESCRIPTION
This change:
- Removes TLS flag as this will now be going through appgw, as defined in https://github.com/hmcts/azure-private-dns/pull/523/files -- without this removal health probe fails and routing through appgw fails

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
