### PR TITLE
Update external-dns to use workload-identity

### DIFF
--- a/apps/admin/external-dns-2/external-dns.yaml
+++ b/apps/admin/external-dns-2/external-dns.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 6.23.4
+      version: 6.26.4
       sourceRef:
         kind: HelmRepository
         name: external-dns
@@ -20,12 +20,15 @@ spec:
       repository: imported/bitnami/external-dns
       tag: 0.13.3-debian-11-r3
     policy: sync
+    serviceAccount:
+      create: false
+      name: admin
     podLabels:
-      aadpodidbinding: external-dns
+      azure.workload.identity/use: "true"
     sources:
       - ingress
     azure:
       resourceGroup: core-infra-intsvc-rg
       tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
       subscriptionId: 1baf5470-1c3e-40d3-a6f7-74bfbce4b348
-      useManagedIdentityExtension: true
+      useWorkloadIdentityExtension: true

--- a/apps/admin/preview/base/kustomization.yaml
+++ b/apps/admin/preview/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
 - path: ../../aad-pod-id/mi/preview/azure-identity-patch.yaml
 - path: ../../traefik2/preview/internal-cert-release-patch.yaml
 - path: ../../external-dns-2/preview/external-dns-private.yaml
+- path: ../service-account-patch.yaml

--- a/apps/admin/preview/service-account-patch.yaml
+++ b/apps/admin/preview/service-account-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    # aat-mi
+    azure.workload.identity/client-id: "1c09e6f2-45f5-4d09-99a2-a6a36e719239"


### PR DESCRIPTION
[DTSPO-12677](https://tools.hmcts.net/jira/browse/DTSPO-12677)


pre-req role assignments for this aat-mi have already been added in [ aks-cft-deploy repo](https://github.com/hmcts/aks-cft-deploy/commit/26ae03238bd50d3832cc3850d6920983fbc6f4c7)



This change:
  - Updates external DNS to use workload identity
  - Upgrades external dns

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
