### PR TITLE
DTSPO-14559 - Add service account for crumble-mi

### DIFF
--- a/apps/cnp/sbox/base/crumble-sa.yaml
+++ b/apps/cnp/sbox/base/crumble-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crumble
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "b2b2d562-d3cb-40bc-8fa3-bd670f10dfb1"

--- a/apps/cnp/sbox/base/kustomization.yaml
+++ b/apps/cnp/sbox/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - crumble-identity.yaml
+  - crumble-sa.yaml
   - test-ingress-redirect.yaml
 namespace: cnp
 patches:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-14559

### Change description ###
Add serviceAccount for crumble-mi
Plum workload identity does not have permission to keyvault and previously crumble was using a dedicated pod identity
May need an update to chart-library to allow overriding the default service account
Blocking test pipeline from passing

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
