### PR TITLE
Fixing the memory request for docmosis

### DIFF
--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -4,6 +4,7 @@ metadata:
   name: docmosis
 spec:
   values:
-    memoryRequests: "2Gi"
     ingressHost: docmosis.perftest.platform.hmcts.net
     image: hmctsprivate.azurecr.io/docmosis:perftest-5290174-370269 #{"$imagepolicy": "flux-system:perftest-docmosis"}
+    java:
+      memoryRequests: '2Gi'

--- a/apps/docmosis/docmosis/prod.yaml
+++ b/apps/docmosis/docmosis/prod.yaml
@@ -6,3 +6,5 @@ spec:
   values:
     memoryRequests: "2Gi"
     ingressHost: docmosis.platform.hmcts.net
+    java:
+      memoryRequests: '2Gi'


### PR DESCRIPTION
Setting at the right level to work with base chart.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
