### PR TITLE
SBOX - Traefik: move secretProviderClass to use workload identity in sbox00 for testing

### DIFF
--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 - ../../traefik2/sbox/secret-provider-internal.yaml
-- ../../traefik2/secret-provider.yaml
 
 patches:
 - path: ../../traefik2/sbox/tlsstore-patch.yaml

--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../../traefik2/sbox/secret-provider-internal.yaml
-- ../../traefik/sbox/secret-provider.yaml
+- ../../traefik2/sbox/secret-provider.yaml
 
 patches:
 - path: ../../traefik2/sbox/tlsstore-patch.yaml

--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../../traefik2/sbox/secret-provider-internal.yaml
-- ../../traefik2/sbox/secret-provider.yaml
+- ../../traefik2/secret-provider.yaml
 
 patches:
 - path: ../../traefik2/sbox/tlsstore-patch.yaml

--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 patches:
 - path: ../../traefik2/sbox/tlsstore-patch.yaml
 - path: ../../traefik2/sbox/00.yaml
+- path: ../../traefik2/sbox/00-secret-provider-internal-temp.yaml
+- path: ../../traefik2/sbox/00-secret-provider-temp.yaml

--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../../traefik2/sbox/secret-provider-internal.yaml
+- ../../traefik/sbox/secret-provider.yaml
 
 patches:
 - path: ../../traefik2/sbox/tlsstore-patch.yaml

--- a/apps/admin/sbox/00/kustomize.yaml
+++ b/apps/admin/sbox/00/kustomize.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: admin
+  namespace: flux-system
+spec:
+  postBuild:
+    substitute:
+      WORKLOAD_IDENTITY_ID: "8ff5473c-4779-4831-be9b-07ded6a33ee9"

--- a/apps/admin/traefik2/sbox/00-secret-provider-internal-temp.yaml
+++ b/apps/admin/traefik2/sbox/00-secret-provider-internal-temp.yaml
@@ -1,0 +1,9 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-internal-cert
+  namespace: admin
+spec:
+  parameters:
+    usePodIdentity: "false"
+    clientID: ${WORKLOAD_IDENTITY_ID}

--- a/apps/admin/traefik2/sbox/00-secret-provider-temp.yaml
+++ b/apps/admin/traefik2/sbox/00-secret-provider-temp.yaml
@@ -1,0 +1,9 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-default-cert
+  namespace: admin
+spec:
+  parameters:
+    usePodIdentity: "false"
+    clientID: ${WORKLOAD_IDENTITY_ID}

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -33,3 +33,23 @@ spec:
         loadBalancerIP: "10.2.9.250"
     serviceAccount:
       name: admin
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-default-cert
+  namespace: admin
+spec:
+  parameters:
+    usePodIdentity: "false"
+    clientID: ${WORKLOAD_IDENTITY_ID}
+---
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-internal-cert
+  namespace: admin
+spec:
+  parameters:
+    usePodIdentity: "false"
+    clientID: ${WORKLOAD_IDENTITY_ID}

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -33,23 +33,3 @@ spec:
         loadBalancerIP: "10.2.9.250"
     serviceAccount:
       name: admin
----
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
-kind: SecretProviderClass
-metadata:
-  name: traefik-default-cert
-  namespace: admin
-spec:
-  parameters:
-    usePodIdentity: "false"
-    clientID: ${WORKLOAD_IDENTITY_ID}
----
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
-kind: SecretProviderClass
-metadata:
-  name: traefik-internal-cert
-  namespace: admin
-spec:
-  parameters:
-    usePodIdentity: "false"
-    clientID: ${WORKLOAD_IDENTITY_ID}


### PR DESCRIPTION
### Change description ###

* move secretProviderClass to use workload identity in sbox00 for testing
* Once tested on individual cluster this can be better implemented into sbox/base for both clusters in an environment


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
