### PR TITLE
Update container logs to v2

### DIFF
--- a/apps/kube-system/container-azm-ms-agentconfig/container-azm-ms-agentconfig.yaml
+++ b/apps/kube-system/container-azm-ms-agentconfig/container-azm-ms-agentconfig.yaml
@@ -42,15 +42,15 @@ data:
           # When the setting is set to false, only the kube events with !normal event type will be collected
           enabled = false
           # When this is enabled (enabled = true), all kube events including normal events will be collected
-       #[log_collection_settings.schema]
+       [log_collection_settings.schema]
           # In the absence of this configmap, default value for containerlog_schema_version is "v1"
           # Supported values for this setting are "v1","v2"
           # See documentation at https://aka.ms/ContainerLogv2 for benefits of v2 schema over v1 schema before opting for "v2" schema
-          # containerlog_schema_version = "v2"
-       #[log_collection_settings.enable_multiline_logs]
+          containerlog_schema_version = "v2"
+       [log_collection_settings.enable_multiline_logs]
           # fluent-bit based multiline log collection for go (stacktrace), dotnet (stacktrace)
           # if enabled will also stitch together container logs split by docker/cri due to size limits(16KB per log line)
-          # enabled = "false"
+          enabled = "true"
 
   prometheus-data-collection-settings: |-
     # Custom Prometheus metrics data collection settings


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-v2-migration



Feature differences | ContainerLog | ContainerLogV2
-- | -- | --
Onboarding | Only configurable through the ConfigMap | Configurable through both the ConfigMap and DCR*
Pricing | Only compatible with full-priced analytics logs | Supports the low cost basic logs tier in addition to analytics logs
Querying | Requires multiple join operations with inventory tables for standard queries | Includes additional pod and container metadata to reduce query complexity and join operations
Multiline | Not supported, multiline entries are split into multiple rows | Support for multiline logging to allow consolidated, single entries for multiline output

Querying v1 is awful, lots of joins required, and v2 also allows basic logs which might be an option

----

I need to find out where / how this is used for changing on CFT
- I checked with Dan Lysiak and searched confluence and couldn't find anything relevant so I think we are ok