### PR TITLE
Try using quotes

### DIFF
--- a/apps/cnp/base/kustomize.yaml
+++ b/apps/cnp/base/kustomize.yaml
@@ -8,5 +8,5 @@ spec:
   postBuild:
     substitute:
       NAMESPACE: "cnp"
-      ISSUER_URL: ${ISSUER_URL}
+      ISSUER_URL: "${ISSUER_URL}"
       TEAM_NOTIFICATION_CHANNEL: "platops-build-notices"


### PR DESCRIPTION
```
Kustomization/flux-system/cnp dry-run failed, reason: Invalid, error: Kustomization.kustomize.toolkit.fluxcd.io "cnp" is invalid: spec.postBuild.substitute.ISSUER_URL: Invalid value: "null": spec.postBuild.substitute.ISSUER_URL in body must be of type string: "null"
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
