### PR TITLE
Sbox - Plum backend: test no workload identity flag with Workload Identity service account

### DIFF
--- a/apps/cnp/plum-recipe-backend/sbox.yaml
+++ b/apps/cnp/plum-recipe-backend/sbox.yaml
@@ -6,5 +6,5 @@ spec:
   values:
     java:
       ingressHost: plum-recipe-backend-sandbox.service.core-compute-sandbox.internal
-      useWorkloadIdentity: true
-      workloadClientID: ${WORKLOAD_IDENTITY_ID}
+      # useWorkloadIdentity: true
+      # workloadClientID: ${WORKLOAD_IDENTITY_ID}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12677


### Change description ###

* Test no workload identity flag with Workload Identity service account for plum-recipe-backend in sandbox


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
