### PR TITLE
Admin namespace: move secretproviderclass patches to individial clusters sbox

### DIFF
--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 patches:
 - path: ../../traefik2/sbox/tlsstore-patch.yaml
 - path: ../../traefik2/sbox/00.yaml
+- path: ../../traefik2/sbox/secret-provider-temp.yaml
 - path: ../../traefik2/sbox/secret-provider-internal-temp.yaml

--- a/apps/admin/sbox/01/kustomization.yaml
+++ b/apps/admin/sbox/01/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 
 patches:
 - path: ../../traefik2/sbox/01.yaml
+- path: ../../traefik2/sbox/secret-provider-temp.yaml

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -9,5 +9,4 @@ resources:
 - ../../delete-hung-pods
 patches:
 - path: ../../traefik2/sbox/secret-provider.yaml
-- path: ../../traefik2/sbox/secret-provider-temp.yaml
 - path: ../../aad-pod-id/mi/sbox/azure-identity-patch.yaml


### PR DESCRIPTION
### Change description ###

* move secretproviderclass patches to individial clusters for sbox


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
