### PR TITLE
Back to using preview images for idam-api in preview env

### DIFF
--- a/apps/idam/idam-api/preview.yaml
+++ b/apps/idam/idam-api/preview.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       disableTraefikTls: false
-      image: hmctspublic.azurecr.io/idam/api:pr-1180
+      image: hmctspublic.azurecr.io/idam/api:preview-9b2a01b-20230223160751 #{"$imagepolicy": "flux-system:preview-idam-api"}
       ingressHost: idam-api.preview.platform.hmcts.net
       replicas: 2
       environment:


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Preview images can be used again for idam-api in Preview environment.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
