### PR TITLE
Perftest - Plum: enable workload identity

### DIFF
--- a/apps/cnp/perftest/base/kustomization.yaml
+++ b/apps/cnp/perftest/base/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- ../../../base/workload-identity
 patches:
 - path: ../../identity/perftest.yaml
 - path: ../../plum-frontend/perftest.yaml
 - path: ../../plum-recipe-backend/perftest.yaml
 - path: ../../plum-recipe-receiver/perftest.yaml
+- path: workload-identity.yaml

--- a/apps/cnp/perftest/base/kustomize.yaml
+++ b/apps/cnp/perftest/base/kustomize.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnp
+  namespace: flux-system
+spec:
+  path: ./apps/cnp/perftest/base
+  postBuild:
+    substitute:
+      WORKLOAD_IDENTITY_ID: "28f771a2-3995-4191-832a-67cede1bb04d"

--- a/apps/cnp/perftest/base/workload-identity.yaml
+++ b/apps/cnp/perftest/base/workload-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: ${WORKLOAD_IDENTITY_ID}
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/cnp/plum-frontend/perftest.yaml
+++ b/apps/cnp/plum-frontend/perftest.yaml
@@ -7,3 +7,5 @@ spec:
   values:
     nodejs:
       ingressHost: plum.perftest.platform.hmcts.net
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}

--- a/apps/cnp/plum-recipe-backend/perftest.yaml
+++ b/apps/cnp/plum-recipe-backend/perftest.yaml
@@ -6,3 +6,5 @@ spec:
   values:
     java:
       ingressHost: plum-recipe-backend-perftest.service.core-compute-perftest.internal
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -57,3 +57,4 @@ patches:
     target:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+  - path: ../../../apps/cnp/perftest/base/kustomize.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12677


### Change description ###

* enable workload identity for plum in perftest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
