### PR TITLE
DTSPO-12662 Workload Identity Resources are not tagged

### DIFF
--- a/apps/base/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/base/workload-identity/workload-identity-ua-identity.yaml
@@ -6,6 +6,11 @@ metadata:
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
+  tags:
+    builtFrom: https://github.com/hmcts/cnp-flux-config
+    businessArea: CFT
+    environment: ${WI_ENVIRONMENT}
+    application: core
   location: uksouth
   owner:
     name: managed-identities-${WI_ENVIRONMENT}-rg

--- a/apps/base/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/base/workload-identity/workload-identity-ua-identity.yaml
@@ -4,13 +4,8 @@ metadata:
   name: ${NAMESPACE}-${WI_ENVIRONMENT}-mi
   namespace: ${NAMESPACE}
   annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+    serviceoperator.azure.com/reconcile-policy: skip
 spec:
-  tags:
-    builtFrom: https://github.com/hmcts/cnp-flux-config
-    businessArea: CFT
-    environment: ${WI_ENVIRONMENT}
-    application: core
   location: uksouth
   owner:
     name: managed-identities-${WI_ENVIRONMENT}-rg


### PR DESCRIPTION
Pods are giving errors that UA resource does not fit our tagging policy. Not sure how/why this isn't showing for resource group either. Will try and test after this if tags defined in flux are merged with existing azure tags, or if existing azure tags are overridden.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
