### PR TITLE
Update reform-scan-servicebus.yaml

### DIFF
--- a/apps/reform-scan/preview/aso/reform-scan-servicebus.yaml
+++ b/apps/reform-scan/preview/aso/reform-scan-servicebus.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   tags:
-    app.kubernetes.io_name: reform-scan
-    application: reform-scan
+    app.kubernetes.io_name: bulk-scan-print
+    application: bulk-scan-print


### PR DESCRIPTION
Should be tag instead of namespace? 

```
apiVersion: servicebus.azure.com/v1beta20210101preview kind: Namespace
metadata:
  name: ${NAMESPACE}-servicebus-${ENVIRONMENT}
  namespace: ${NAMESPACE}
spec:
  tags:
    app.kubernetes.io_name: *application tag value*
    application: *application tag value*
```

And it is shown as: 

```
reform-scan: # separate `bulk-scan` product copy since #349
  team: "Bulk Scanning and Printing"
  namespace: "reform-scan"
  azure_ad_group: dcd_group_bulkscan_v2
  slack:
    contact_channel: "#rbs"
    build_notices_channel: "#bsp-build-notices"
  tags:
    application: bulk-scan-print
  ardoq:
    application_id: "869a8652d5586f1c4f05ee4a"
```
