### PR TITLE
DTSPO-13245 removing test access for postgres flexserver sbox

### DIFF
--- a/apps/cnp/plum-recipe-backend/sbox.yaml
+++ b/apps/cnp/plum-recipe-backend/sbox.yaml
@@ -6,14 +6,3 @@ spec:
   values:
     java:
       ingressHost: plum-recipe-backend.service.core-compute-sandbox.internal
-      keyVaults:
-        "plumsi":
-          secrets:
-            - name: recipe-backend-POSTGRES-DATABASE-v14
-              alias: POSTGRES_DATABASE
-            - name: recipe-backend-POSTGRES-HOST-v14
-              alias: POSTGRES_HOST
-            - name: recipe-backend-POSTGRES-USER-v14
-              alias: POSTGRES_USER
-            - name: recipe-backend-POSTGRES-PASS-v14
-              alias: POSTGRES_PASSWORD


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSPO-13245](https://tools.hmcts.net/jira/browse/DTSPO-13245)

### Change description ###

removing test as chart is being updated to affect all environments.  https://github.com/hmcts/cnp-plum-recipes-service/compare/master...DTSPO-13245-Updating-access-to-postgres-flexserver?quick_pull=1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
