### PR TITLE
DTSPO-12663 Update aso sbox to use DCD-CFT-Sandbox sub

### DIFF
--- a/apps/azureserviceoperator-system/sbox/aso-controller-settings.yaml
+++ b/apps/azureserviceoperator-system/sbox/aso-controller-settings.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-  AZURE_CLIENT_ID: ENC[AES256_GCM,data:Inx3FyTfk2tpNEuR+85oAz8IOd/qafrmyk2wCR1oEtqYS2bNwkuxc1NweIPtnPdV,iv:rVJjHxGazWUcQXzwhsI/KA+p9Q5ER3uVqM3+i3mWXS0=,tag:R9SkMEygQMx8ctVcla4d6w==,type:str]
-  AZURE_SUBSCRIPTION_ID: ENC[AES256_GCM,data:NOw4vOgB/EhL+W/Rj/1LmwavPOysLgMjHom1nmDEyU/wTi05E+7GlTlM12Og3wWg,iv:xK1ImrOz/Bk6VVYNoxUg9oR4VgNP6Npc3G7BNtw+ZEg=,tag:TBhp/RTX0Hv5mwpanqdBsQ==,type:str]
-  AZURE_TENANT_ID: ENC[AES256_GCM,data:K6TVNHIgAR38GOp7/gstVBVC8DS8RwsUotsbVGTZ1/v/x2Ui+VcoIN6tVU7gT9oH,iv:QAfGbNSGoq5d/LPyzjYz5i1z3aeUSSNimEmhrvcjSUw=,tag:egM3TdVE2lRwfHg/GM2Mcg==,type:str]
+  AZURE_CLIENT_ID: ENC[AES256_GCM,data:Rg5eyJIy4mCNP/B7GNGS0a9udUrj1rbxEuFiTXzHrMHK7Jem0lkv+k3qyOvZnC5w,iv:7c/JGEDkY60xy9h81vK0oYTUOuVy+N+00BIkSPzDZfM=,tag:TYzley3x7fZMOpjSI7xWcQ==,type:str]
+  AZURE_SUBSCRIPTION_ID: ENC[AES256_GCM,data:KCcBWM13Z1gsxAf2FiowAgGfp+0Yx5n4cUlTYql+iXmYbbwb2yzDz/L2zZUFGUbL,iv:akqKdZKWbqZvOYVOX1B9KUqNBe4IRtABWwlrZNf6aMs=,tag:K2bzZFLhpUifYndFjHEfHQ==,type:str]
+  AZURE_TENANT_ID: ENC[AES256_GCM,data:Q3COzmbhAZwo5hxmHN7vHYe0tYHJnFAESbrs4oMpFOuqmFHDukzTBg5IbV79vOWN,iv:RFjEs5QOEFskUi1bPX0moLWof+N9UNR5n1jSzigd0Us=,tag:Nc8Hw7V3tQZ0uJIOyw7Z9w==,type:str]
 kind: Secret
 metadata:
   name: aso-controller-settings
@@ -15,12 +15,12 @@ sops:
     - vault_url: https://dcdcftappssboxkv.vault.azure.net
       name: sops-key
       version: 4dfa9dd4b0444f03bd64e2128e347537
-      created_at: "2023-02-13T17:57:36Z"
-      enc: A1FRzO7kgqrmWxPOsx9LQ6Ha__UJkyJUGgmlGEOKF8I1kee3NqpgfB5GEo-lBH3JxmNnSjHb9nmob4y5Fzrqoan59HBGFNGSFniDSIobk_-CKh8Kt141xQ6zMD-nCn1SL7zZhlhZW1BsMagK2g89nXCq-jEDWgByPRboxUP1fZ31He-khWX1VJIlSfABqbHzz-N3u1LRFQcTfFH3ClsEUp6RohpWGCA3sj08b335k16JGnYJOR6TvtrmDlNLnsye52k07eqH8eaYAaaUhIU6afUUbpjA9SAByX3ucVg55wfUawqQNkhcZL-9BRCO3S_nRvtZAcUpSnPUImuvXTD-PA
+      created_at: "2023-04-19T11:28:31Z"
+      enc: rrYBWtzZxaan7pHlyf829QpYbz2JtzYgra8wkXdKw6PYRnZ2YTIXNgcNtoQHCy5LtYN4PU8w03kJk7Ko2kHKaQOSVTF1a0ckJqI-sSnldzOLFHUNP5Ng2aE8avJ_NoaZ-YGxQ307hO6Tu8HUN0aPdy_fUjznczR9mVmmfqTg66osTB_KtVQhEp5IHpn3M_YaoIcl74ZmVdKgsxwzBPqhX4FXHPKBrkG8531fchOSAp2XPOiPgpEAZY2G8ZaqHaYUCoBBRGB5bFGMF_NPyKkaUpU91WkvkTxa2iMQiEYx7zSi4oUjp2B8k1-qEQmwZYWzbfs2DflB2MJshRHNQUxcIQ
   hc_vault: []
   age: []
-  lastmodified: "2023-02-13T17:57:36Z"
-  mac: ENC[AES256_GCM,data:zwEMA3XYIEc+iHoM7XjjEnPqrdSfIHX21k5MzVdf7ZL9RyTyOgD5XUbqaEITeYdiUdV17utBeKUcYOtEMyrJb/v2DwqgibWbkh6sFx6946e4bda0kzERWY91DCAESU/YJb6Who42TOAahxFtCCAbf0TnpOIm8MyICz8wqeHbqUo=,iv:Kd7b/aPLN869wj+BCuZipHnqaI4cL9km2FkzMNoTLj8=,tag:CZyATjrdcNf2q2alBYmsVg==,type:str]
+  lastmodified: "2023-04-19T11:28:32Z"
+  mac: ENC[AES256_GCM,data:wvo0P25MjvfKv84qKddntVWoNTkpoB/1uTOQKmUzc5R1nrEl+lv8Y2N7bGfH6WYLGatczuGRcxkTE/CQ73BnPMF4tqG75zb51lq+Ord6RCV1zdi+IYPvXxPuHd7tEbd56ew0wGY3KnVWvXK9rnh6KGArT/hPle2eyVAINQbN+R8=,iv:ZliBEBaM+qR13k7iQqlpwnZS1cSTjQ28Vllv2oq8zvs=,tag:34tMtMsa1KCBpVNzChx1Bw==,type:str]
   pgp: []
   encrypted_regex: ^(data|stringData)$
   version: 3.7.3


### PR DESCRIPTION
Testing feasibility of using ASO for workload identity migration, ASO is already running in sbox but is pointed to CFTAPPS subscription



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
