### PR TITLE
remove finrem-performance (not used now) from finrem dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -314,7 +314,7 @@ spec:
                     title: Private Law
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(finrem-case-orchestration-service|finrem-ccd-definitions|finrem-performance-tests)\/master
+                      ^HMCTS.*\/(finrem-case-orchestration-service|finrem-ccd-definitions)\/master
                     name: FinRem
                     recurse: true
                     title: FinRem Dashboard


### PR DESCRIPTION
remove finrem-performance (not used now) from finrem dashboard