### PR TITLE
Revert "CFT PTLSBOX - Jenkins: explicitly set serviceaccount, disable creation by chart"

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   values:
     checkDeprecation: false
-    serviceAccount:
-      create: false
-      name: jenkins
     controller:
       tag: 2.400-387
       javaOpts: >-


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#22407

- reverting the additional values spec so that it can be re-added to test if it causes a restart of jenkins