### PR TITLE
CFT PTLSBOX - Kured & Jenkins: remove name parameter from serviceaccount values

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: jenkins
 spec:
   values:
+    serviceAccount:
+      create: false
     checkDeprecation: false
     controller:
       tag: 2.400-387

--- a/apps/kured/sbox-intsvc/base/kured.yaml
+++ b/apps/kured/sbox-intsvc/base/kured.yaml
@@ -8,4 +8,3 @@ spec:
   values:
     serviceAccount:
       create: false
-      name: kured


### PR DESCRIPTION
### Change description ###

- remove the 'name' parameter from serviceAccount values for cft-ptlsbox to test if needed or not (it should use chart fullname by default and find the existing serviceAccount)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
