### PR TITLE
ITHC: Remove divorce namespace to enable patching due to crashloop

### DIFF
--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -11,7 +11,8 @@ resources:
   - ../../../apps/cnp/base/kustomize.yaml
   - ../../../apps/idam/base/kustomize.yaml
   - ../../../apps/financial-remedy/base/kustomize.yaml
-  - ../../../apps/divorce/base/kustomize.yaml
+  # div-pfe-nodejs: unknown redis_error Failed to connect to Redis connect ECONNREFUSED
+  # - ../../../apps/divorce/base/kustomize.yaml
   - ../../../apps/wa/base/kustomize.yaml
   # MountVolume.SetUp failed for volume "vault-nfdiv”. A secret with (name/id) redis-access-key was not found in this key vault.
   # - ../../../apps/nfdiv/base/kustomize.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12901


### Change description ###

* Remove divorce namespace to enable patching due to crashloop


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
