### PR TITLE
DTSPO-14559 - Switch crumble to UAMI resource

### DIFF
--- a/apps/cnp/sbox/base/crumble-identity.yaml
+++ b/apps/cnp/sbox/base/crumble-identity.yaml
@@ -1,19 +1,11 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
+apiVersion: managedidentity.azure.com/v1beta20181130
+kind: UserAssignedIdentity
 metadata:
-  name: crumble
-  namespace: cnp
+  name: crumble-${WI_ENVIRONMENT}-mi
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
 spec:
-  type: 0
-  resourceID: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/crumble-sandbox-mi
-  clientID: b2b2d562-d3cb-40bc-8fa3-bd670f10dfb1
-
----
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentityBinding
-metadata:
-  name: crumble-binding
-  namespace: cnp
-spec:
-  azureIdentity: crumble
-  selector: crumble
+  location: uksouth
+  owner:
+    name: managed-identities-${WI_ENVIRONMENT}-rg


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-14559

### Change description ###
Switch crumble identity to use azure service operator UAMI api resource

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
