### PR TITLE
indent fix for imageAutomation

### DIFF
--- a/apps/sscs/sscs-hearings-api/image-policy.yaml
+++ b/apps/sscs/sscs-hearings-api/image-policy.yaml
@@ -6,8 +6,8 @@ spec:
   filterTags:
     pattern: '^pr-462-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
-    policy:
-      alphabetical:
-        order: asc
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: sscs-hearings-api


### PR DESCRIPTION
### Change description ###
Fix imageAutomation 

Issue:
`flux-system                     82d   False   ImagePolicy/flux-system/sscs-hearings-api dry-run failed, error: failed to create typed patch object (flux-system/sscs-hearings-api; image.toolkit.fluxcd.io/v1beta1, Kind=ImagePolicy): .spec.filterTags.policy: field not declared in schema.`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
