### PR TITLE
SBOX - Traefik: bool to string pod label

### DIFF
--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -20,7 +20,7 @@ spec:
             volumeAttributes:
               secretProviderClass: traefik-internal-cert
       podLabels:
-        useWorkloadIdentity: true
+        useWorkloadIdentity: "true"
     additionalVolumeMounts:
       - name: traefik-internal-cert
         mountPath: "/mnt/certs"


### PR DESCRIPTION
### Change description ###

* change pod label for workload identity from bool to string


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
