### PR TITLE
Remove flags of third batch of demo apps

### DIFF
--- a/apps/adoption/adoption-web/demo.yaml
+++ b/apps/adoption/adoption-web/demo.yaml
@@ -7,8 +7,6 @@ spec:
   interval: 1m
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
-      disableTraefikTls: false
       readinessPeriod: 15
       image: hmctspublic.azurecr.io/adoption/web:pr-956-1788ce5-20230315183803 #{"$imagepolicy": "flux-system:demo-adoption-web"}
       environment:

--- a/apps/bar/bar-web-int/demo.yaml
+++ b/apps/bar/bar-web-int/demo.yaml
@@ -6,8 +6,6 @@ spec:
   releaseName: bar-web-int
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       image: hmctspublic.azurecr.io/bar/web:prod-3eff5e5-20230206232334 #{"$imagepolicy": "flux-system:bar-web"}
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/bar/bar-web/demo.yaml
+++ b/apps/bar/bar-web/demo.yaml
@@ -6,8 +6,6 @@ spec:
   releaseName: bar-web
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       image: hmctspublic.azurecr.io/bar/web:prod-3eff5e5-20230206232334 #{"$imagepolicy": "flux-system:demo-bar-web"}
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/ccd/ccd-ac-int-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-ac-int-api-gateway-web/demo.yaml
@@ -6,6 +6,4 @@ spec:
   releaseName: ccd-ac-int-api-gateway-web
   values:
     nodejs:
-      disableTraefikTls: false
-      enableOAuth: true
       image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-5fe4fe0-20230303104742 #{"$imagepolicy": "flux-system:ccd-ac-int-api-gateway-web"}

--- a/apps/idam/idam-hmcts-access/demo.yaml
+++ b/apps/idam/idam-hmcts-access/demo.yaml
@@ -7,5 +7,3 @@ spec:
   releaseName: idam-hmcts-access
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy

--- a/apps/idam/idam-user-dashboard/demo.yaml
+++ b/apps/idam/idam-user-dashboard/demo.yaml
@@ -7,5 +7,3 @@ spec:
   releaseName: idam-user-dashboard
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
-      disableTraefikTls: false

--- a/apps/sscs/sscs-cor-frontend/demo.yaml
+++ b/apps/sscs/sscs-cor-frontend/demo.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      enableOAuth: true
       ingressHost: sscs-cor.demo.platform.hmcts.net
       image: hmctspublic.azurecr.io/sscs-cor/frontend:prod-5ba3660-20230328103347 #{"$imagepolicy": "flux-system:sscs-cor-frontend"}
       environment:

--- a/apps/sscs/sscs-tribunals-frontend/demo.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/demo.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: benefit-appeal.demo.platform.hmcts.net
       image: hmctspublic.azurecr.io/sscs/tribunals-frontend:prod-32cbe82-20220825134712 #{"$imagepolicy": "flux-system:sscs-tribunals-frontend"}
       environment:

--- a/apps/xui/xui-ao-webapp-integration/demo.yaml
+++ b/apps/xui/xui-ao-webapp-integration/demo.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: administer-orgs-int.demo.platform.hmcts.net
       environment:
         DUMMY_VAR: 1

--- a/apps/xui/xui-mo-webapp-integration/demo.yaml
+++ b/apps/xui/xui-mo-webapp-integration/demo.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
-      enableOAuth: true
       ingressHost: manage-org-int.demo.platform.hmcts.net
       environment:
         DEBUG: xuiNode:*,-xuiNode:auth:s2s


### PR DESCRIPTION
This change:
- Removes demo-specific flags from third batch of apps to be migrated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
