### PR TITLE
Dtspo 12618 remove demo ingress flags

### DIFF
--- a/apps/am/am-judicial-booking-service/demo.yaml
+++ b/apps/am/am-judicial-booking-service/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         AM_INFO: true

--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG

--- a/apps/am/am-role-assignment-service/demo.yaml
+++ b/apps/am/am-role-assignment-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       replicas: 5
-      ingressClass: traefik-private
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG

--- a/apps/bar/bar-api-int/demo.yaml
+++ b/apps/bar/bar-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: bar-api-int
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/bar/api:prod-41c4035-20230323113912 #{"$imagepolicy": "flux-system:bar-api"}
       environment:
         DUMMY_RESTART_VAR: false

--- a/apps/bar/bar-api/demo.yaml
+++ b/apps/bar/bar-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: bar-api
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/bar/api:prod-41c4035-20230323113912 #{"$imagepolicy": "flux-system:bar-api"}
       environment:
         DUMMY_RESTART_VAR: false

--- a/apps/bsp/bulk-scan-orchestrator/demo.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/bulk-scan/orchestrator:pr-2384-20fa22f-20230327114405 #{"$imagepolicy": "flux-system:demo-bulk-scan-orchestrator"}
-      ingressClass: traefik-private
       environment:
         TRANSFORMATION_URL_SSCS: "http://sscs-bulk-scan-demo.service.core-compute-demo.internal/transform-scanned-data"
         AUTO_CASE_CREATION_ENABLED_SSCS: "false"

--- a/apps/bsp/bulk-scan-payment-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/bulk-scan/payment-processor:pr-880-abc74e4-20230327115241 #{"$imagepolicy": "flux-system:demo-bulk-scan-payment-processor"}
-      ingressClass: traefik-private
       replicas: 2
       environment:
         REFRESH_PODS: "true"

--- a/apps/bsp/bulk-scan-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-processor/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/bulk-scan/processor:pr-2654-336621a-20230327115156 #{"$imagepolicy": "flux-system:demo-bulk-scan-processor"}
-      ingressClass: traefik-private
       environment:
         #60 days in seconds
         SAS_TOKEN_VALIDITY: "5184000"

--- a/apps/bsp/bulk-scan-sample-app/demo.yaml
+++ b/apps/bsp/bulk-scan-sample-app/demo.yaml
@@ -6,4 +6,3 @@ spec:
   releaseName: bulk-scan-sample-app
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         LOGGING_LEVEL_COM_ZAXXER_HIKARI_HIKARICONFIG: DEBUG

--- a/apps/camunda/camunda-optimize/demo.yaml
+++ b/apps/camunda/camunda-optimize/demo.yaml
@@ -4,6 +4,5 @@ metadata:
   name: camunda-optimize
 spec:
   values:
-    ingressClass: traefik-private
     environment:
       OPTIMIZE_ELASTICSEARCH_HOST: 10.96.216.253

--- a/apps/ccd/ccd-ac-int-api-gateway-web/ccd-ac-int-api-gateway-web.yaml
+++ b/apps/ccd/ccd-ac-int-api-gateway-web/ccd-ac-int-api-gateway-web.yaml
@@ -10,7 +10,6 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-5fe4fe0-20230303104742 #{"$imagepolicy": "flux-system:ccd-ac-int-api-gateway-web"}
       ingressHost: ac-int-gateway-ccd.demo.platform.hmcts.net
-      ingressClass: traefik-no-proxy
       environment:
         CORS_ORIGIN_WHITELIST: "*"
         TIMING-ALLOW-ORIGIN: "https://ccd-ac-int.demo.platform.hmcts.net"

--- a/apps/ccd/ccd-ac-int-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-ac-int-data-store-api/demo.yaml
@@ -6,5 +6,4 @@ spec:
   releaseName: ccd-ac-int-data-store-api
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-2a7d2f6-20230328190412 #{"$imagepolicy": "flux-system:demo-ccd-ac-int-data-store-api"}

--- a/apps/ccd/ccd-ac-int-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-ac-int-definition-store-api/demo.yaml
@@ -6,5 +6,4 @@ spec:
   releaseName: ccd-ac-int-definition-store-api
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-a9979b4-20230328191110 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}

--- a/apps/ccd/ccd-admin-web/demo.yaml
+++ b/apps/ccd/ccd-admin-web/demo.yaml
@@ -6,7 +6,5 @@ spec:
   releaseName: ccd-admin-web
   values:
     nodejs:
-      ingressClass: traefik-no-proxy
-      disableTraefikTls: false
       environment:
         ADMINWEB_ELASTIC_CASE_TYPES_URL: http://ccd-definition-store-api-demo.service.core-compute-demo.internal/elastic-support/case-types

--- a/apps/ccd/ccd-case-activity-api/demo.yaml
+++ b/apps/ccd/ccd-case-activity-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-case-activity-api
   values:
     nodejs:
