### PR TITLE
Tune idle timeout of agent

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -102,7 +102,7 @@ spec:
                         maxVirtualMachinesLimit: 80
                         retentionStrategy:
                           azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 60
+                            idleTerminationMinutes: 5
                         usageMode: "NORMAL"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-daily"

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -66,7 +66,7 @@ spec:
               osType: "Linux"
               retentionStrategy:
                 azureVMCloudRetentionStrategy:
-                  idleTerminationMinutes: 60
+                  idleTerminationMinutes: 5
               shutdownOnIdle: false
               storageAccountNameReferenceType: "existing"
               storageAccountType: "Standard_LRS"


### PR DESCRIPTION
We pay per second used and I'm seeing a lot of idle agents sitting there after builds in the morning.

We can tune this as required to get a good balance but these should only take ~1 min to spawn a new one