### PR TITLE
FPET-775-added LA email domain to allowed list

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -53,6 +53,7 @@ spec:
           - bradfordcft.org.uk
           - yorkshireadoptionagency.org.uk
           - adoptionlancashireblackpool.org.uk
+          - adoptioncounts.org.uk
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Change description ###
Adoption - LA email's not ending with gov.uk to be allowed

### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FPET-775
