### PR TITLE
Revert "Force case-loader to deploy old image and exclude from tests"

### DIFF
--- a/apps/sscs/sscs-case-loader/prod-00.yaml
+++ b/apps/sscs/sscs-case-loader/prod-00.yaml
@@ -13,7 +13,6 @@ spec:
       cpuRequests: "1000m"
       memoryLimits: "3072Mi"
       cpuLimits: "2500m"
-      image: hmctspublic.azurecr.io/sscs/case-loader:prod-a5e2a3b-20230731162423
       environment:
         IDAM_OAUTH2_REDIRECT_URL: https://sscs-case-loader-prod.service.core-compute-prod.internal
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -2,7 +2,6 @@
 set -ex -o pipefail
 
 EXCLUSIONS_LIST=(
-  apps/sscs/sscs-case-loader/prod-00.yaml
   apps/docmosis/docmosis/docmosis.yaml
   apps/docmosis/docmosis/aat.yaml
   apps/docmosis/docmosis/sbox.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#24197