-      ingressClass: traefik-private
       java:
       image: hmctspublic.azurecr.io/ccd/case-activity-api:prod-221f7a1-20230316164132 #{"$imagepolicy": "flux-system:demo-ccd-case-activity-api"}
       environment:

--- a/apps/ccd/ccd-case-document-am-api/demo.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/case-document-am-api:prod-c3e0ebb-20230329133424 #{"$imagepolicy": "flux-system:ccd-case-document-am-api"}
       environment:
         RESTART: 1

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-2a7d2f6-20230328190412 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
       replicas: 4
       autoscaling:

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -13,7 +13,6 @@ spec:
       cpuLimits: "4"
       autoscaling:
         enabled: false
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-a9979b4-20230328191110 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
       environment:
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net

--- a/apps/ccd/ccd-int/ccd-int.yaml
+++ b/apps/ccd/ccd-int/ccd-int.yaml
@@ -53,7 +53,6 @@ spec:
       nodejs:
         disableKeyVaults: true
         image: hmctspublic.azurecr.io/ccd/admin-web:prod-a2eb00d-20230303104712 #{"$imagepolicy": "flux-system:ccd-admin-web"}
-        ingressClass: traefik-no-proxy
         ingressHost: ccd-admin-{{ .Release.Name }}.demo.platform.hmcts.net
         disableTraefikTls: false
         environment:
@@ -65,7 +64,6 @@ spec:
       nodejs:
         disableKeyVaults: true
         image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-5fe4fe0-20230303104742 #{"$imagepolicy": "flux-system:ccd-api-gateway-web"}
-        ingressClass: traefik-no-proxy
         ingressHost: gateway-{{ .Release.Name }}.demo.platform.hmcts.net
         disableTraefikTls: false
         environment:

--- a/apps/ccd/ccd-test-stubs-service/demo.yaml
+++ b/apps/ccd/ccd-test-stubs-service/demo.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/ccd/ccd-user-profile-api/demo.yaml
+++ b/apps/ccd/ccd-user-profile-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccd-user-profile-api
   values:
     java:
-      ingressClass: traefik-private
       environment:
         USER_PROFILE_DB_HOST: ccd-user-profile-api-postgres-db-v11-demo.postgres.database.azure.com
         USER_PROFILE_DB_USERNAME: ccd@ccd-user-profile-api-postgres-db-v11-demo

--- a/apps/ccd/demo-disabled/ccd-backend-frontend.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-backend-frontend.yaml.disabled
@@ -26,7 +26,6 @@ spec:
     ccd-admin-web:
       nodejs:
         image: hmctspublic.azurecr.io/ccd/admin-web:prod-1f77564f
-        ingressClass: traefik-no-proxy
         ingressHost: ccd-admin-{{ .Release.Name }}.demo.platform.hmcts.net
         secrets:
           IDAM_OAUTH2_AW_CLIENT_SECRET:
@@ -34,7 +33,6 @@ spec:
     ccd-api-gateway-web:
       nodejs:
         image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-eb012c9f
-        ingressClass: traefik-no-proxy
         ingressHost: gateway-{{ .Release.Name }}.demo.platform.hmcts.net
         secrets:
           IDAM_OAUTH2_CLIENT_SECRET:

--- a/apps/ccd/message-publisher/demo.yaml
+++ b/apps/ccd/message-publisher/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: message-publisher
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DATA_STORE_DB_HOST: ccd-data-store-api-postgres-db-v11-demo.postgres.database.azure.com
         DATA_STORE_DB_USERNAME: ccd@ccd-data-store-api-postgres-db-v11-demo

--- a/apps/civil/civil-general-applications/demo.yaml
+++ b/apps/civil/civil-general-applications/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/civil/general-applications:prod-38ab28d-20230329144051 #{"$imagepolicy": "flux-system:civil-general-applications"}
       keyVaults:
         civil:

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/civil/service:pr-2084-c59b74e-20230330103131 #{"$imagepolicy": "flux-system:demo-civil-service"}
       keyVaults:
         civil:

--- a/apps/cnp/plum-frontend/plum-frontend-demo-publicaccess.yaml
+++ b/apps/cnp/plum-frontend/plum-frontend-demo-publicaccess.yaml
@@ -15,7 +15,6 @@ spec:
   values:
     nodejs:
       ingressHost: plum-public.demo.platform.hmcts.net
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/plum/frontend:prod-8fc35ce-20230330115702 # {"$imagepolicy": "flux-system:plum-frontend"}
       startupPeriod: 120
       startupFailureThreshold: 3

--- a/apps/cpo/case-payment-orders-api-int/demo.yaml
+++ b/apps/cpo/case-payment-orders-api-int/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/cpo/case-payment-orders-api:prod-9c9f4bf-20230328190829 #{"$imagepolicy": "flux-system:case-payment-orders-api"}
-      ingressClass: traefik-private

