### PR TITLE
Revert "Test latest chart without using WI to test feature flags"

### DIFF
--- a/apps/cnp/plum-recipe-backend/sbox.yaml
+++ b/apps/cnp/plum-recipe-backend/sbox.yaml
@@ -6,5 +6,5 @@ spec:
   values:
     java:
       ingressHost: plum-recipe-backend-sandbox.service.core-compute-sandbox.internal
-#       useWorkloadIdentity: true
-#       workloadClientID: ${WORKLOAD_IDENTITY_ID}
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#23395 -- app runs with and without these flags, so happy with the chart changes