### PR TITLE
Disable displayCommitters for each build monitor

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -91,258 +91,344 @@ spec:
                 - all:
                     name: all
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|camunda-.*)\/master
                     name: Platform
                     recurse: true
                     title: Platform
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS_Nightly\/(.*fpl-ccd-configuration.*|.*ia-ccd-e2e-tests.*|.*cmc-ccd-e2e-tests.*|.*div-ccd-e2e-tests.*|.*finrem-ccd-definitions.*|.*finrem-ccd-e2e-tests.*|.*probate-back-office.*|.*sscs-ccd-e2e-tests.*|.*rpx-xui-webapp.*)\/master
                     name: CC-SRT-FULL
                     recurse: true
                     title: Common Components - Service Regression Full Nightly Pipeline
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS_Nightly\/(.*fpl-ccd-configuration.*|.*ia-ccd-e2e-tests.*|.*cmc-ccd-e2e-tests.*|.*div-ccd-e2e-tests.*|.*finrem-ccd-definitions.*|.*finrem-ccd-e2e-tests.*|.*probate-back-office.*|.*sscs-ccd-e2e-tests.*|.*rpx-xui-webapp.*)\/QA-588
                     name: CC-SRT
                     recurse: true
                     title: Common Components - Service Regression Functional Only
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(send-letter-.*|blob-router-service|bulk-scan-.*|reform-scan-.*)\/master
                     name: BSP
                     recurse: true
                     title: BSP
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       .+\/(rpx-.*)\/(master|demo)
                     name: RPX
                     recurse: true
                     title: RPX
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       .+\/(rpx-.*)\/(.*PR-.*)
                     name: RPX-PR
                     recurse: true
                     title: RPX-PR
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS_(\w_to_\w)(?!.*Nightly).*\/(?!.*ccd-case-disposer|.*ccd-case-migration-starter)(ccd.*|aac.*|cpo.*|hmc-.*|ts.*)\/master
                     name: CDM
                     recurse: true
                     title: CDM Master Builds Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS_(\w_to_\w_Nightly).*\/(?!.*ccd-case-disposer|.*ccd-cache-warm-performance|.*ccd-cdm-performance|.*ccd-case-migration-starter|.*hmc-judicial-payment-frontend|.*hmc-judicial-payment-service)(ccd.*|aac.*|cpo.*|hmc-.*|ts.*)\/master
                     name: CDM Nightly
                     recurse: true
                     title: CDM Nightly Builds Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(.*ccd-user-profile-api.*PR-399|.*ccd-definition-store-api.*PR-575|.*ccd-data-store-api.*PR-1260|jps.*\/master|.*ccd-case-migration-starter\/master)
                     name: CDM DEV
                     recurse: true
                     title: CDM Develop Builds Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(sscs-evidence-share|sscs-bulk-scan|sscs-case-loader|sscs-cor-frontend|sscs-shared-infrastructure|sscs-submit-your-appeal|sscs-track-your-appeal-notifications|sscs-tribunals-case-api|sscs-ccd-e2e-tests|sscs-ccd-callback-orchestrator|sscs-ccd-definitions|sscs-hearings-api)\/master
                     name: SSCS
                     recurse: true
                     title: SSCS Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/ia.*\/master
                     name: IA
                     recurse: true
                     title: I & A Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(bar-api|bar-web|bar-shared-infrastructure|ccfr-fees-register-app|ccfr-fees-register-admin-web|ccpay-bulkscanning-app|ccpay-payment-app|ccpayfr-shared-infrastructure|ccpay-payment-api-gateway|ccpay-scheduled-jobs|ccpay-functions-node|ccpay-service-request-cpo-update-service|ccpay-bubble|ccpay-paymentoutcome-web|ccpay-refunds-app|ccpay-notifications-service)\/master
                     name: Fees-and-Pay
                     recurse: true
                     title: Fees&Pay Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(probate-frontend|probate-caveats-frontend|probate-business-service|probate-submit-service|probate-back-office|probate-orchestrator-service|probate-shared-infrastructure)\/master
                     name: PROBATE
                     recurse: true
                     title: PROBATE Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(div-case-data-formatter|div-case-maintenance-service|div-case-orchestration-service|div-ccd-definitions|div-decree-absolute-frontend|div-decree-nisi-frontend|div-document-generator-client|div-evidence-management-client-api|div-fees-and-payments-service|div-respondent-frontend)\/master
                     name: DIV
                     recurse: true
                     title: Divorce Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/nfdiv-.+\/master
                     name: NFDIV
                     recurse: true
                     title: No fault divorce Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS_j_to_z_Nightly\/(nfdiv-.*)\/master
                     name: NFD Nightly
                     recurse: true
                     title: NFD Nightly Builds Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(?!sptribs-dss)(sptribs-).+\/master
                     name: SPTRIBS
                     recurse: true
                     title: Special Tribunals Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS_j_to_z_Nightly.*\/(?!sptribs-dss)(sptribs-).+\/master
                     name: Special Tribunals Nightly
                     recurse: true
                     title: Special Tribunals Builds Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(am-shared-infrastructure|am-org-role-mapping-service|am-role-assignment-batch-service|am-role-assignment-service|am-judicial-booking-service|am-role-assignment-batch-service|am-role-assignment-refresh-batch)\/master
                     name: AM
                     recurse: true
                     title: AM
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(ctsc-shared-infrastructure|ctsc-work-.*)\/master
                     name: CTSC
                     recurse: true
                     title: CTSC
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(ecm-shared-infrastructure|ecm-consumer)\/master
                     name: ETHOS
                     recurse: true
                     title: ETHOS
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(cmc-citizen-frontend|cmc-claim-store|cmc-shared-infrastructure|cmc-performance-test|cmc-ccd-e2e-tests)\/master
                     name: CMC
                     recurse: true
                     title: CMC
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(rd-professional-api|rd-user-profile-api|rd-profile-sync|rd-judicial-data-load|rd-judicial-api|rd-shared-infrastructure|rd-location-ref-api|rd-location-ref-data-load|rd-caseworker-ref-api|rd-lrd-performance|rd-crd-performance|rd-commondata-api|rd-commondata-dataload)\/master
                     name: RD
                     recurse: true
                     title: Ref Data Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/adoption-.+\/master
                     name: ADOPTION
                     recurse: true
                     title: Adoption Data Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(fpl-ccd-configuration|fpl-wa-task-configuration|fpl-cron-ccd-data-migration-tool)\/master
                     name: FPLA
                     recurse: true
                     title: Family Public Law
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/pcq-.+\/master
                     name: PCQ
                     recurse: true
                     title: PCQ
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(lau-.+|.*ccd-case-disposer|.*disposer-idam-user|.*disposer-shared-infrastructure)\/master
                     name: LAU
                     recurse: true
                     title: LAU
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/rse-.+\/master
                     name: RSE
                     recurse: true
                     title: RSE
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(em-ccd-orchestrator|em-native-pdf-annotator-app|em-annotation-api|em-stitching-api|em-media-viewer|em-showcase|document-management-store-app|dg-docassembly-api|em-hrs-api|em-hrs-ingestor)\/master
                     name: Evidence
                     recurse: true
                     title: Evidence Management
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/civil-(?!damages|sdt).*\/master
                     name: Civil
                     recurse: true
                     title: Civil Data Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/civil-sdt.*\/master
                     name: Civil-SDT
                     recurse: true
                     title: Civil SDT Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/wa-.+\/master
                     name: WA
                     recurse: true
                     title: WA
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(idam-api|idam-web-public|idam-user-dashboard|idam-performance-tests|idam-hmcts-access|idam-testing-support-api|idam-access-config|idam-shared-infrastructure)\/master
                     name: IDAM
                     recurse: true
                     title: IDAM Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/fact-.*\/master
                     name: FACT
                     recurse: true
                     title: FACT Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/rpts-.*\/master
                     name: RPTS
                     recurse: true
                     title: RPTS Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.+Nightly\/(.*performance.*|.*Performance.*)\/master
                     name: Performance
                     recurse: true
                     title: Performance Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(prl-cos-api|prl-ccd-definitions|prl-dgs-api|prl-citizen-frontend|prl-shared-infrastructure|prl-wa-task-configuration|prl-wa-post-deployment-ft-tests|prl-ccd-case-migration)\/master
                     name: PRL
                     recurse: true
                     title: Private Law
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(finrem-case-orchestration-service|finrem-ccd-definitions)\/master
                     name: FinRem
                     recurse: true
                     title: FinRem Dashboard
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(et-ccd-callbacks|et-message-handler|et-shared-infrastructure|et-sya-frontend|et-sya-api|et-xui-e2e-tests|et-hearings-api|et-ccd-definitions-[a-z]+)\/master
                     name: ET
                     recurse: true
                     title: Employment Tribunals
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(fis-hmc-api|fis-ds-web|fis-bulk-scan-api|family-api-gateway|fis-ds-update-web)\/master
                     name: FIS
                     recurse: true
                     title: Family Integration
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(tax-tribunals-shared-infrastructure|tax-tribunals-datacapture)\/master
                     name: TT
                     recurse: true
                     title: Tax Tribunals
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(help-with-fees-shared-infrastructure|hwf-staffapp|hwf-publicapp)\/master
                     name: HWF
                     recurse: true
                     title: Help with Fees
                 - buildMonitor:
+                    config:
+                      displayCommitters: false
                     includeRegex: >-
                       ^HMCTS.*\/(et-pet-shared-infrastructure|et-pet-et1|et-pet-et3|et-pet-api|et-pet-admin|et-pet-ccd-export)\/master
                     name: ETPET


### PR DESCRIPTION
The views stopped working on new url and @timja noticed this setting being off fixed things

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
