### PR TITLE
Prod - Plum: enable workload identity

### DIFF
--- a/apps/cnp/plum-frontend/prod.yaml
+++ b/apps/cnp/plum-frontend/prod.yaml
@@ -7,3 +7,5 @@ spec:
   values:
     nodejs:
       ingressHost: plum.platform.hmcts.net
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}

--- a/apps/cnp/plum-recipe-backend/prod.yaml
+++ b/apps/cnp/plum-recipe-backend/prod.yaml
@@ -6,3 +6,5 @@ spec:
   values:
     java:
       ingressHost: plum-recipe-backend.service.core-compute-prod.internal
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}

--- a/apps/cnp/prod/base/kustomization.yaml
+++ b/apps/cnp/prod/base/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- ../../../base/workload-identity
 patches:
 - path: ../../identity/prod.yaml
 - path: ../../plum-frontend/prod.yaml
 - path: ../../plum-recipe-backend/prod.yaml
 - path: ../../plum-recipe-receiver/prod.yaml
+- path: workload-identity.yaml

--- a/apps/cnp/prod/base/kustomize.yaml
+++ b/apps/cnp/prod/base/kustomize.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cnp
+  namespace: flux-system
+spec:
+  path: ./apps/cnp/aat/base
+  postBuild:
+    substitute:
+      WORKLOAD_IDENTITY_ID: "03257b71-0d08-4e44-b09c-c75b63b4ec4f"

--- a/apps/cnp/prod/base/workload-identity.yaml
+++ b/apps/cnp/prod/base/workload-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: ${WORKLOAD_IDENTITY_ID}
+  labels:
+    azure.workload.identity/use: "true"

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -55,3 +55,4 @@ patches:
     target:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+  - path: ../../../apps/cnp/aat/prod/kustomize.yaml

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -55,4 +55,4 @@ patches:
     target:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
-  - path: ../../../apps/cnp/aat/prod/kustomize.yaml
+  - path: ../../../apps/cnp/prod/base/kustomize.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12677


### Change description ###

* enable workload identity for plum in prod


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
