### PR TITLE
SIDM-8770: remove auto deploy to prod for user dashboard

### DIFF
--- a/apps/idam/idam-user-dashboard/idam-user-dashboard.yaml
+++ b/apps/idam/idam-user-dashboard/idam-user-dashboard.yaml
@@ -9,7 +9,7 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/idam/user-dashboard:prod-93e1398-20230620085057 #{"$imagepolicy": "flux-system:idam-user-dashboard"}
+      image: hmctspublic.azurecr.io/idam/user-dashboard:prod-93e1398-20230620085057
   chart:
     spec:
       chart: ./stable/idam-user-dashboard


### PR DESCRIPTION
### JIRA link (if applicable) ###

[SIDM-8770](https://tools.hmcts.net/jira/browse/SIDM-8770)

### Change description ###

Prevent user dashboard being deployed to prod when master pipeline succeeds.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
