### PR TITLE
Update 01 issuer URL

### DIFF
--- a/apps/flux-system/sbox/01/kustomize.yaml
+++ b/apps/flux-system/sbox/01/kustomize.yaml
@@ -10,6 +10,6 @@ spec:
       ENVIRONMENT: "sbox"
       WI_ENVIRONMENT: "sandbox"
       CLUSTER: "01"
-      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/01fc0a5e-9d05-4a25-9430-3995e282a21d/"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/e7e4152a-50e3-49a4-ab3b-4e34a2f7ddf7/"
       ENV_MONITOR_CHANNEL: "aks-monitor-sbox"
       KEYVAULT_ENVIRONMENT: "sandbox"


### PR DESCRIPTION
There's a weird bug where `aks-sbox-mi` is overwriting the federated credential created by 00 cluster with the old oidc issuer url after a certain amount of minutes. This causes an app using workload identity on the 'upgraded' cluster to break.
It seems they're competing with each other as there's only one `plum-fic` federated identity which isn't great, updating this to test and will then look into how we can avoid that



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
