### PR TITLE
DTSPO-13692 - update demo/ithc camunda kustomization

### DIFF
--- a/apps/camunda/camunda-api/camunda-api.yaml
+++ b/apps/camunda/camunda-api/camunda-api.yaml
@@ -12,6 +12,17 @@ spec:
       ingressHost: camunda-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
       environment:
         CAMUNDA_API_AUTH_ENABLED: false
+      keyVaults:
+        camunda:
+          secrets:
+            - name: bpm-POSTGRES-PASS
+              alias: spring.datasource.password
+            - name: camunda-admin-password
+              alias: CAMUNDA_ADMIN_PASSWORD
+            - name: s2s-secret-camunda-bpm
+              alias: S2S_SECRET_CAMUNDA_BPM
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
   chart:
     spec:
       chart: ./stable/camunda-bpm

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -6,6 +6,7 @@ spec:
   values:
     java:
       environment:
+        CAMUNDA_DB_HOST: "hmcts-camunda-v14-flexible-{{ .Values.global.environment }}.postgres.database.azure.com"
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         LOGGING_LEVEL_COM_ZAXXER_HIKARI_HIKARICONFIG: DEBUG
         LOGGING_LEVEL_COM_ZAXXER_HIKARI: TRACE

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -7,6 +7,7 @@ spec:
     java:
       environment:
         CAMUNDA_DB_HOST: "hmcts-camunda-v14-flexible-{{ .Values.global.environment }}.postgres.database.azure.com"
+        CAMUNDA_DB_USER_NAME: "camundaadmin"
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         LOGGING_LEVEL_COM_ZAXXER_HIKARI_HIKARICONFIG: DEBUG
         LOGGING_LEVEL_COM_ZAXXER_HIKARI: TRACE

--- a/apps/camunda/camunda-api/ithc.yaml
+++ b/apps/camunda/camunda-api/ithc.yaml
@@ -9,14 +9,3 @@ spec:
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         CAMUNDA_DB_HOST: "hmcts-camunda-v14-flexible-{{ .Values.global.environment }}.postgres.database.azure.com"
         CAMUNDA_DB_USER_NAME: "camundaadmin"
-      keyVaults:
-        camunda:
-          secrets:
-            - name: bpm-v14-POSTGRES-PASS
-              alias: spring.datasource.password
-            - name: camunda-admin-password
-              alias: CAMUNDA_ADMIN_PASSWORD
-            - name: s2s-secret-camunda-bpm
-              alias: S2S_SECRET_CAMUNDA_BPM
-            - name: app-insights-connection-string
-              alias: app-insights-connection-string

--- a/apps/camunda/demo/base/kustomization.yaml
+++ b/apps/camunda/demo/base/kustomization.yaml
@@ -16,6 +16,6 @@ patches:
     patch: |
       - op: replace
         path: /spec/values/java/keyVaults/camunda/secrets/0
-        value: 
+        value:
           name: bpm-v14-POSTGRES-PASS
           alias: spring.datasource.password

--- a/apps/camunda/demo/base/kustomization.yaml
+++ b/apps/camunda/demo/base/kustomization.yaml
@@ -9,3 +9,13 @@ patchesStrategicMerge:
   - ../../camunda-optimize/demo.yaml
   - ../../camunda-api/demo.yaml
   - ../../camunda-ui/demo.yaml
+patches:
+  - target:
+      kind: HelmRelease
+      name: camunda-api
+    patch: |
+      - op: replace
+        path: /spec/values/java/keyVaults/camunda/secrets/0
+        value: 
+          name: bpm-v14-POSTGRES-PASS
+          alias: spring.datasource.password

--- a/apps/camunda/ithc/base/kustomization.yaml
+++ b/apps/camunda/ithc/base/kustomization.yaml
@@ -8,3 +8,13 @@ patchesStrategicMerge:
   - ../../identity/ithc.yaml
   - ../../camunda-optimize/ithc.yaml
   - ../../camunda-api/ithc.yaml
+patches:
+  - target:
+      kind: HelmRelease
+      name: camunda-api
+    patch: |
+      - op: replace
+        path: /spec/values/java/keyVaults/camunda/secrets/0
+        value: 
+          name: bpm-v14-POSTGRES-PASS
+          alias: spring.datasource.password

--- a/apps/camunda/ithc/base/kustomization.yaml
+++ b/apps/camunda/ithc/base/kustomization.yaml
@@ -15,6 +15,6 @@ patches:
     patch: |
       - op: replace
         path: /spec/values/java/keyVaults/camunda/secrets/0
-        value: 
+        value:
           name: bpm-v14-POSTGRES-PASS
           alias: spring.datasource.password


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13692

### Change description ###
Trying to only update postgres pass secret in demo and ithc environments to use password for flexible server.

Currently, the secrets are passed through from the upstream chart but kustomize does not enable you to replace one of these values on its own, instead it replaces the whole secrets object meaning the unaltered secrets like connection string don't get passed through.

Previous [PR](https://github.com/hmcts/cnp-flux-config/commit/764d5bbec7f6785b70fd9be541c7338a1cd86b48) got around this by passing the whole object.

This is a limitation of kustomize. The chart is hosted in a GitRepo so the latest version is always used. A custom chart could be created as an alternative to this method but either way will be reverted once all environments have been migrated to flexible server.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
