### PR TITLE
CFT Neuvector Perftest - Move domain, implement generic http redirect

### DIFF
--- a/apps/neuvector/neuvector/perftest/00.yaml
+++ b/apps/neuvector/neuvector/perftest/00.yaml
@@ -12,7 +12,15 @@ spec:
           secretName: nv-storage-secret
           shareName: neuvector-data-00
         ingress:
-          host: neuvector00-api.service.core-compute-perftest.internal
+          host: cft-neuvector00-api.perftest.platform.hmcts.net
+          enabled: true
+          path: "/"
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/router.tls: "true"
+        apisvc:
+          annotations:
+            traefik.ingress.kubernetes.io/service.serversscheme: https
         configmap:
           data:
             samlinitcfg.yaml: |
@@ -55,4 +63,8 @@ spec:
               Cluster_Name: perftest00
       manager:
         ingress:
-          host: neuvector00.service.core-compute-perftest.internal
+          host: cft-neuvector00-api.perftest.platform.hmcts.net
+          enabled: true
+          annotations:
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            kubernetes.io/ingress.class: traefik

--- a/apps/neuvector/neuvector/perftest/01.yaml
+++ b/apps/neuvector/neuvector/perftest/01.yaml
@@ -12,7 +12,15 @@ spec:
           secretName: nv-storage-secret
           shareName: neuvector-data-01
         ingress:
-          host: neuvector01-api.service.core-compute-perftest.internal
+          host: cft-neuvector01-api.perftest.platform.hmcts.net
+          enabled: true
+          path: "/"
+          annotations:
+            kubernetes.io/ingress.class: traefik
+            traefik.ingress.kubernetes.io/router.tls: "true"
+        apisvc:
+          annotations:
+            traefik.ingress.kubernetes.io/service.serversscheme: https
         configmap:
           data:
             samlinitcfg.yaml: |
@@ -55,4 +63,8 @@ spec:
               Cluster_Name: perftest01
       manager:
         ingress:
-          host: neuvector01.service.core-compute-perftest.internal
+          host: cft-neuvector01.perftest.platform.hmcts.net
+          enabled: true
+          annotations:
+            traefik.ingress.kubernetes.io/router.tls: "true"
+            kubernetes.io/ingress.class: traefik

--- a/apps/neuvector/perftest/00/kustomization.yaml
+++ b/apps/neuvector/perftest/00/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../base/neuvector-redirect-ingress.yaml
 
 patchesStrategicMerge:
   - ../../neuvector/perftest/00.yaml
+  - ../../perftest/00/neuvector-redirect-ingress.yaml

--- a/apps/neuvector/perftest/00/neuvector-redirect-ingress.yaml
+++ b/apps/neuvector/perftest/00/neuvector-redirect-ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: neuvector-redirect-ingress
+  namespace: neuvector
+spec:
+  rules:
+    - host: cft-neuvector00.perftest.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: neuvector-service-webui
+                port:
+                  number: 8443
+            path: /
+            pathType: ImplementationSpecific

--- a/apps/neuvector/perftest/01/kustomization.yaml
+++ b/apps/neuvector/perftest/01/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../../base/neuvector-redirect-ingress.yaml
 
 patchesStrategicMerge:
   - ../../neuvector/perftest/01.yaml
+  - ../../perftest/01/neuvector-redirect-ingress.yaml

--- a/apps/neuvector/perftest/01/neuvector-redirect-ingress.yaml
+++ b/apps/neuvector/perftest/01/neuvector-redirect-ingress.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: neuvector-redirect-ingress
+  namespace: neuvector
+spec:
+  rules:
+    - host: cft-neuvector01.perftest.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: neuvector-service-webui
+                port:
+                  number: 8443
+            path: /
+            pathType: ImplementationSpecific


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-13348


### Change description ###

* change domain to _perftest.platform.hmcts.net_
* implement the generic middleware/ingress for the http->https redirect


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
