### PR TITLE
fix flux-system errors in PTL image automation

### DIFF
--- a/apps/money-claims/cmc-claim-store/demo-image-policy.yaml
+++ b/apps/money-claims/cmc-claim-store/demo-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-cmc-claim-store

--- a/apps/probate/probate-cron-hmrc-extract/image-policy.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/image-repo.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1alpha2
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImageRepository
 metadata:
   name: probate-cron-hmrc-extract


### PR DESCRIPTION
### Change description ###
fix flux-system errors in PTL image automation kustomize
`flux-system 126d False ImagePolicy/flux-system/demo-cmc-claim-store dry-run failed, error: no matches for kind "ImagePolicy" in version "[image.toolkit.fluxcd.io/v1alpha2](http://image.toolkit.fluxcd.io/v1alpha2)"...`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
