### PR TITLE
FPET-764-corrected LA email domain in allowed list

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -52,7 +52,7 @@ spec:
           - scottishadoption.org
           - bradfordcft.org.uk
           - yorkshireadoptionagency.org.uk
-          - adoptionlancashireblackpool.org
+          - adoptionlancashireblackpool.org.uk
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FPET-764


### Change description ###
Adoption - LA email's not ending with gov.uk to be allowed 

