### PR TITLE
Add policy back in, pointed at prod image

### DIFF
--- a/apps/et/et-sya/demo-image-policy.yaml
+++ b/apps/et/et-sya/demo-image-policy.yaml
@@ -11,6 +11,5 @@ spec:
   policy:
     alphabetical:
       order: asc
-spec:
   imageRepositoryRef:
     name: et-sya

--- a/apps/et/et-sya/demo-image-policy.yaml
+++ b/apps/et/et-sya/demo-image-policy.yaml
@@ -5,5 +5,12 @@ metadata:
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+spec:
   imageRepositoryRef:
     name: et-sya


### PR DESCRIPTION
ReconciliationFailed         kustomization/flux-system                                                    ImagePolicy/flux-system/demo-et-sya dry-run failed, reason: Invalid, error: ImagePolicy.image.toolkit.fluxcd.io "demo-et-sya" is invalid: spec.policy: Required value 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
