### PR TITLE
Update ingress to correct DNS value in ithc,perftest and sbox

### DIFF
--- a/apps/cnp/plum-recipe-backend/ithc.yaml
+++ b/apps/cnp/plum-recipe-backend/ithc.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressHost: plum-recipe-backend.service.core-compute-ithc.internal
+      ingressHost: plum-recipe-backend-ithc.service.core-compute-ithc.internal

--- a/apps/cnp/plum-recipe-backend/perftest.yaml
+++ b/apps/cnp/plum-recipe-backend/perftest.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressHost: plum-recipe-backend.service.core-compute-perftest.internal
+      ingressHost: plum-recipe-backend-perftest.service.core-compute-perftest.internal

--- a/apps/cnp/plum-recipe-backend/sbox.yaml
+++ b/apps/cnp/plum-recipe-backend/sbox.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressHost: plum-recipe-backend.service.core-compute-sandbox.internal
+      ingressHost: plum-recipe-backend-sandbox.service.core-compute-sandbox.internal


### PR DESCRIPTION
Causing plum-recipe-backend urls in these envs to be unreachable as DNS doesn't line up 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
