### PR TITLE
Http ingress listener with redirect middleware - neuvector aat-00

### DIFF
--- a/apps/neuvector/aat/00/neuvector-redirect.yaml
+++ b/apps/neuvector/aat/00/neuvector-redirect.yaml
@@ -1,4 +1,25 @@
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: neuvector-neuvectorredirect@kubernetescrd
+  name: neuvector-redirect-ingress
+  namespace: neuvector
+spec:
+  rules:
+    - host: cft-neuvector00.aat.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: neuvector-service-webui
+                port:
+                  number: 8443
+            path: /
+            pathType: ImplementationSpecific
+---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:

--- a/apps/neuvector/neuvector/aat/00.yaml
+++ b/apps/neuvector/neuvector/aat/00.yaml
@@ -78,4 +78,3 @@ spec:
           annotations:
             kubernetes.io/ingress.class: traefik
             traefik.ingress.kubernetes.io/router.tls: "true"
-            traefik.ingress.kubernetes.io/router.middlewares: neuvector-neuvectorredirect@kubernetescrd


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12488


### Change description ###

add the port 80 ingress listener and attach middleware redirect. Remove middleware incorrectly assigned to 443 listener configured in Helm Release through annotations


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