--- a/apps/cpo/case-payment-orders-api/demo.yaml
+++ b/apps/cpo/case-payment-orders-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         CPO_S2S_AUTHORISED_SERVICES: xui_webapp,payment_app,service_request_cpo_update_service,ccpay_cpo_function_node
         S2S_AUTHORIZATIONS_CCPAY_ID: ccpay_cpo_function_node

--- a/apps/dg/dg-docassembly/demo.yaml
+++ b/apps/dg/dg-docassembly/demo.yaml
@@ -7,6 +7,5 @@ spec:
   releaseName: dg-docassembly
   values:
     java:
-      ingressClass: traefik-private
       environment:
         VAR_FV2: value1

--- a/apps/divorce/div-cfs/demo.yaml
+++ b/apps/divorce/div-cfs/demo.yaml
@@ -6,5 +6,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/cfs:prod-a805f5d-20230207162619 #{"$imagepolicy": "flux-system:demo-div-cfs"}

--- a/apps/divorce/div-cms/demo.yaml
+++ b/apps/divorce/div-cms/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/cms:prod-873e7ee-20230206152221 #{"$imagepolicy": "flux-system:demo-div-cms"}
       environment:
         IDAM_API_BASEURL: "https://idam-api.demo.platform.hmcts.net"

--- a/apps/divorce/div-cos/demo.yaml
+++ b/apps/divorce/div-cos/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/cos:pr-1752-a200bf4-20230315155541 #{"$imagepolicy": "flux-system:demo-div-cos"}
       environment:
         IDAM_API_URL: "https://idam-api.demo.platform.hmcts.net"

--- a/apps/divorce/div-dgs/demo.yaml
+++ b/apps/divorce/div-dgs/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/dgs:prod-c8de9b3-20230324111743 #{"$imagepolicy": "flux-system:demo-div-dgs"}
       environment:
         MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/apps/divorce/div-emca/demo.yaml
+++ b/apps/divorce/div-emca/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/emca:prod-4370fd1-20230206144806 #{"$imagepolicy": "flux-system:demo-div-emca"}
       environment:
         IDAM_API_HEALTH_URI: https://idam-api.demo.platform.hmcts.net/health

--- a/apps/divorce/div-fps/demo.yaml
+++ b/apps/divorce/div-fps/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/div/fps:prod-0df9f9d-20230206113707 #{"$imagepolicy": "flux-system:demo-div-fps"}
       environment:
         GENERAL_APPLICATION_WITHOUT_NOTICE_FEE_KEYWORD: "GeneralAppWithoutNotice"

--- a/apps/dm-store/dm-store/demo.yaml
+++ b/apps/dm-store/dm-store/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/dm/store:prod-e2f77d9-20230330095726 #{"$imagepolicy": "flux-system:demo-dm-store"}
       environment:
         ENABLE_TTL: false

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -4,6 +4,5 @@ metadata:
   name: docmosis
 spec:
   values:
-    ingressClass: traefik-private
     ingressHost: docmosis.demo.platform.hmcts.net
     image: hmctsprivate.azurecr.io/docmosis:demo-036b597-362101 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/apps/em/em-anno/demo.yaml
+++ b/apps/em/em-anno/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/anno:prod-5259698-20230329191324 #{"$imagepolicy": "flux-system:demo-em-anno"}
       environment:
         TEST_VAR: value1

--- a/apps/em/em-ccd-orchestrator/demo.yaml
+++ b/apps/em/em-ccd-orchestrator/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/ccdorc:pr-1126-7ad24f2-20230327092257 #{"$imagepolicy": "flux-system:demo-em-ccd-orchestrator"}
       environment:
         DUMMY_VAR: DELETE_ME

--- a/apps/em/em-hrs-api/demo.yaml
+++ b/apps/em/em-hrs-api/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/em/em-npa/demo.yaml
+++ b/apps/em/em-npa/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/npa:prod-afbb035-20230330091055 #{"$imagepolicy": "flux-system:demo-em-npa"}
       environment:
         TEST_VAR: value1

--- a/apps/em/em-stitching/demo.yaml
+++ b/apps/em/em-stitching/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/em/stitching:pr-1448-4ab2688-20230327084144 #{"$imagepolicy": "flux-system:demo-em-stitching"}
       environment:
         TEST_VAR: value2

--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: et-cos
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/et/cos:pr-576-778ce8e-20230329105447 #{"$imagepolicy": "flux-system:demo-et-cos"}
       environment:
         AAC_URL: http://aac-manage-case-assignment-demo.service.core-compute-demo.internal

--- a/apps/et/et-msg-handler/demo.yaml
+++ b/apps/et/et-msg-handler/demo.yaml
@@ -6,5 +6,4 @@ spec:
   releaseName: et-msg-handler
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/et/msg-handler:prod-26f13f8-20230330134417 #{"$imagepolicy": "flux-system:et-msg-handler"}

