### PR TITLE
Traefik: move podLabel: aadpodidbinding from base to cluster level

### DIFF
--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.10.143.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/aat/01.yaml
+++ b/apps/admin/traefik2/aat/01.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.10.159.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.50.79.221"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.50.95.221"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.11.207.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.11.223.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.48.79.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.48.95.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.101.159.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/preview/01.yaml
+++ b/apps/admin/traefik2/preview/01.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.101.191.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/prod/00.yaml
+++ b/apps/admin/traefik2/prod/00.yaml
@@ -11,3 +11,6 @@ spec:
     autoscaling:
       minReplicas: 8
       maxReplicas: 16
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/prod/01.yaml
+++ b/apps/admin/traefik2/prod/01.yaml
@@ -11,3 +11,6 @@ spec:
     autoscaling:
       minReplicas: 8
       maxReplicas: 16
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ptl-intsvc/00.yaml
+++ b/apps/admin/traefik2/ptl-intsvc/00.yaml
@@ -8,6 +8,9 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.10.73.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik
     additionalArguments:
       - "--entryPoints.web.forwardedHeaders.insecure=true"
       - "--entryPoints.websecure.forwardedHeaders.insecure=true"

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.2.11.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -41,8 +41,6 @@ spec:
       enabled: true
       isDefaultClass: false
     deployment:
-      podLabels:
-        aadpodidbinding: traefik
       additionalVolumes:
         - name: traefik-default-cert
           csi:


### PR DESCRIPTION
### Change description ###

* move podLabel: aadpodidbinding from base to cluster level
* allows podLabel: useWorkloadIdentity: "true" to take effect (only added to sbox00 in this PR for testing)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
