### PR TITLE
DTSPO-2473 Set preview sub id to sbox on sbox

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -72,6 +72,8 @@ spec:
                         value: cft-sbox-01-rg
                       - key: AKS_PREVIEW_SUBSCRIPTION_NAME
                         value: DCD-CFTAPPS-SBOX
+                      - key: AKS_PREVIEW_SUBSCRIPTION_ID
+                        value: b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb
                       - key: AKS_AAT_SUBSCRIPTION_NAME
                         value: DCD-CFTAPPS-SBOX
                       - key: AAT_AKS_KEY_VAULT


### PR DESCRIPTION
I was very confused in https://sandbox-build.platform.hmcts.net/job/HMCTS_a_to_c_Sandbox/job/camunda-shared-infrastructure/job/elastic-cloud/12/console trying to see why it was picking up the preview subscription ID.

turns out the name is overridden from preview to sandbox, so the find method finds the preview subscription...