### PR TITLE
Fix draft-store app insights

### DIFF
--- a/apps/rpe/draft-store-service/aat.yaml
+++ b/apps/rpe/draft-store-service/aat.yaml
@@ -5,38 +5,3 @@ metadata:
 spec:
   values:
     java:
-      testsConfig:
-        memoryLimits: "3072Mi"
-        serviceAccountName: tests-service-account
-      keyVaults:
-        draft-store:
-          excludeEnvironmentSuffix: false
-          secrets:
-            - name: s2s-secret-for-tests
-            - name: idam-password-for-tests
-            - name: idam-client-secret-for-tests
-            - name: service-POSTGRES-PASS-V14
-              alias: DRAFT_STORE_DB_PASSWORD
-      environment:
-        TEST_URL: http://draft-store-service-java
-        SLACK_CHANNEL: "platops-build-notices"
-        SLACK_NOTIFY_SUCCESS: "false"
-        USE_IDAM_TESTING_SUPPORT: "true"
-        S2S_URL_FOR_TESTS: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        IDAM_URL_FOR_TESTS: "https://idam-api.aat.platform.hmcts.net"
-        S2S_NAME_FOR_TESTS: "draft_store_tests"
-        IDAM_USER_EMAIL_FOR_TESTS: "reformplatformengineering+tests@gmail.com"
-        IDAM_CLIENT_ID_FOR_TESTS: "cmc_citizen"
-        IDAM_REDIRECT_URI_FOR_TESTS: "https://cmc-citizen-frontend-aat-staging.service.core-compute-aat.internal/receiver"
-        DRAFT_STORE_DB_HOST: rpe-draft-store-v14-aat.postgres.database.azure.com
-        DRAFT_STORE_DB_USER_NAME: pgadmin
-      smoketestscron:
-        enabled: false
-        schedule: "15 0/1 * * *"
-      functionaltestscron:
-        enabled: false
-        schedule: "25 0/6 * * *"
-      smoketests:
-        enabled: false
-      functionaltests:
-        enabled: false

--- a/apps/rpe/draft-store-service/demo.yaml
+++ b/apps/rpe/draft-store-service/demo.yaml
@@ -5,11 +5,3 @@ metadata:
 spec:
   values:
     java:
-      environment:
-        DRAFT_STORE_DB_HOST: rpe-draft-store-v14-demo.postgres.database.azure.com
-        DRAFT_STORE_DB_USER_NAME: pgadmin
-      keyVaults:
-        draft-store:
-          secrets:
-            - name: service-POSTGRES-PASS-V14
-              alias: DRAFT_STORE_DB_PASSWORD

--- a/apps/rpe/draft-store-service/ithc.yaml
+++ b/apps/rpe/draft-store-service/ithc.yaml
@@ -5,11 +5,3 @@ metadata:
 spec:
   values:
     java:
-      environment:
-        DRAFT_STORE_DB_HOST: rpe-draft-store-v14-ithc.postgres.database.azure.com
-        DRAFT_STORE_DB_USER_NAME: pgadmin
-      keyVaults:
-        draft-store:
-          secrets:
-            - name: service-POSTGRES-PASS-V14
-              alias: DRAFT_STORE_DB_PASSWORD

--- a/apps/rpe/draft-store-service/perftest.yaml
+++ b/apps/rpe/draft-store-service/perftest.yaml
@@ -5,11 +5,3 @@ metadata:
 spec:
   values:
     java:
-      environment:
-        DRAFT_STORE_DB_HOST: rpe-draft-store-v14-perftest.postgres.database.azure.com
-        DRAFT_STORE_DB_USER_NAME: pgadmin
-      keyVaults:
-        draft-store:
-          secrets:
-            - name: service-POSTGRES-PASS-V14
-              alias: DRAFT_STORE_DB_PASSWORD

--- a/apps/rpe/draft-store-service/prod.yaml
+++ b/apps/rpe/draft-store-service/prod.yaml
@@ -7,10 +7,3 @@ spec:
     java:
       environment:
         IDAM_URL: https://idam-api.platform.hmcts.net
-        DRAFT_STORE_DB_HOST: rpe-draft-store-v14-prod.postgres.database.azure.com
-        DRAFT_STORE_DB_USER_NAME: pgadmin
-      keyVaults:
-        draft-store:
-          secrets:
-            - name: service-POSTGRES-PASS-V14
-              alias: DRAFT_STORE_DB_PASSWORD

--- a/apps/rpe/draft-store-service/sbox.yaml
+++ b/apps/rpe/draft-store-service/sbox.yaml
@@ -5,11 +5,3 @@ metadata:
 spec:
   values:
     java:
-      environment:
-        DRAFT_STORE_DB_HOST: rpe-draft-store-v14-sandbox.postgres.database.azure.com
-        DRAFT_STORE_DB_USER_NAME: pgadmin
-      keyVaults:
-        draft-store:
-          secrets:
-            - name: service-POSTGRES-PASS-V14
-              alias: DRAFT_STORE_DB_PASSWORD


### PR DESCRIPTION
All secrets were being overridden without specifying app insights connection string