### PR TITLE
Increase cmc-citizen-frontend memory requirements

### DIFF
--- a/apps/money-claims/cmc-citizen-frontend/cmc-citizen-frontend.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/cmc-citizen-frontend.yaml
@@ -10,6 +10,8 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/cmc/citizen-frontend:prod-f901301-20230817125014 #{"$imagepolicy": "flux-system:cmc-citizen-frontend"}
+      memoryRequests: 1Gi
+      memoryLimits: 2Gi
   chart:
     spec:
       chart: ./stable/cmc-citizen-frontend


### PR DESCRIPTION
Current settings are not enough for it to start reliably