### PR TITLE
Update kubectl image repo

### DIFF
--- a/apps/admin/delete-hung-pods/cron.yaml
+++ b/apps/admin/delete-hung-pods/cron.yaml
@@ -18,7 +18,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: kubectl
-              image: bitnami/kubectl
+              image: hmctspublic.azurecr.io/imported/bitnami/kubectl
               command:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
Update to use ACR Cache instead of docker io as per https://tools.hmcts.net/jira/browse/DTSPO-14808




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
