### PR TITLE
Flux: move kustomize controller patch to envs kustomization

### DIFF
--- a/apps/flux-system/aat/base/kustomization.yaml
+++ b/apps/flux-system/aat/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/base/kustomization.yaml
+++ b/apps/flux-system/base/kustomization.yaml
@@ -7,5 +7,3 @@ resources:
   - hmctspublic-helmrepo.yaml
   - hmcts-stable-charts-gitrepo.yaml
   - plum-recipe-receiver-gitrepo.yaml
-patchesStrategicMerge:
-  - patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/ithc/base/kustomization.yaml
+++ b/apps/flux-system/ithc/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/perftest/base/kustomization.yaml
+++ b/apps/flux-system/perftest/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/base/kustomization.yaml
+++ b/apps/flux-system/preview/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/prod/base/kustomization.yaml
+++ b/apps/flux-system/prod/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/ptl-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/ptl-intsvc/base/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - aks-sops-aadpodidentity.yaml
 
 patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml
   - ../../base/patches/image-automation-components-patch.yaml

--- a/apps/flux-system/sbox-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/sbox-intsvc/base/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
   - aks-sops-aadpodidentity.yaml
+patchesStrategicMerge:
+  - ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12552


### Change description ###

- Move the kustomise controller patch file into env kustomization.yaml files. Needed to patch gotk-components.yaml which moved to env kustomization.yaml files in earlier PR


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
