### PR TITLE
DTSPO-12798 - Update traefik nonprod 01 envs

### DIFF
--- a/apps/admin/traefik2/aat/01.yaml
+++ b/apps/admin/traefik2/aat/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/demo/01-auth-proxy.yaml
+++ b/apps/admin/traefik2/demo/01-auth-proxy.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2-auth-proxy
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     additionalArguments:
       - --providers.kubernetesingress.ingressendpoint.ip=51.142.81.236

--- a/apps/admin/traefik2/demo/01-no-proxy.yaml
+++ b/apps/admin/traefik2/demo/01-no-proxy.yaml
@@ -6,6 +6,15 @@ metadata:
   name: traefik2-no-proxy
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     additionalArguments:
       - --providers.kubernetesingress.ingressendpoint.ip=51.142.80.151

--- a/apps/admin/traefik2/demo/01-private.yaml
+++ b/apps/admin/traefik2/demo/01-private.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2-private
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     additionalArguments:
       - --providers.kubernetesingress.ingressendpoint.ip=10.50.95.221

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/preview/01.yaml
+++ b/apps/admin/traefik2/preview/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 21.1.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-12798


### Change description ###
Update traefik to 21.1.0 in nonprod 01 envs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
