### PR TITLE
Add Keda with workload identity in ithc

### DIFF
--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -3,11 +3,9 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../../rbac/reader-clusterrole.yaml
-- ../../keda
 - ../../traefik2
 - ../../aad-pod-id/mi
 - ../../delete-hung-pods
 patches:
-- path: keda-identity.yaml
 - path: ../../traefik2/ithc/secret-provider.yaml
 - path: ../../aad-pod-id/mi/ithc/azure-identity-patch.yaml

--- a/apps/flux-system/ithc/00/kustomize.yaml
+++ b/apps/flux-system/ithc/00/kustomize.yaml
@@ -12,3 +12,4 @@ spec:
       CLUSTER: "00"
       ENV_MONITOR_CHANNEL: "aks-monitor-ithc"
       KEYVAULT_ENVIRONMENT: "ithc"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/cc24080e-c6ca-4ade-b2e7-10465209751a/"

--- a/apps/flux-system/ithc/01/kustomize.yaml
+++ b/apps/flux-system/ithc/01/kustomize.yaml
@@ -12,3 +12,4 @@ spec:
       CLUSTER: "01"
       ENV_MONITOR_CHANNEL: "aks-monitor-ithc"
       KEYVAULT_ENVIRONMENT: "ithc"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/6c89e2e0-1f3d-4368-a7e8-0d648745d395/"

--- a/apps/keda/base/kustomization.yaml
+++ b/apps/keda/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ../keda/keda.yaml
+  - ../keda/keda-helmrepo.yaml
+  - ../../../base/workload-identity
+namespace: keda

--- a/apps/keda/base/kustomize.yaml
+++ b/apps/keda/base/kustomize.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: keda
+  namespace: flux-system
+spec:
+  path: ./apps/keda/${ENVIRONMENT}/base
+  postBuild:
+    substitute:
+      NAMESPACE: "keda"
+      TEAM_NOTIFICATION_CHANNEL: "platops-build-notices"
+      TEAM_AAD_GROUP_ID: "253a03f0-6310-40d2-a286-1de6ac85f052"
+      WI_NAME: "keda"

--- a/apps/keda/ithc/base/kustomization.yaml
+++ b/apps/keda/ithc/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ../../../rbac/nonprod-role.yaml
+namespace: keda
+patches:
+  - workload-identity.yaml

--- a/apps/keda/ithc/base/workload-identity.yaml
+++ b/apps/keda/ithc/base/workload-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "0af7735a-657d-4e05-8b41-23f7b49d8a30"
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/keda/keda/keda-helmrepo.yaml
+++ b/apps/keda/keda/keda-helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  url: https://kedacore.github.io/charts
+  interval: 10m

--- a/apps/keda/keda/keda.yaml
+++ b/apps/keda/keda/keda.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  releaseName: keda
+  values:
+    http:
+      timeout: 50000
+    image:
+      pullPolicy: IfNotPresent
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1024Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    serviceAccount:
+      create: false
+      name: keda
+  chart:
+    spec:
+      chart: keda
+      version: 2.11.2
+      sourceRef:
+        kind: HelmRepository
+        name: keda
+        namespace: keda

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -16,7 +16,7 @@ spec:
         mode: "protect" # one of: monitor, protect
         rules:
           - '{"config":{"id":1000,"category":"Kubernetes","comment":"Allow system namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"neuvector,kube-system,knode-system"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
-          - '{"config":{"id":1001,"category":"Kubernetes","comment":"Allow admin namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"admin,kubecost,kured,monitoring,dynatrace,flux-system,azureserviceoperator-system,cert-manager"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1001,"category":"Kubernetes","comment":"Allow admin namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"admin,kubecost,kured,monitoring,dynatrace,flux-system,azureserviceoperator-system,cert-manager,keda"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
           - '{"config":{"id":1002,"category":"Kubernetes","comment":"Allow HMCTS registries","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://hmctspublic.azurecr.io/,https://hmctsprivate.azurecr.io/"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
           - '{"config":{"id":1003,"category":"Kubernetes","comment":"Default deny","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://localhost/,https://*.*/"}],"disable":false,"rule_type": "deny","cfg_type":"user_created"}}'
         defaultAction: "allow"

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -55,6 +55,7 @@ resources:
   - ../../../apps/tax-tribunals/base/kustomize.yaml
   - ../../../apps/cui/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
+  - ../../../apps/keda/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
- Moves to separate namespace
- Uses service accoutn created by base/ 
- Adds WI config by default to all envs 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
