### PR TITLE
Remove demo flux flags

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo.yaml
@@ -6,8 +6,6 @@ spec:
   releaseName: ccd-api-gateway-web
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
-      disableTraefikTls: false
       environment:
         CORS_ORIGIN_WHITELIST: "*"
         TIMING-ALLOW-ORIGIN: "https://www-ccd.demo.platform.hmcts.net"

--- a/apps/ccd/ccd-case-print-service/demo.yaml
+++ b/apps/ccd/ccd-case-print-service/demo.yaml
@@ -6,9 +6,6 @@ spec:
   releaseName: ccd-case-print-service
   values:
     nodejs:
-      disableTraefikTls: false
-      java:
-      enableOAuth: true
       image: hmctspublic.azurecr.io/ccd/case-print-service:prod-7ac9243-20230316164153 #{"$imagepolicy": "flux-system:demo-ccd-case-print-service"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 2

--- a/apps/xui/xui-activity-tracker-api/demo.yaml
+++ b/apps/xui/xui-activity-tracker-api/demo.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: activity-tracker-api.demo.platform.hmcts.net
       environment:
         FEATURE_SECURE_COOKIE_ENABLED: false

--- a/apps/xui/xui-webapp-ac-integration/demo.yaml
+++ b/apps/xui/xui-webapp-ac-integration/demo.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: manage-case-ac-int.demo.platform.hmcts.net
       image: hmctspublic.azurecr.io/xui/webapp:prod-78fd4e2-20230328094903 #{"$imagepolicy": "flux-system:xui-webapp"}
       environment:

--- a/apps/xui/xui-webapp-caa-assigned-case-view/demo.yaml
+++ b/apps/xui/xui-webapp-caa-assigned-case-view/demo.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: manage-case-caa-assigned-case-view.demo.platform.hmcts.net
       environment:
         FEATURE_SECURE_COOKIE_ENABLED: false

--- a/apps/xui/xui-webapp-hearings-integration/demo.yaml
+++ b/apps/xui/xui-webapp-hearings-integration/demo.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: manage-case-hearings-int.demo.platform.hmcts.net
       environment:
         DUMMY_VAR: 1

--- a/apps/xui/xui-webapp-integration/demo.yaml
+++ b/apps/xui/xui-webapp-integration/demo.yaml
@@ -8,8 +8,6 @@ spec:
       replicas: 20
       memoryLimits: "1Gi"
       cpuLimits: "2000m"
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: manage-case-int.demo.platform.hmcts.net
       environment:
         FEATURE_SECURE_COOKIE_ENABLED: false


### PR DESCRIPTION
This change:
- Removes demo specific flags from apps to be migrated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
