### PR TITLE
Rolling restart of draft store all envs

### DIFF
--- a/apps/rpe/draft-store-service/draft-store-service.yaml
+++ b/apps/rpe/draft-store-service/draft-store-service.yaml
@@ -6,6 +6,8 @@ spec:
   releaseName: draft-store-service
   values:
     java:
+      environment:
+        RESTART_ME: '2'
       disableTraefikTls: true
       replicas: 2
       useInterpodAntiAffinity: true


### PR DESCRIPTION
Follow up to https://github.com/hmcts/cnp-flux-config/pull/23946

Adjusting CSI driver values doesn't seem to restart a pod, so changing an env var.
Some envs had environment values changes so will be fine but not all.