### PR TITLE
Migrate CFT Neuvector ITHC env to https, new domain with http redirect

### DIFF
--- a/apps/neuvector/aat/01/kustomization.yaml
+++ b/apps/neuvector/aat/01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../base/neuvector-redirect-ingress.yaml
 
 patchesStrategicMerge:
-  - ../../neuvector/aat/01.yaml
+  - ../../aat/00/neuvector-redirect-ingress.yaml

--- a/apps/neuvector/aat/01/neuvector-redirect-ingress.yaml
+++ b/apps/neuvector/aat/01/neuvector-redirect-ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: neuvector-redirect-ingress
+  namespace: neuvector
+spec:
+  rules:
+    - host: cft-neuvector01.aat.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: neuvector-service-webui
+                port:
+                  number: 8443
+            path: /
+            pathType: ImplementationSpecific

--- a/apps/neuvector/ithc/00/kustomization.yaml
+++ b/apps/neuvector/ithc/00/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../base/neuvector-redirect-ingress.yaml
 
 patchesStrategicMerge:
-  - ../../neuvector/ithc/00.yaml
+  - ../../ithc/00/neuvector-redirect-ingress.yaml

--- a/apps/neuvector/ithc/00/neuvector-redirect-ingress.yaml
+++ b/apps/neuvector/ithc/00/neuvector-redirect-ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: neuvector-redirect-ingress
+  namespace: neuvector
+spec:
+  rules:
+    - host: cft-neuvector00.ithc.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: neuvector-service-webui
+                port:
+                  number: 8443
+            path: /
+            pathType: ImplementationSpecific

--- a/apps/neuvector/ithc/01/kustomization.yaml
+++ b/apps/neuvector/ithc/01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../base/neuvector-redirect-ingress.yaml
 
 patchesStrategicMerge:
-  - ../../neuvector/ithc/01.yaml
+  - ../../ithc/01/neuvector-redirect-ingress.yaml

--- a/apps/neuvector/ithc/01/neuvector-redirect-ingress.yaml
+++ b/apps/neuvector/ithc/01/neuvector-redirect-ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: neuvector-redirect-ingress
+  namespace: neuvector
+spec:
+  rules:
+    - host: cft-neuvector01.ithc.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: neuvector-service-webui
+                port:
+                  number: 8443
+            path: /
+            pathType: ImplementationSpecific

--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -12,7 +12,15 @@ spec:
           secretName: nv-storage-secret
           shareName: neuvector-data-00
         ingress:
-          host: neuvector00-api.service.core-compute-ithc.internal
+          host: cft-neuvector00-api.ithc.platform.hmcts.net
+          enabled: true
+          path: "/"
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/router.tls: "true"
+        apisvc:
+          annotations:
+            traefik.ingress.kubernetes.io/service.serversscheme: https
         configmap:
           data:
             samlinitcfg.yaml: |
@@ -55,4 +63,8 @@ spec:
               Cluster_Name: ithc00
       manager:
         ingress:
-          host: neuvector00.service.core-compute-ithc.internal
+          host: cft-neuvector00.ithc.platform.hmcts.net
+          enabled: true
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/router.tls: "true"

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -12,7 +12,15 @@ spec:
           secretName: nv-storage-secret
           shareName: neuvector-data-01
         ingress:
-          host: neuvector01-api.service.core-compute-ithc.internal
+          host: cft-neuvector01-api.ithc.platform.hmcts.net
+          enabled: true
+          path: "/"
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/router.tls: "true"
+        apisvc:
+          annotations:
+            traefik.ingress.kubernetes.io/service.serversscheme: https
         configmap:
           data:
             samlinitcfg.yaml: |
@@ -55,4 +63,8 @@ spec:
               Cluster_Name: ithc01
       manager:
         ingress:
-          host: neuvector01.service.core-compute-ithc.internal
+          host: cft-neuvector01.ithc.platform.hmcts.net
+          enabled: true
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/router.tls: "true"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12488


### Change description ###

* Change host values for CFT Nuevector ITHC to _ithc.platform.hmcts.net_ domain
* add CFT Neuvector ITHC redirect ingress router and attach redirect middleware


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
