### PR TITLE
Swap keda to workload identity on perftest

### DIFF
--- a/apps/admin/perftest/base/keda-identity.yaml
+++ b/apps/admin/perftest/base/keda-identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: keda
-  namespace: admin
-spec:
-  type: 0
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keda-perftest-mi"
-  clientID: "67747202-cf4b-4125-9eae-341516afd71b"

--- a/apps/admin/perftest/base/kustomization.yaml
+++ b/apps/admin/perftest/base/kustomization.yaml
@@ -3,11 +3,9 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../../rbac/reader-clusterrole.yaml
-- ../../keda
 - ../../traefik2
 - ../../aad-pod-id/mi
 - ../../delete-hung-pods
 patches:
-- path: keda-identity.yaml
 - path: ../../traefik2/perftest/secret-provider.yaml
 - path: ../../aad-pod-id/mi/perftest/azure-identity-patch.yaml

--- a/apps/flux-system/perftest/00/kustomize.yaml
+++ b/apps/flux-system/perftest/00/kustomize.yaml
@@ -12,3 +12,4 @@ spec:
       CLUSTER: "00"
       ENV_MONITOR_CHANNEL: "aks-monitor-perftest"
       KEYVAULT_ENVIRONMENT: "perftest"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/daef9cf4-17b5-4b39-9582-99ad17ce8266/"

--- a/apps/flux-system/perftest/01/kustomize.yaml
+++ b/apps/flux-system/perftest/01/kustomize.yaml
@@ -12,3 +12,4 @@ spec:
       CLUSTER: "01"
       ENV_MONITOR_CHANNEL: "aks-monitor-perftest"
       KEYVAULT_ENVIRONMENT: "perftest"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/81298aaf-9aed-4b71-94d8-32ca7aa57227/"

--- a/apps/keda/perftest/base/kustomization.yaml
+++ b/apps/keda/perftest/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ../../../rbac/nonprod-role.yaml
+namespace: keda
+patches:
+  - path: workload-identity.yaml

--- a/apps/keda/perftest/base/workload-identity.yaml
+++ b/apps/keda/perftest/base/workload-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "67747202-cf4b-4125-9eae-341516afd71b"
+  labels:
+    azure.workload.identity/use: "true"

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -51,6 +51,7 @@ resources:
   - ../../../apps/jps/base/kustomize.yaml
   - ../../../apps/cui/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
+  - ../../../apps/keda/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
I have annotated CRDs so that they don't get deleted

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
