### PR TITLE
SBOX - Plum: Test no workload identity flag with Workload Identity enabled service account

### DIFF
--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -7,5 +7,5 @@ spec:
   values:
     nodejs:
       ingressHost: plum.sandbox.platform.hmcts.net
-      useWorkloadIdentity: true
-      workloadClientID: ${WORKLOAD_IDENTITY_ID}
+      # useWorkloadIdentity: true
+      # workloadClientID: ${WORKLOAD_IDENTITY_ID}


### PR DESCRIPTION
## JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12677


### Change description ###

* Test no workload identity flag with Workload Identity enabled service account for Plum Sandbox


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
