### PR TITLE
DTSPO-15525: Attempt to add multi-cluster support for testing

### DIFF
--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -10,7 +10,8 @@ spec:
       controller:
         federation:
           managedsvc:
-            type: LoadBalancer
+            type: ClusterIP
+            host: cft-neuvector00.ithc.platform.hmcts.net
         azureFileShare:
           secretName: nv-storage-secret
           shareName: neuvector-data-01

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -12,7 +12,7 @@ spec:
           managedsvc:
             type: ClusterIP
             ingress:
-              host: cft-neuvector.platform.hmcts.net
+              host: cft-neuvector01.ithc.platform.hmcts.net
               ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -11,7 +11,9 @@ spec:
         federation:
           managedsvc:
             type: ClusterIP
-            host: cft-neuvector00.ithc.platform.hmcts.net
+            ingress:
+              host: cft-neuvector.platform.hmcts.net
+              ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret
           shareName: neuvector-data-01

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -12,7 +12,7 @@ spec:
           managedsvc:
             type: ClusterIP
             ingress:
-              host: cft-neuvector01.ithc.platform.hmcts.net
+              host: cft-neuvector01-managed.ithc.platform.hmcts.net
               ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -12,7 +12,7 @@ spec:
           managedsvc:
             type: ClusterIP
             ingress:
-              host: cft-neuvector01-managed.ithc.platform.hmcts.net
+              host: cft-neuvector01.ithc.platform.hmcts.net
               ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -8,6 +8,9 @@ spec:
   values:
     neuvector:
       controller:
+        federation:
+          managedsvc:
+            type: LoadBalancer
         azureFileShare:
           secretName: nv-storage-secret
           shareName: neuvector-data-01

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -23,7 +23,7 @@ spec:
           mastersvc:
             type: ClusterIP
             ingress:
-              host: cft-neuvector-manager.platform.hmcts.net
+              host: cft-neuvector.platform.hmcts.net
               ingressClassName: traefik
         ingress:
           host: cft-neuvector-api.platform.hmcts.net

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -23,7 +23,7 @@ spec:
           mastersvc:
             type: ClusterIP
             ingress:
-              host: cft-neuvector.platform.hmcts.net
+              host: cft-neuvector-manager.platform.hmcts.net
               ingressClassName: traefik
         ingress:
           host: cft-neuvector-api.platform.hmcts.net

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -22,7 +22,9 @@ spec:
         federation:
           mastersvc:
             type: ClusterIP
-            host: cft-neuvector.platform.hmcts.net
+            ingress:
+              host: cft-neuvector.platform.hmcts.net
+              ingressClassName: traefik
         ingress:
           host: cft-neuvector-api.platform.hmcts.net
           enabled: true

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -19,6 +19,9 @@ spec:
           - neuvector-new-admin-password
     neuvector:
       controller:
+        federation:
+          mastersvc:
+            type: LoadBalancer
         ingress:
           host: cft-neuvector.platform.hmcts.net
           enabled: true

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -21,9 +21,10 @@ spec:
       controller:
         federation:
           mastersvc:
-            type: LoadBalancer
+            type: ClusterIP
+            host: cft-neuvector.platform.hmcts.net
         ingress:
-          host: cft-neuvector.platform.hmcts.net
+          host: cft-neuvector-api.platform.hmcts.net
           enabled: true
         configmap:
           data:


### PR DESCRIPTION
As a pre-req for multi-cluster management with Neuvector 
```
If you plan to use the multi-cluster management functions in NeuVector, one cluster must have the Federation Master service deployed, and each remote cluster must have the Federation Worker service.
```

This change:
  - Adds `controller.federation.mastersvc.type` to PTL, which will make it able to manage other clusters.
  - Adds `controller.federation.managedsvc.type` to ITHC for testing, which makes it manageable by PTL cluster.
  - Adds new multi-cluster ingress hosts for each to use as the hostname in neuvector UI
  - Updates API url for PTL to correct value

May need more for TLS considerations, but will see


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
