### PR TITLE
CFT PTLSBOX - Jenkins: explicitly set serviceaccount, disable creation by chart

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   values:
     checkDeprecation: false
+    serviceAccount:
+      create: false
+      name: jenkins
     controller:
       tag: 2.400-387
       javaOpts: >-


### PR DESCRIPTION
### Change description ###

- disable creation of new service account through chart for jenkins namespace
- explicitly set to new base serviceaccount for namespace instead


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
