### PR TITLE
Reduced pod count to zero to complete DB switch over

### DIFF
--- a/apps/em/em-stitching/demo.yaml
+++ b/apps/em/em-stitching/demo.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     java:
+      replicas: 0
       keyVaults:
         em-stitching:
           resourceGroup: em-stitching


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-5525.
### Change description ###
Reduced pod count to zero. This is to ensure batch job is stopped. Only then we can copy over the last sequence id's related to batch job.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
