### PR TITLE
increase DOCUMENT_TASK_MILLISECONDS

### DIFF
--- a/apps/em/em-stitching/prod.yaml
+++ b/apps/em/em-stitching/prod.yaml
@@ -17,7 +17,7 @@ spec:
         memory:
           averageUtilization: 85
       environment:
-        DUMMY_VAR: DELETE_ME2
+        DOCUMENT_TASK_MILLISECONDS: 5000
         DOCMOSIS_ENDPOINT: https://docmosis.platform.hmcts.net/rs/convert
         DOCMOSIS_RENDER_ENDPOINT: https://docmosis.platform.hmcts.net/rs/render
         IDAM_API_BASE_URI: https://idam-api.platform.hmcts.net


### PR DESCRIPTION
increase DOCUMENT_TASK_MILLISECONDS to avoid 409 error in ccd-data