### PR TITLE
Update FIC to create one per cluster

### DIFF
--- a/apps/base/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/base/workload-identity/workload-identity-federated-credential.yaml
@@ -1,7 +1,7 @@
 apiVersion: managedidentity.azure.com/v1beta20220131preview
 kind: FederatedIdentityCredential
 metadata:
-  name: ${WI_NAME}-fic
+  name: ${WI_NAME}-${CLUSTER}-fic
   namespace: ${NAMESPACE}
 spec:
   owner:


### PR DESCRIPTION
This is to try and create separate resources per cluster so that we can account for the different oidc issuer urls per cluster


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