--- a/apps/et/et-sya-api/demo.yaml
+++ b/apps/et/et-sya-api/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/et/sya-api:pr-264-dfb0b63-20230330124740 #{"$imagepolicy": "flux-system:demo-et-sya-api"}
-      ingressClass: traefik-private
       environment:
         SUBMIT_CASE_EMAIL_TEMPLATE_ID: 10c31d51-c518-4d73-b2c3-1c02771ef41e
         CY_SUBMIT_CASE_EMAIL_TEMPLATE_ID: f61f7f2a-4825-491b-bc48-0299f1a8ba23

--- a/apps/ethos/ecm-consumer/demo.yaml
+++ b/apps/ethos/ecm-consumer/demo.yaml
@@ -7,5 +7,4 @@ spec:
   releaseName: ecm-consumer
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ethos/ecm-consumer:pr-633-5985643-20230320095247 #{"$imagepolicy": "flux-system:demo-ecm-consumer"}

--- a/apps/ethos/repl-docmosis-service/demo.yaml
+++ b/apps/ethos/repl-docmosis-service/demo.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: repl-docmosis-service
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ethos/repl-docmosis-backend:pr-2037-786a458-20230324095828 #{"$imagepolicy": "flux-system:demo-repl-docmosis-service"}
       environment:
         SECURE_DOC_STORE_FEATURE: false

--- a/apps/fact/fact-api/demo.yaml
+++ b/apps/fact/fact-api/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/family-public-law/fpl-case-service/demo.yaml
+++ b/apps/family-public-law/fpl-case-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressHost: fpl-case-service-demo.service.core-compute-demo.internal
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/fpl/case-service:pr-4118-0d5eeeb-20230320135421 #{"$imagepolicy": "flux-system:demo-fpl-case-service"}
       environment:
         RELEASE: NOW

--- a/apps/fees-pay/ccpay-bulkscanning-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccpay-bulkscanning-api-int
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/bulkscanning-api:prod-7437e7a-20230323114302 #{"$imagepolicy": "flux-system:demo-int-ccpay-bulkscanning-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/ccpay-bulkscanning-api/demo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/bulkscanning-api:prod-7437e7a-20230323114302 #{"$imagepolicy": "flux-system:demo-ccpay-bulkscanning-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/ccpay-cpo-update-service/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/cpo-update-service:prod-985c234-20230323114319 #{"$imagepolicy": "flux-system:ccpay-cpo-update-service"}
       environment:
         DUMMY_VARIABLE: true

--- a/apps/fees-pay/ccpay-notifications-service-int/demo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service-int/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/notifications-service:pr-140-2e18f8c-20230329145841 #{"$imagepolicy": "flux-system:demo-int-ccpay-notifications-service"}
       environment:
         DUMMY_VARIABLE: false

--- a/apps/fees-pay/ccpay-notifications-service/demo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/notifications-service:pr-140-2e18f8c-20230329145841 #{"$imagepolicy": "flux-system:demo-ccpay-notifications-service"}
       environment:
         DUMMY_VARIABLE: false

--- a/apps/fees-pay/ccpay-payment-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccpay-payment-api-int
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/payment/api:pr-1391-39067dd-20230328122114 #{"$imagepolicy": "flux-system:demo-int-ccpay-payment-app"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: ccpay-payment-api
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/payment/api:pr-1393-20a69b2-20230329111715 #{"$imagepolicy": "flux-system:demo-ccpay-payment-app"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/ccpay-refunds-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api-int/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/refunds-api:pr-351-daca31a-20230329165252 #{"$imagepolicy": "flux-system:demo-int-ccpay-refunds-api"}
       environment:
         DUMMY_VARIABLE: false

--- a/apps/fees-pay/ccpay-refunds-api/demo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ccpay/refunds-api:pr-353-4aa730c-20230324151501 #{"$imagepolicy": "flux-system:demo-ccpay-refunds-api"}
       environment:
         DUMMY_VARIABLE: true

--- a/apps/fees-pay/fees-register-api-int/demo.yaml
+++ b/apps/fees-pay/fees-register-api-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: fees-register-api-int
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/fees-register/api:prod-0d8c1f6-20230323114255 #{"$imagepolicy": "flux-system:demo-int-fees-register-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/fees-register-api/demo.yaml
+++ b/apps/fees-pay/fees-register-api/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: fees-register-api
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/fees-register/api:prod-0d8c1f6-20230323114255 #{"$imagepolicy": "flux-system:demo-fees-register-api"}
       imagePullPolicy: Always
       environment:

--- a/apps/fees-pay/fees-register-frontend-int/demo.yaml
+++ b/apps/fees-pay/fees-register-frontend-int/demo.yaml
@@ -6,8 +6,6 @@ spec:
   releaseName: fees-register-frontend-int
   values:
     nodejs:
