### PR TITLE
Use updated managed identities CMC nonprod

### DIFF
--- a/apps/family-public-law/identity/demo.yaml
+++ b/apps/family-public-law/identity/demo.yaml
@@ -4,5 +4,5 @@ metadata:
   name: family-public-law
   namespace: family-public-law
 spec:
-  resourceID: /subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-demo-mi
-  clientID: a3fa3d5e-e9bf-4633-9a0e-2e2533ae8d28
+  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-demo-mi
+  clientID: bb3c54a7-5340-441a-9a78-929c47ff52c3

--- a/apps/money-claims/identity/aat.yaml
+++ b/apps/money-claims/identity/aat.yaml
@@ -4,5 +4,5 @@ metadata:
   name: money-claims
   namespace: money-claims
 spec:
-  resourceID: /subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/money-claims-aat-mi
-  clientID: cdd8557e-6ed2-4456-a078-e6c3ffe1d271
+  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmc-aat-mi
+  clientID: 4f040df6-0541-4814-b88d-1a2a42b4aaa0

--- a/apps/money-claims/identity/demo.yaml
+++ b/apps/money-claims/identity/demo.yaml
@@ -4,5 +4,5 @@ metadata:
   name: money-claims
   namespace: money-claims
 spec:
-  resourceID: /subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/money-claims-demo-mi
-  clientID: d064f80f-e150-4732-8bd4-2c8576587b05
+  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmc-demo-mi
+  clientID: 7b1d9b2a-21f7-415d-9269-2691eff93549

--- a/apps/money-claims/identity/ithc.yaml
+++ b/apps/money-claims/identity/ithc.yaml
@@ -4,5 +4,5 @@ metadata:
   name: money-claims
   namespace: money-claims
 spec:
-  resourceID: /subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/money-claims-ithc-mi
-  clientID: fc4f4865-52dd-42f2-a0da-87663f935514
+  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmc-ithc-mi
+  clientID: 263e56b5-7185-4e4b-8050-ec468bd7b1e8

--- a/apps/money-claims/identity/perftest.yaml
+++ b/apps/money-claims/identity/perftest.yaml
@@ -4,5 +4,5 @@ metadata:
   name: money-claims
   namespace: money-claims
 spec:
-  resourceID: /subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/money-claims-perftest-mi
-  clientID: 65f015d7-76ba-4214-832a-e14fa64455d1
+  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cmc-perftest-mi
+  clientID: a5f28e4c-3351-487b-8cf7-7c54fd74b547


### PR DESCRIPTION
[DTSPO-13642](https://tools.hmcts.net/jira/browse/DTSPO-13642)

This change:
  - Updates flux to use new MIs in nonprod for money-claims, as built in their shared infra
  - Adds missing demo FPL MI


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
