### PR TITLE
Change connection timeout for Redis

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -52,8 +52,7 @@ spec:
         FEATUREFLAGS_V2_API_INVITATION_CONTROLLER_ENABLED: true
         IDAM_QUERIES_CHANGED-USERS-WITH-ROLES_QUERY-ID: query-lastChanged-with-roles-user-value
         IDAM_QUERIES_CHANGED-USERS-WITH-SINGLE-ROLE_ENABLED: false
-        IDAM_QUERIES_CHANGED-USERS-WITH-ROLES_ENABLED: false
-        SPRING_REDIS_TIMEOUT: 200
+        SPRING_REDIS_TIMEOUT: 300
   chart:
     spec:
       chart: idam-api


### PR DESCRIPTION
### JIRA link (if applicable) ###
Follow up on https://github.com/hmcts/cnp-flux-config/pull/23918.


### Change description ###
Bump connection timeout to 300ms.

Undo "temporary disabling search queries as R9.0 data recon has reset lastModified timestamps for all account".

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
