### PR TITLE
Perftest: switch to infra sub managed identities for move to WI

### DIFF
--- a/apps/aac/identity/perftest.yaml
+++ b/apps/aac/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: aac
   namespace: aac
 spec:
-  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aac-perftest-mi"
-  clientID: "2fa9ecac-b7a6-4237-899b-21d5f19135e6"
+  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aac-perftest-mi"
+  clientID: "83a3b504-785f-4c86-b216-11e5854e0bfb"

--- a/apps/bsp/identity/perftest.yaml
+++ b/apps/bsp/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: bsp
   namespace: bsp
 spec:
-  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bsp-perftest-mi"
-  clientID: "7f7547c9-d2ce-442f-80cc-a0af69410b1a"
+  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bulk-scan-perftest-mi"
+  clientID: "5f2e5a6c-d341-4aca-b2fc-17b0065bfb8d"

--- a/apps/ccd/identity/perftest.yaml
+++ b/apps/ccd/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ccd
   namespace: ccd
 spec:
-  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ccd-perftest-mi"
-  clientID: "909d9d3b-d8bc-4448-9366-7b532dbec83c"
+  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ccd-perftest-mi"
+  clientID: "16677269-65c4-4750-85ce-c11917333d17"

--- a/apps/divorce/identity/perftest.yaml
+++ b/apps/divorce/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: divorce
   namespace: divorce
 spec:
-  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/div-perftest-mi"
-  clientID: "859d3727-9d6a-412a-ac4a-66ec780e5ac0"
+  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/div-perftest-mi"
+  clientID: "1057d000-fba4-4df3-8cd6-385bbc848b34"

--- a/apps/dm-store/identity/perftest.yaml
+++ b/apps/dm-store/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: dm-store
   namespace: dm-store
 spec:
-  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dm-store-perftest-mi"
-  clientID: "049ee95f-8630-43d2-95a4-c8598478a2af"
+  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dm-perftest-mi"
+  clientID: "018fddc2-0004-40aa-8ede-d9394f15dd14"

--- a/apps/family-public-law/identity/perftest.yaml
+++ b/apps/family-public-law/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: family-public-law
   namespace: family-public-law
 spec:
-  resourceID: /subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-perftest-mi
-  clientID: eeebb801-eb0e-43ed-b161-e1295d10ee9f
+  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-perftest-mi
+  clientID: 86afcbe0-2992-42c9-800d-641ccb437008

--- a/apps/reform-scan/identity/perftest.yaml
+++ b/apps/reform-scan/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: reform-scan
   namespace: reform-scan
 spec:
-  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/reform-scan-perftest-mi"
-  clientID: "72c210b0-bcb7-4c7a-8bf5-25abcd131180"
+  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/reform-scan-perftest-mi"
+  clientID: "f7ead875-6fdf-4eb7-9a63-b4939e49ebcf"

--- a/apps/rpe/identity/send-letter-identity-ithc.yaml
+++ b/apps/rpe/identity/send-letter-identity-ithc.yaml
@@ -4,5 +4,5 @@ metadata:
   name: send-letter
   namespace: rpe
 spec:
-  resourceID: /subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/send-letter-ithc-mi
-  clientID: 1b02340a-ac83-45f9-848c-8ea8ad7bd82c
+  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpe-ithc-mi
+  clientID: da837ab8-df3a-4d7f-be54-3a324a5260f3

--- a/apps/rpe/identity/send-letter-identity-perftest.yaml
+++ b/apps/rpe/identity/send-letter-identity-perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: send-letter
   namespace: rpe
 spec:
-  resourceID: /subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/send-letter-perftest-mi
-  clientID: 50d3fc9c-d1d3-4a85-b528-12fa0e84b59f
+  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpe-perftest-mi
+  clientID: 696d773d-bab4-4257-9ae5-049a47549560

--- a/apps/xui/identity/perftest.yaml
+++ b/apps/xui/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: xui
   namespace: xui
 spec:
-  resourceID: /subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/xui-perftest-mi
-  clientID: 497c8cab-16a8-4c81-af19-063db18c4621
+  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpx-perftest-mi
+  clientID: a0b2ad13-f1f0-44c3-89ac-a6e82b5a05ef


### PR DESCRIPTION
Switch to managed identities in infra subs, needed for move to Workload Identity
(and send-letter ithc as missed in ithc pr)
