### PR TITLE
Remove identity mention for external-dns

### DIFF
--- a/apps/admin/external-dns-2/external-dns.yaml
+++ b/apps/admin/external-dns-2/external-dns.yaml
@@ -18,7 +18,7 @@ spec:
     image:
       registry: hmctspublic.azurecr.io
       repository: imported/bitnami/external-dns
-      tag: 0.13.2-debian-11-r11
+      tag: 0.13.6-debian-11-r28
     policy: sync
     serviceAccount:
       create: false

--- a/apps/admin/external-dns-2/external-dns.yaml
+++ b/apps/admin/external-dns-2/external-dns.yaml
@@ -18,7 +18,7 @@ spec:
     image:
       registry: hmctspublic.azurecr.io
       repository: imported/bitnami/external-dns
-      tag: 0.13.3-debian-11-r3
+      tag: 0.13.2-debian-11-r11
     policy: sync
     serviceAccount:
       create: false

--- a/apps/admin/external-dns-2/preview/external-dns-private.yaml
+++ b/apps/admin/external-dns-2/preview/external-dns-private.yaml
@@ -10,5 +10,3 @@ spec:
     domainFilters:
       - service.core-compute-preview.internal
       - preview.platform.hmcts.net
-    azure:
-      userAssignedIdentityID: dc9bf214-5644-4c23-a5ad-56a015626fae


### PR DESCRIPTION
Getting this error:

```
external-dns: azure.userAssignedIdentityID
    You must enable the MSI when provider="azure-private-dns" and userAssignedIdentityID is set.
    Please set the useManagedIdentityExtension parameter (--set azure.useManagedIdentityExtension="true")
  Warning  error  77s (x5 over 4m17s)  helm-controller  reconciliation failed: upgrade retries exhausted
```
Seems a file was missed which is still setting that other value

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
