### PR TITLE
SSCS-11993 Add aac identity to preview

### DIFF
--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - ../../../rpe/identity/identity.yaml
 - ../../../ccd/identity/identity.yaml
 - ../../../em/identity/identity.yaml
+- ../../../aac/identity/identity.yaml
 - ../../../am/identity/identity.yaml
 - ../../../hmc/identity/identity.yaml
 - ../../../wa/identity/identity.yaml
@@ -22,6 +23,7 @@ patches:
 - path: ../../../rpe/identity/aat.yaml
 - path: ../../../ccd/identity/aat.yaml
 - path: ../../../em/identity/aat.yaml
+- path: ../../../aac/identity/aat.yaml
 - path: ../../../am/identity/aat.yaml
 - path: ../../../hmc/identity/aat.yaml
 - path: ../../../wa/identity/aat.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-11993

### Change description ###
Add aac identify to preview to allow the deployment of aac-manage-case-assignment service.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
