### PR TITLE
AM-2730 enable civil_wa_1_1 DB flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -8,4 +8,4 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: iac_wa_1_2
+        DB_FEATURE_FLAG_ENABLE: civil_wa_1_1


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [AM-2730](https://tools.hmcts.net/jira/browse/AM-2730) _"Prod Civil role issue - Any user with a team leader role does not inherit the permissions of the staff role that it has responsibility for"_

### Change description ###

Enable `civil_wa_1_1` DB flag in Demo, see hmcts/am-org-role-mapping-service#1426.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
