### PR TITLE
FPET-749-added LA email domain to allowed list

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -50,6 +50,7 @@ spec:
           - westernbayadoption.org
           - stdavidscs.org
           - scottishadoption.org
+          - bradfordcft.org.uk
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FPET-749


### Change description ###
Adoption - LA email's not ending with gov.uk to be allowed


