### PR TITLE
DTSPO-14034 - Fix arm builders in ptl jenkins

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -21,12 +21,6 @@ spec:
               ephemeralOSDisk: true
               executeInitScriptAsRoot: true
               existingStorageAccountName: "hmctsjenkinscftptl"
-              imageReference:
-                galleryImageDefinition: "jenkins-ubuntu"
-                galleryImageVersion: "1.4.65"
-                galleryName: "hmcts"
-                galleryResourceGroup: "hmcts-image-gallery-rg"
-                gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
               imageTopLevelType: "advanced"
               initScript: |
                 usermod -a -G docker jenkinsssh


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14034

### Change description ###
Top level imageReference block should have been removed in previous commit
Causing arm builders version to be overridden

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
