### PR TITLE
Adds datasource to grafana for sds ithc prom and alertmanager

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/ptl-intsvc/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ptl-intsvc/00.yaml
@@ -144,6 +144,22 @@ spec:
           type: camptocamp-prometheus-alertmanager-datasource
           url: https://sds-alertmanager-01.test.platform.hmcts.net
           access: proxy
+        - name: sds-prometheus-ithc-00
+          type: prometheus
+          url: https://sds-prometheus-00.ithc.platform.hmcts.net
+          access: proxy
+        - name: sds-alertmanager-ithc-00
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: https://sds-alertmanager-00.ithc.platform.hmcts.net
+          access: proxy
+        - name: sds-prometheus-ithc-01
+          type: prometheus
+          url: https://sds-prometheus-01.ithc.platform.hmcts.net
+          access: proxy
+        - name: sds-alertmanager-ithc-01
+          type: camptocamp-prometheus-alertmanager-datasource
+          url: https://sds-alertmanager-01.ithc.platform.hmcts.net
+          access: proxy
         - name: sds-prometheus-stg-00
           type: prometheus
           url: https://sds-prometheus-00.stg.platform.hmcts.net


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-11262

### Change description ###

Adds datasource to grafana for sds ithc prom and alertmanager

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
