### PR TITLE
remove image version tag Neuvector - AAT

### DIFF
--- a/apps/neuvector/neuvector/aat/aat.yaml
+++ b/apps/neuvector/neuvector/aat/aat.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   values:
     neuvector:
-      tag: 5.1.1
       cve:
         scanner:
           image:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12488


### Change description ###

remove the image version tag from flux config so image version is controlled by upstream chart. As flux config points to specific release version of chart-neuvector then the release version used will determine the image version deployed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
