### PR TITLE
Update demo.yaml revert to prod image policy

### DIFF
--- a/apps/xui/xui-webapp-ac-integration/demo.yaml
+++ b/apps/xui/xui-webapp-ac-integration/demo.yaml
@@ -37,4 +37,4 @@ spec:
         SERVICES_REFUNDS_API_URL: http://ccpay-refunds-api-demo.service.core-compute-demo.internal
         SERVICES_NOTIFICATIONS_API_URL: http://ccpay-notifications-service-demo.service.core-compute-demo.internal
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
-      image: hmctspublic.azurecr.io/xui/webapp:prod-f0b1be1-20230707211141 #{"$imagepolicy": "flux-system:demo-xui-webapp-ac-integration"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-f0b1be1-20230707211141 #{"$imagepolicy": "flux-system:xui-webapp-ac-integration"}


### PR DESCRIPTION
ac-int is broken in demo as pointed manually to prod but with demo image policy - no updates are happening and likely old prod image has been deleted - this should update to use prod image policy and auto update the image



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
