### PR TITLE
Remove demo flags for apps to be migrated

### DIFF
--- a/apps/civil/civil-citizen-ui/demo.yaml
+++ b/apps/civil/civil-citizen-ui/demo.yaml
@@ -6,14 +6,11 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      enableOAuth: true
       replicas: 2
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      ingressClass: traefik-no-proxy
       ingressHost: civil-citizen-ui.demo.platform.hmcts.net
       image: hmctspublic.azurecr.io/civil/citizen-ui:prod-ad0bf94-20230324154659 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       environment:

--- a/apps/fees-pay/fees-register-frontend/demo.yaml
+++ b/apps/fees-pay/fees-register-frontend/demo.yaml
@@ -6,8 +6,6 @@ spec:
   releaseName: fees-register-frontend
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
-      disableTraefikTls: false
       image: hmctspublic.azurecr.io/fees-register/frontend:prod-395af2b-20230323113052 #{"$imagepolicy": "flux-system:demo-fees-register-frontend"}
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/ia/ia-aip-frontend/demo.yaml
+++ b/apps/ia/ia-aip-frontend/demo.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: immigration-appeal.demo.platform.hmcts.net
       image: hmctspublic.azurecr.io/ia/aip-frontend:pr-847-a958810-20230321205708 #{"$imagepolicy": "flux-system:demo-ia-aip-frontend"}
       environment:

--- a/apps/lau/lau-frontend-int/demo.yaml
+++ b/apps/lau/lau-frontend-int/demo.yaml
@@ -6,8 +6,6 @@ spec:
   releaseName: lau-frontend-int
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       image: hmctspublic.azurecr.io/lau/frontend:prod-920d19f-20230324150532 #{"$imagepolicy": "flux-system:lau-frontend"}
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/lau/lau-frontend/demo.yaml
+++ b/apps/lau/lau-frontend/demo.yaml
@@ -5,5 +5,3 @@ metadata:
 spec:
   values:
     nodejs:
-      enableOAuth: true
-      disableTraefikTls: false

--- a/apps/money-claims/cmc-citizen-frontend/demo.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/demo.yaml
@@ -7,9 +7,7 @@ spec:
   values:
     nodejs:
       image: hmctspublic.azurecr.io/cmc/citizen-frontend:prod-ac80a74-20230324171017 #{"$imagepolicy": "flux-system:cmc-citizen-frontend"}
-      ingressClass: traefik-no-proxy
       ingressHost: moneyclaims.demo.platform.hmcts.net
-      disableTraefikTls: false
       environment:
         GA_TRACKING_ID: UA-97111056-1
         FEATURE_TESTING_SUPPORT: true

--- a/apps/nfdiv/nfdiv-frontend/demo.yaml
+++ b/apps/nfdiv/nfdiv-frontend/demo.yaml
@@ -6,9 +6,7 @@ spec:
   releaseName: nfdiv-frontend
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
       ingressHost: nfdiv.demo.platform.hmcts.net
-      disableTraefikTls: false
       image: hmctspublic.azurecr.io/nfdiv/frontend:prod-bc0a701-20230323122339 #{"$imagepolicy": "flux-system:nfdiv-frontend"}
       environment:
         WEBCHAT_AVAYA_URL: webchat.training.ctsc.hmcts.net

--- a/apps/pcq/pcq-frontend-int/demo.yaml
+++ b/apps/pcq/pcq-frontend-int/demo.yaml
@@ -5,9 +5,7 @@ metadata:
 spec:
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
       ingressHost: pcq-int.demo.platform.hmcts.net
-      disableTraefikTls: false
       environment:
         DUMMY_RESTART_VAR: true
         PCQ_BACKEND_URL: http://pcq-backend-int-demo.service.core-compute-demo.internal

--- a/apps/pcq/pcq-frontend/demo.yaml
+++ b/apps/pcq/pcq-frontend/demo.yaml
@@ -5,6 +5,4 @@ metadata:
 spec:
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
       ingressHost: pcq.demo.platform.hmcts.net
-      disableTraefikTls: false

--- a/apps/private-law/prl-citizen-frontend/demo.yaml
+++ b/apps/private-law/prl-citizen-frontend/demo.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
-      disableTraefikTls: false
       image: hmctspublic.azurecr.io/prl/citizen-frontend:pr-838-0c0e1a7-20230315225304 #{"$imagepolicy": "flux-system:demo-prl-citizen-frontend"}
       cpuLimits: "1000m"
       cpuRequests: "500m"

--- a/apps/probate/probate-frontend/demo.yaml
+++ b/apps/probate/probate-frontend/demo.yaml
@@ -6,9 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
       ingressHost: probate.demo.platform.hmcts.net
-      disableTraefikTls: false
       image: hmctspublic.azurecr.io/probate/frontend:pr-1742-92ab128-20230321150624 #{"$imagepolicy": "flux-system:demo-probate-frontend"}
       environment:
         VAR_FV2: demo-1


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12614

This change:
- Removes demo specific flags from apps to be migrated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
