### PR TITLE
DTSPO-15293 Create chart-job-gitrepo.yaml

### DIFF
--- a/apps/flux-system/base/chart-job-gitrepo.yaml
+++ b/apps/flux-system/base/chart-job-gitrepo.yaml
@@ -1,0 +1,17 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: chart-job
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: ssh://github.com/hmcts/chart-job
+  ref:
+    branch: master
+  secretRef:
+    name: git-credentials
+  ignore: |
+    # exclude all
+    /*
+    # include charts directory
+    !/job/


### PR DESCRIPTION
### Jira link (if applicable)
[DTSPO-15293](https://tools.hmcts.net/jira/browse/DTSPO-15293)


### Change description ###
conventing plat-ops cronjobs to use helm release with chart-job,  adding chart-job to flux
