### PR TITLE
adding yamllint.yaml comments.min-spaces-from-content

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -9,6 +9,7 @@ rules:
   empty-lines:
     max: 1
   comments:
+    level: error
     min-spaces-from-content: 1
     require-starting-space: false
   indentation:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -9,6 +9,7 @@ rules:
   empty-lines:
     max: 1
   comments:
+    min-spaces-from-content: 1
     require-starting-space: false
   indentation:
     indent-sequences: consistent


### PR DESCRIPTION
### Change description ###
Removes the spam in logs:
```
Run ./tests/lint-yaml.sh
+ yamllint . -c .yamllint.yaml
./apps/backstage/backstage/backstage.yaml
  Warning: 15:80 [comments] too few spaces before comment
```

- Also move to error to allow pipeline to break if comment not correct.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
