### PR TITLE
Add build monitor for civil-sdt repositories

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -292,6 +292,12 @@ spec:
                     title: Civil Data Dashboard
                 - buildMonitor:
                     includeRegex: >-
+                      ^HMCTS.*\/civil-sdt.*\/master
+                    name: Civil-SDT
+                    recurse: true
+                    title: Civil SDT Dashboard
+                - buildMonitor:
+                    includeRegex: >-
                       ^HMCTS.*\/wa-.+\/master
                     name: WA
                     recurse: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Updated jenkins.yaml to add a build monitor for the civil-sdt repositories.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
