### PR TITLE
Add missing image policy

### DIFF
--- a/apps/sscs/sscs-tribunals-frontend/image-policy.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/image-policy.yaml
@@ -7,3 +7,6 @@ metadata:
 spec:
   imageRepositoryRef:
     name: sscs-tribunals-frontend
+  policy:
+    alphabetical:
+      order: asc


### PR DESCRIPTION
### Change description ###
Add missing image policy

Error in flux-system on PTL
`  Warning  ReconciliationFailed  5m34s (x5642 over 5d16h)  kustomize-controller  ImagePolicy/flux-system/sscs-tribunals-frontend dry-run failed, reason: Invalid, error: ImagePolicy.image.toolkit.fluxcd.io "sscs-tribunals-frontend" is invalid: spec.policy: Required value`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
