### PR TITLE
Remove tls flag

### DIFF
--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-bb62d79-20230202111908
-      disableTraefikTls: false
       ingressClass: traefik-private
       ingressHost: idam-api.demo.platform.hmcts.net
       environment:


### PR DESCRIPTION
This change:
- Moves IDAM-API to a/a
- Manages monitoring records for 01 as code
Similar done and tested with https://github.com/hmcts/cnp-flux-config/pull/21666

To be merged with https://github.com/hmcts/azure-private-dns/pull/524


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
