### PR TITLE
Disable ingestion of all CCD JDBC queries into AppInsights

### DIFF
--- a/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
+++ b/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
@@ -14,6 +14,8 @@ spec:
         CCD_MULTIPARTY_CASE_TYPES: "*"
         CCD_MULTIPARTY_EVENTS: "*"
         CCD_MULTIPARTY_LOG_LEVEL: INFO
+        # AppInsights by default captures every sql query which adds up to 10s of GB daily.
+        APPLICATIONINSIGHTS_INSTRUMENTATION_JDBC_ENABLED: false
   chart:
     spec:
       chart: ./stable/ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
+++ b/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
@@ -15,6 +15,7 @@ spec:
         CCD_MULTIPARTY_EVENTS: "*"
         CCD_MULTIPARTY_LOG_LEVEL: INFO
         # AppInsights by default captures every sql query which adds up to 10s of GB daily.
+        # https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-config
         APPLICATIONINSIGHTS_INSTRUMENTATION_JDBC_ENABLED: false
   chart:
     spec:

--- a/apps/ccd/ccd-definition-store-api/ccd-definition-store-api.yaml
+++ b/apps/ccd/ccd-definition-store-api/ccd-definition-store-api.yaml
@@ -11,6 +11,9 @@ spec:
       image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-a32009d-20230608191041 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
       environment:
         DEFINITION_STORE_TX_TIMEOUT_DEFAULT: 120
+        # AppInsights by default captures every sql query which adds up to 10s of GB daily.
+        # https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-config
+        APPLICATIONINSIGHTS_INSTRUMENTATION_JDBC_ENABLED: false
   chart:
     spec:
       chart: ./stable/ccd-definition-store-api


### PR DESCRIPTION
Currently all SQL queries are ingested into the dependencies AppInsights table and incurring ~20GB of ingestion each day. Failed queries will still be captured as exceptions.