### PR TITLE
Reduce number of ExUI replicas in prod.yaml to 20

### DIFF
--- a/apps/xui/xui-webapp/prod.yaml
+++ b/apps/xui/xui-webapp/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     nodejs:
-      replicas: 24
+      replicas: 20
       memoryLimits: "4Gi"
       memoryRequests: "3Gi"
       ingressHost: manage-case.platform.hmcts.net


### PR DESCRIPTION
There is some evidence that ExUI is saturating redis. Reducing the number of instances to 20 may improve this


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EXUI-775

### Change description ###

Reduce replica count from 24 to 20

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
