### PR TITLE
Disposer ns set in aat

### DIFF
--- a/apps/disposer/aat/base/kustomization.yaml
+++ b/apps/disposer/aat/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
-  - ../../idam-user-disposer/idam-user-disposer.yaml
 namespace: disposer
 patchesStrategicMerge:
   - ../../identity/aat.yaml

--- a/apps/disposer/aat/base/kustomization.yaml
+++ b/apps/disposer/aat/base/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../idam-user-disposer/idam-user-disposer.yaml
+namespace: disposer
 patchesStrategicMerge:
   - ../../identity/aat.yaml

--- a/apps/disposer/base/kustomize.yaml
+++ b/apps/disposer/base/kustomize.yaml
@@ -4,7 +4,8 @@ metadata:
   name: disposer
   namespace: flux-system
 spec:
-  path: ./apps/disposer/${ENVIRONMENT}/base
+  path: ./apps/disposer/${ENVIRONMENT}/${CLUSTER}
+##  path: ./apps/disposer/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "disposer"

--- a/apps/disposer/base/kustomize.yaml
+++ b/apps/disposer/base/kustomize.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: flux-system
 spec:
   path: ./apps/disposer/${ENVIRONMENT}/${CLUSTER}
-##  path: ./apps/disposer/${ENVIRONMENT}/base
   postBuild:
     substitute:
       NAMESPACE: "disposer"

--- a/apps/disposer/demo/base/kustomization.yaml
+++ b/apps/disposer/demo/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
-  - ../../idam-user-disposer/idam-user-disposer.yaml
 namespace: disposer
 patchesStrategicMerge:
   - ../../identity/demo.yaml

--- a/apps/disposer/ithc/base/kustomization.yaml
+++ b/apps/disposer/ithc/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
-  - ../../idam-user-disposer/idam-user-disposer.yaml
 namespace: disposer
 patchesStrategicMerge:
   - ../../identity/ithc.yaml

--- a/apps/disposer/perftest/base/kustomization.yaml
+++ b/apps/disposer/perftest/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
-  - ../../idam-user-disposer/idam-user-disposer.yaml
 namespace: disposer
 patchesStrategicMerge:
   - ../../identity/perftest.yaml

--- a/apps/disposer/prod/base/kustomization.yaml
+++ b/apps/disposer/prod/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../idam-user-disposer/idam-user-disposer.yaml
 namespace: disposer
 patchesStrategicMerge:
   - ../../identity/prod.yaml


### PR DESCRIPTION
HelmRelease/idam-user-disposer namespace not specified

idam-user-disposer was already being deployed from being included in base https://github.com/hmcts/cnp-flux-config/blob/master/apps/disposer/base/kustomization.yaml#L6 - so duplication also needed fixed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
