### PR TITLE
Revert SDT gateway demo image

### DIFF
--- a/apps/civil/civil-sdt-gateway/demo-image-policy.yaml
+++ b/apps/civil/civil-sdt-gateway/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-civil-sdt-gateway
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-123-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-sdt-gateway


### PR DESCRIPTION
### Jira link (if applicable)
SDT-144 (https://tools.hmcts.net/jira/browse/SDT-144)


### Change description ###
Remove pull request specific configuration from civil-sdt-gateway demo-image-policy.yaml so that it reverts to using latest prod image.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
