### PR TITLE
Add yq and remove static bash

### DIFF
--- a/tests/static-file-checks.sh
+++ b/tests/static-file-checks.sh
@@ -2,11 +2,11 @@
 
 # Script to check if apiVersion is present in all yaml files in apps/
 
-# for FILE in $(find apps/* -type f -name "*.yaml"); do
+for FILE in $(find apps/* -type f -name "*.yaml"); do
 
     if [ $(yq eval '.apiVersion' $FILE -N) == "test" ]
     then
         echo "apiVersion: missing in $FILE" && exit 1
     fi
 
-# done
+done

--- a/tests/static-file-checks.sh
+++ b/tests/static-file-checks.sh
@@ -2,11 +2,11 @@
 
 # Script to check if apiVersion is present in all yaml files in apps/
 
-for FILE in $(find apps/* -type f -name "*.yaml"); do
+# for FILE in $(find apps/* -type f -name "*.yaml"); do
 
-    if [ $(yq eval '.apiVersion' $FILE) = null ]
+    if [ $(yq eval '.apiVersion' $FILE -N) == "test" ]
     then
         echo "apiVersion: missing in $FILE" && exit 1
     fi
 
-done
+# done

--- a/tests/static-file-checks.sh
+++ b/tests/static-file-checks.sh
@@ -3,8 +3,10 @@
 # Script to check if apiVersion is present in all yaml files in apps/
 
 for FILE in $(find apps/* -type f -name "*.yaml"); do
-
-    if [ $(yq eval '.apiVersion' $FILE -N) == "test" ]
+    
+    API_VERSION_CHECK=$(yq eval -N '.apiVersion' $FILE -N)
+    
+    if [ "$API_VERSION_CHECK" == "null" ]
     then
         echo "apiVersion: missing in $FILE" && exit 1
     fi

--- a/tests/static-file-checks.sh
+++ b/tests/static-file-checks.sh
@@ -4,8 +4,9 @@
 
 for FILE in $(find apps/* -type f -name "*.yaml"); do
 
-    if [[ ! $(grep -E "apiVersion:" $FILE) ]]
+    if [ $(yq eval '.apiVersion' $FILE) = null ]
     then
         echo "apiVersion: missing in $FILE" && exit 1
     fi
+
 done


### PR DESCRIPTION
### Change description ###
Add yq and remove static bash

-n required
`  -N, --no-doc                        Don't print document separators (---)`

without error appesrs:
`./tests/static-file-checks.sh: line 7: [: syntax error: `---' unexpected`

Moving command to variable to mitigate error:
`-bash: [: too many arguments`



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
