### PR TITLE
LAU-630 Update jenkins.yaml for disposer-shared-infrastructure

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -268,7 +268,7 @@ spec:
                     title: PCQ
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(lau-.+|.*ccd-case-disposer|.*idam-user-disposer)\/master
+                      ^HMCTS.*\/(lau-.+|.*ccd-case-disposer|.*idam-user-disposer|.*disposer-shared-infrastructure)\/master
                     name: LAU
                     recurse: true
                     title: LAU


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-630


### Change description ###
This change is to get build for disposer-shared-infrastructure on lau Dashboard


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
