### PR TITLE
Latest IDAM prod images to non-prod

### DIFF
--- a/apps/idam/idam-api/aat.yaml
+++ b/apps/idam/idam-api/aat.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-6ed31fd-20230324162715
+      image: hmctspublic.azurecr.io/idam/api:prod-0880243-20230418174922
       ingressHost: idam-api.aat.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-6ed31fd-20230324162715
+      image: hmctspublic.azurecr.io/idam/api:prod-0880243-20230418174922
       ingressHost: idam-api.demo.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-api/ithc.yaml
+++ b/apps/idam/idam-api/ithc.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-6ed31fd-20230324162715
+      image: hmctspublic.azurecr.io/idam/api:prod-0880243-20230418174922
       ingressHost: idam-api.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-api/perftest.yaml
+++ b/apps/idam/idam-api/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-6ed31fd-20230324162715
+      image: hmctspublic.azurecr.io/idam/api:prod-0880243-20230418174922
       ingressHost: idam-api.perftest.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-6ed31fd-20230324162715
+      image: hmctspublic.azurecr.io/idam/api:prod-0880243-20230418174922
       ingressHost: idam-api.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 4

--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f35245a-20230327152200
+      image: hmctspublic.azurecr.io/idam/web-public:prod-603dc78-20230418095139
       ingressHost: idam-web-public.aat.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f35245a-20230327152200
+      image: hmctspublic.azurecr.io/idam/web-public:prod-603dc78-20230418095139
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.demo.platform.hmcts.net

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f35245a-20230327152200
+      image: hmctspublic.azurecr.io/idam/web-public:prod-603dc78-20230418095139
       ingressHost: idam-web-public.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f35245a-20230327152200
+      image: hmctspublic.azurecr.io/idam/web-public:prod-603dc78-20230418095139
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.perftest.platform.hmcts.net

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f35245a-20230327152200
+      image: hmctspublic.azurecr.io/idam/web-public:prod-603dc78-20230418095139
       ingressHost: idam-web-public.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 2


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
Changes driven by Platops work:
* using base java image "java:11-distroless"
* removed security.sh file


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