-      disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       image: hmctspublic.azurecr.io/fees-register/frontend:prod-395af2b-20230323113052 #{"$imagepolicy": "flux-system:demo-int-fees-register-frontend"}
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/financial-remedy/finrem-cos/demo.yaml
+++ b/apps/financial-remedy/finrem-cos/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/finrem/cos:prod-ef35440-20230330090336 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
       environment:
         FEATURE_PBA_CASE_TYPE: true

--- a/apps/financial-remedy/finrem-ns/demo.yaml
+++ b/apps/financial-remedy/finrem-ns/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/finrem/ns:prod-8c59df8-20230329160005 #{"$imagepolicy": "flux-system:finrem-ns"}
       environment:
         SWAGGER_ENABLED: false

--- a/apps/fis/fis-bulk-scan-api/demo.yaml
+++ b/apps/fis/fis-bulk-scan-api/demo.yaml
@@ -6,4 +6,3 @@ spec:
   releaseName: fis-bulk-scan-api
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/fis/fis-cos-api/demo.yaml
+++ b/apps/fis/fis-cos-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/fis/cos-api:prod-fb1ff66-20230327211414 #{"$imagepolicy": "flux-system:demo-fis-cos-api"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 2

--- a/apps/fis/fis-hmc-api/demo.yaml
+++ b/apps/fis/fis-hmc-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/fis/hmc-api:pr-163-1cada55-20230329115250 #{"$imagepolicy": "flux-system:demo-fis-hmc-api"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 2

--- a/apps/hmc/hmc-cft-hearing-service-int/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service-int/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-d7f0796-20230328190445 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
-      ingressClass: traefik-private

--- a/apps/hmc/hmc-cft-hearing-service/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-d7f0796-20230328190445 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
-      ingressClass: traefik-private
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_REPOSITORY: DEBUG

--- a/apps/hmc/hmc-hmi-inbound-adapter-int/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter-int/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:prod-7ae59e9-20230328190535 #{"$imagepolicy": "flux-system:demo-hmc-hmi-inbound-adapter"}
-      ingressClass: traefik-private

--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/hmc/hmc-hmi-outbound-adapter-int/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter-int/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-314531c-20230328190743 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
-      ingressClass: traefik-private

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_REPOSITORY: DEBUG

--- a/apps/ia/ia-aip-frontend/perftest.yaml
+++ b/apps/ia/ia-aip-frontend/perftest.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     nodejs:
       disableTraefikTls: false
-      ingressClass: traefik-no-proxy
       ingressHost: immigration-appeal.perftest.platform.hmcts.net
       environment:
         NODE_ENV: development

--- a/apps/ia/ia-bail-case-api/demo.yaml
+++ b/apps/ia/ia-bail-case-api/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/bail-case-api:pr-302-7eb1e32-20230313125454

--- a/apps/ia/ia-case-access-api/demo.yaml
+++ b/apps/ia/ia-case-access-api/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/case-api:pr-1202-55f7f56-20230321210602
       environment:
         IA_HOME_OFFICE_INTEGRATION_ENABLED: "true"

--- a/apps/ia/ia-case-documents-api/demo.yaml
+++ b/apps/ia/ia-case-documents-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/case-documents-api:prod-20222ba-20230329181901 #{"$imagepolicy": "flux-system:ia-case-documents-api"}
       environment:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net

--- a/apps/ia/ia-case-notifications-api/demo.yaml
+++ b/apps/ia/ia-case-notifications-api/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/case-notifications-api:pr-732-0b20970-20230313124500 #{"$imagepolicy": "flux-system:demo-ia-case-notifications-api"}

--- a/apps/ia/ia-case-payments-api/demo.yaml
+++ b/apps/ia/ia-case-payments-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/case-payments-api:prod-29ab94a-20230208155735 #{"$imagepolicy": "flux-system:ia-case-payments-api"}
       ingressHost: ia-case-payments-api-demo.service.core-compute-demo.internal
       environment:

--- a/apps/ia/ia-home-office-integration-api/demo.yaml
+++ b/apps/ia/ia-home-office-integration-api/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/home-office-integration-api:prod-d17f8f6-20230208164411 #{"$imagepolicy": "flux-system:ia-home-office-integration-api"}

--- a/apps/ia/ia-home-office-mock-api/demo.yaml
+++ b/apps/ia/ia-home-office-mock-api/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/ia/ia-timed-event-service/demo.yaml
+++ b/apps/ia/ia-timed-event-service/demo.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/ia/timed-event-service:prod-3d9b2bd-20230222102705 #{"$imagepolicy": "flux-system:ia-timed-event-service"}

--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-6ed31fd-20230324162715
-      ingressClass: traefik-private
       ingressHost: idam-api.demo.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-testing-support-api/demo.yaml
