### PR TITLE
DFPL: Add missing perftest-image-policy resource in kustomization

### DIFF
--- a/apps/family-public-law/automation/kustomization.yaml
+++ b/apps/family-public-law/automation/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../fpl-case-service/image-repo.yaml
   - ../fpl-case-service/demo-image-policy.yaml
+  - ../fpl-case-service/perftest-image-policy.yaml
   - ../fpl-case-service/image-policy.yaml
   - ../fpl-cron-ccd-data-migration-tool/image-repo.yaml
   - ../fpl-cron-ccd-data-migration-tool/demo-image-policy.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
 - Add perftest-image-policy to the automation kustomization (assuming this is why it's never picked up any changes in the past and it doesn't pull latest images!)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
