### PR TITLE
CCD-4443: Revert demo-image-policy to 'prod'

### DIFF
--- a/apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-643-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4443

### Change description ###
Revert demo-image-policy to 'prod'.

(Note 'pr-643' change to https://github.com/hmcts/cnp-flux-config/blob/master/apps/ccd/ccd-case-document-am-api/demo.yaml has already been reverted.)

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```