+++ b/apps/idam/idam-testing-support-api/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       ingressHost: idam-testing-support-api.demo.platform.hmcts.net
-      ingressClass: traefik-private
       environment:
         IDAM_API_URL: https://idam-api.demo.platform.hmcts.net
         SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: https://idam-web-public.demo.platform.hmcts.net/o/jwks

--- a/apps/jps/jps-judicial-payment-service/demo.yaml
+++ b/apps/jps/jps-judicial-payment-service/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/lau/lau-case-backend-int/demo.yaml
+++ b/apps/lau/lau-case-backend-int/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/lau/lau-case-backend/demo.yaml
+++ b/apps/lau/lau-case-backend/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/lau/lau-idam-backend-int/demo.yaml
+++ b/apps/lau/lau-idam-backend-int/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/lau/lau-idam-backend/demo.yaml
+++ b/apps/lau/lau-idam-backend/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/money-claims/cmc-ccd/demo.yaml
+++ b/apps/money-claims/cmc-ccd/demo.yaml
@@ -31,7 +31,6 @@ spec:
     ccd-admin-web:
       nodejs:
         image: hmctspublic.azurecr.io/ccd/admin-web:prod-a2eb00d-20230303104712 #{"$imagepolicy": "flux-system:ccd-admin-web"}
-        ingressClass: traefik-no-proxy
         ingressHost: ccd-admin-{{ .Release.Name }}.demo.platform.hmcts.net
         secrets:
           IDAM_OAUTH2_AW_CLIENT_SECRET:
@@ -39,7 +38,6 @@ spec:
     ccd-api-gateway-web:
       nodejs:
         image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-5fe4fe0-20230303104742 #{"$imagepolicy": "flux-system:ccd-api-gateway-web"}
-        ingressClass: traefik-no-proxy
         ingressHost: gateway-{{ .Release.Name }}.demo.platform.hmcts.net
         secrets:
           IDAM_OAUTH2_CLIENT_SECRET:

--- a/apps/money-claims/cmc-claim-store/demo.yaml
+++ b/apps/money-claims/cmc-claim-store/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/cmc/claim-store:prod-587ac6c-20230329112718 #{"$imagepolicy": "flux-system:cmc-claim-store"}
       keyVaults:
         cmc:

--- a/apps/monitoring/kube-prometheus-stack/demo/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/demo/00.yaml
@@ -7,14 +7,14 @@ spec:
   values:
     prometheus:
       ingress:
-        ingressClassName: traefik-private
+        ingressClassName: traefik
         hosts:
           - prometheus-00.demo.platform.hmcts.net
       prometheusSpec:
         retention: 30d
     alertmanager:
       ingress:
-        ingressClassName: traefik-private
+        ingressClassName: traefik
         hosts:
           - alertmanager-00.demo.platform.hmcts.net
       config:

--- a/apps/monitoring/kube-prometheus-stack/demo/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/demo/01.yaml
@@ -7,14 +7,14 @@ spec:
   values:
     prometheus:
       ingress:
-        ingressClassName: traefik-private
+        ingressClassName: traefik
         hosts:
           - prometheus-01.demo.platform.hmcts.net
       prometheusSpec:
         retention: 30d
     alertmanager:
       ingress:
-        ingressClassName: traefik-private
+        ingressClassName: traefik
         hosts:
           - alertmanager-01.demo.platform.hmcts.net
       config:

--- a/apps/nfdiv/nfdiv-case-api/demo.yaml
+++ b/apps/nfdiv/nfdiv-case-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/nfdiv/case-api:prod-56f30e9-20230330110607 #{"$imagepolicy": "flux-system:demo-nfdiv-case-api"}
       environment:
         CASE_HOLDING_WEEKS: 20

--- a/apps/pcq/pcq-backend-int/demo.yaml
+++ b/apps/pcq/pcq-backend-int/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       ingressHost: pcq-backend-int-demo.service.core-compute-demo.internal
-      ingressClass: traefik-private
       environment:
         S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
         DB_ALLOW_DELETE_RECORD: "false"

--- a/apps/pcq/pcq-backend/demo.yaml
+++ b/apps/pcq/pcq-backend/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/private-law/prl-cos/demo.yaml
+++ b/apps/private-law/prl-cos/demo.yaml
@@ -27,7 +27,6 @@ spec:
             - filtered-court-ids
             - postcode-lookup-token
       replicas: 2
-      ingressClass: traefik-private
       memoryRequests: "768Mi"
       cpuRequests: "1000m"
       memoryLimits: "3072Mi"

--- a/apps/private-law/prl-dgs/demo.yaml
+++ b/apps/private-law/prl-dgs/demo.yaml
@@ -10,7 +10,6 @@ spec:
       replicas: 2
       readinessDelay: 45
       readinessTimeout: 10
-      ingressClass: traefik-private
       readinessPeriod: 10
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/prl/dgs:prod-91b943a-20230324112406 #{"$imagepolicy": "flux-system:prl-dgs"}

