### PR TITLE
DTSPO-14034 - Remove arm daily pool

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -137,19 +137,3 @@ spec:
                           galleryImageDefinition: "jenkins-ubuntu-arm"
                           galleryImageVersion: "1.4.70"
                         <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-builders-arm-daily"
-                        templateDesc: "Jenkins build agents running on ARM64 CPUs"
-                        labels: "arm daily"
-                        maxVirtualMachinesLimit: 5
-                        retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
-                        usageMode: "EXCLUSIVE"
-                        virtualMachineSize: "Standard_D4pds_v5"
-                        imageReference:
-                          galleryName: "hmcts"
-                          galleryResourceGroup: "hmcts-image-gallery-rg"
-                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                          galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.70"
-                        <<: *vm_template_values_anchor


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14034

### Change description ###
Remove arm daily pool in ptl until I can get security scans updated to work without zap-cli
Prevents usually x64 nightly test runs being scheduled on arm agents
Relates to https://github.com/hmcts/cnp-jenkins-library/pull/1136

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
