### PR TITLE
Add workload identity resources to CNP preview

### DIFF
--- a/apps/cnp/preview/base/kustomization.yaml
+++ b/apps/cnp/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../base
+- ../../../base/workload-identity
 - ../../../base/resourcequota-pvc.yaml
 - ../../identity/identity.yaml
 - ../../plum-batch/plum-batch.yaml


### PR DESCRIPTION
Preview doesn't include in the same way from cnp/base - so is missing these resources defined in https://github.com/hmcts/cnp-flux-config/blob/6c8ae1f1d2ef4893025c42fddebf6e7c3f9a9694/apps/cnp/base/kustomization.yaml#L5


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