--- a/apps/probate/probate-back-office/demo.yaml
+++ b/apps/probate/probate-back-office/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/probate/back-office:pr-2182-8db49d1-20230328123837 #{"$imagepolicy": "flux-system:demo-probate-back-office"}
       environment:
         CCD_GATEWAY_HOST: https://manage-case.demo.platform.hmcts.net

--- a/apps/probate/probate-business-service/demo.yaml
+++ b/apps/probate/probate-business-service/demo.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/probate/probate-orchestrator-service/demo.yaml
+++ b/apps/probate/probate-orchestrator-service/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/probate/orchestrator-service:prod-ebc1332-20230330123113 #{"$imagepolicy": "flux-system:probate-orchestrator-service"}
       ingressHost: probate-orchestrator-service-demo.service.core-compute-demo.internal
       environment:

--- a/apps/probate/probate-submit-service/demo.yaml
+++ b/apps/probate/probate-submit-service/demo.yaml
@@ -6,4 +6,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/rd/rd-caseworker-ref-api-integration/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api-integration/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: rd-caseworker-ref-api-int-demo.service.core-compute-demo.internal
       environment:
         DELETE_CWR: true

--- a/apps/rd/rd-caseworker-ref-api/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DELETE_CWR: true
         CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api

--- a/apps/rd/rd-commondata-api/demo.yaml
+++ b/apps/rd/rd-commondata-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DELETE_ORG: true
         CRD_S2S_AUTHORISED_SERVICES: rd_commondata_api,xui_webapp,ccd_data,sscs,sscs_bulkscan,iac,civil_service,prl_cos_api

--- a/apps/rd/rd-judicial-api-integration/demo.yaml
+++ b/apps/rd/rd-judicial-api-integration/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: rd-judicial-api-int-demo.service.core-compute-demo.internal
       environment:
         DELETE_ORG: false

--- a/apps/rd/rd-judicial-api/demo.yaml
+++ b/apps/rd/rd-judicial-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/rd/judicial-api:prod-7fa492a-20230329162737 #{"$imagepolicy": "flux-system:rd-judicial-api"}
       environment:
         DELETE_ORG: true

--- a/apps/rd/rd-location-ref-api-integration/demo.yaml
+++ b/apps/rd/rd-location-ref-api-integration/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: rd-location-ref-api-int-demo.service.core-compute-demo.internal
       environment:
         LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api

--- a/apps/rd/rd-location-ref-api/demo.yaml
+++ b/apps/rd/rd-location-ref-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api,ccd_data,xui_webapp,prl_cos_api,sscs,sscs_bulkscan,adoption_web,rd_judicial_api,civil_service,civil_general_applications,sptribs_case_api,fis_hmc_api
         DELETE_ORG: true

--- a/apps/rd/rd-professional-api-integration/demo.yaml
+++ b/apps/rd/rd-professional-api-integration/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: rd-professional-api-int-demo.service.core-compute-demo.internal
       environment:
         USER_PROFILE_URL: http://rd-user-profile-api-int-demo.service.core-compute-demo.internal

--- a/apps/rd/rd-professional-api/demo.yaml
+++ b/apps/rd/rd-professional-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DELETE_ORG: true
         ACTIVE_ORG_EXT: true

--- a/apps/rd/rd-profile-sync-integration/demo.yaml
+++ b/apps/rd/rd-profile-sync-integration/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: rd-profile-sync-int-demo.service.core-compute-demo.internal
       environment:
         USER_PROFILE_URL: http://rd-user-profile-api-int-demo.service.core-compute-demo.internal

--- a/apps/rd/rd-profile-sync/demo.yaml
+++ b/apps/rd/rd-profile-sync/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DELETE_ORG: true

--- a/apps/rd/rd-user-profile-api-integration/demo.yaml
+++ b/apps/rd/rd-user-profile-api-integration/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       ingressHost: rd-user-profile-api-int-demo.service.core-compute-demo.internal
       environment:
         DELETE_ORG: true

--- a/apps/rd/rd-user-profile-api/demo.yaml
+++ b/apps/rd/rd-user-profile-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DELETE_ORG: true
         PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api

--- a/apps/reform-scan/reform-scan-blob-router/demo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       memoryLimits: "1024Mi"
       environment:
         TASK_SCAN_DELAY: 300000

--- a/apps/reform-scan/reform-scan-notification-service/demo.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         PENDING_NOTIFICATIONS_SEND_DELAY_IN_MINUTE: 0
         REFRESH_PODS: "true"

--- a/apps/rpe/demo/base/pdf-service-ingress.yaml
+++ b/apps/rpe/demo/base/pdf-service-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: rpe-pdf-service
   namespace: rpe
 spec:
-  ingressClassName: traefik-private
+  ingressClassName: traefik
   rules:
     - host: cmc-pdf-service-demo.service.core-compute-demo.internal
       http:

