### PR TITLE
Reduce idle time for daily build agents

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -64,9 +64,6 @@ spec:
               osDiskSize: 60
               osDiskStorageAccountType: "Standard_LRS"
               osType: "Linux"
-              retentionStrategy:
-                azureVMCloudRetentionStrategy:
-                  idleTerminationMinutes: 60
               shutdownOnIdle: false
               storageAccountNameReferenceType: "existing"
               storageAccountType: "Standard_LRS"
@@ -103,11 +100,17 @@ spec:
                         templateDesc: "Jenkins build agents for HMCTS"
                         labels: "ubuntu"
                         maxVirtualMachinesLimit: 80
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 60
                         usageMode: "NORMAL"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
                         labels: "daily"
                         maxVirtualMachinesLimit: 20
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
                         usageMode: "EXCLUSIVE"
                         <<: *vm_template_values_anchor


### PR DESCRIPTION
I noticed a lot of daily build agents sitting around in the afternoon. once the build queue clears these aren't used much so set a much lower idle timeout