### PR TITLE
add labels service-account identity

### DIFF
--- a/apps/base/service-account.yaml
+++ b/apps/base/service-account.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    meta.helm.sh/release-name: ${NAMESPACE}
+    meta.helm.sh/release-namespace: ${NAMESPACE}

--- a/apps/base/service-account.yaml
+++ b/apps/base/service-account.yaml
@@ -3,7 +3,8 @@ kind: ServiceAccount
 metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
-  labels:
-    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  annotations:
     meta.helm.sh/release-name: ${NAMESPACE}
     meta.helm.sh/release-namespace: ${NAMESPACE}
+  labels:
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"


### PR DESCRIPTION
### Change description ###

- add labels to service-account to pilot fix for errors to jenkins & kured in ptlsbox since rebuilt

error:

`Helm install failed: rendered manifests contain a resource that already exists. Unable to continue with install: ServiceAccount "jenkins" in namespace "jenkins" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "jenkins"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "jenkins"...`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