--- a/apps/rpe/draft-store-service/demo.yaml
+++ b/apps/rpe/draft-store-service/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         DRAFT_STORE_DB_HOST: rpe-draft-store-v14-demo.postgres.database.azure.com
         DRAFT_STORE_DB_USER_NAME: pgadmin

--- a/apps/rpe/pdf-service/demo.yaml
+++ b/apps/rpe/pdf-service/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/rpe/rpe-send-letter-service/demo.yaml
+++ b/apps/rpe/rpe-send-letter-service/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/rpe/send-letter-service:pr-2207-eda87fb-20230329154850 #{"$imagepolicy": "flux-system:demo-rpe-send-letter-service"}
-      ingressClass: traefik-private
       environment:
         ENCRYPTION_ENABLED: false
         CIVIL_SERVICE_ENABLED: true

--- a/apps/rpe/rpe-service-auth-provider/demo.yaml
+++ b/apps/rpe/rpe-service-auth-provider/demo.yaml
@@ -6,4 +6,3 @@ spec:
   releaseName: rpe-service-auth-provider
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/rpts/rpts-api/demo.yaml
+++ b/apps/rpts/rpts-api/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         ORDINANCE_SURVEY_KEY: todo

--- a/apps/sscs/sscs-bulk-scan/demo.yaml
+++ b/apps/sscs/sscs-bulk-scan/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-87dea06-20230327120627 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}
       keyVaults:
         sscs-bulk-scan:

--- a/apps/sscs/sscs-ccd-callback-orchestrator/demo.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       replicas: 2
-      ingressClass: traefik-private
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/ccd-callback-orchestrator:prod-b2d4427-20230323164427 #{"$imagepolicy": "flux-system:sscs-ccd-callback-orchestrator"}
       environment:

--- a/apps/sscs/sscs-evidence-share/demo.yaml
+++ b/apps/sscs/sscs-evidence-share/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/sscs/evidence-share:prod-bef61b1-20230322102610 #{"$imagepolicy": "flux-system:sscs-evidence-share"}
       environment:
         ROBOTICS_EMAIL_TO: venkata.akepati@hmcts.net

--- a/apps/sscs/sscs-hearings-api/demo.yaml
+++ b/apps/sscs/sscs-hearings-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/sscs/hearings-api:prod-31a6c6d-20230329124404 #{"$imagepolicy": "flux-system:sscs-hearings-api"}
       environment:
         TRIBUNALS_HEARINGS_LISTENING_ENABLED: true

--- a/apps/sscs/sscs-tribunals-api/demo.yaml
+++ b/apps/sscs/sscs-tribunals-api/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       aadIdentityName: sscs
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-59eb5ff-20230330120337 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       environment:

--- a/apps/sscs/sscs-tribunals-api/ithc.yaml
+++ b/apps/sscs/sscs-tribunals-api/ithc.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-59eb5ff-20230330120337 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       aadIdentityName: sscs
       environment:

--- a/apps/sscs/sscs-tya-notif/demo.yaml
+++ b/apps/sscs/sscs-tya-notif/demo.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
-      ingressClass: traefik-private
       replicas: 2
       enableOAuth: true
       useInterpodAntiAffinity: true

--- a/apps/ts/ts-translation-service-int/demo.yaml
+++ b/apps/ts/ts-translation-service-int/demo.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/ts/translation-service:prod-da253b7-20230328190559 #{"$imagepolicy": "flux-system:ts-translation-service"}
-      ingressClass: traefik-private

--- a/apps/ts/ts-translation-service/demo.yaml
+++ b/apps/ts/ts-translation-service/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private

--- a/apps/wa/wa-case-event-handler/demo.yaml
+++ b/apps/wa/wa-case-event-handler/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/wa/case-event-handler:prod-2a0ca4d-20230322123455 #{"$imagepolicy": "flux-system:wa-case-event-handler"}
-      ingressClass: traefik-private
       environment:
         AZURE_SERVICE_BUS_FEATURE_TOGGLE: true
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG

--- a/apps/wa/wa-task-management-api/demo.yaml
+++ b/apps/wa/wa-task-management-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG
         LOGGING_LEVEL_ORG_HIBERNATE_SQL: DEBUG

--- a/apps/wa/wa-task-monitor/demo.yaml
+++ b/apps/wa/wa-task-monitor/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG

--- a/apps/wa/wa-workflow-api/demo.yaml
+++ b/apps/wa/wa-workflow-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      ingressClass: traefik-private
       environment:
         REFRESH_FLAG: ""
         LOGGING_LEVEL_UK_GOV_HMCTS: DEBUG


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12618

This change:
- Removes different ingress classes from demo - default is `traefik` which is inherited by apps from the base charts. These were only used to determine DNS record IP addresses, which is now being managed elsewhere and not by external dns
- Goes in before these ingress classes are removed by https://github.com/hmcts/cnp-flux-config/pull/21996




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
