### PR TITLE
DTSPO-15109 Workaround kustomize sortorder bug with namespaces

### DIFF
--- a/apps/aac/preview/base/kustomization.yaml
+++ b/apps/aac/preview/base/kustomization.yaml
@@ -8,3 +8,5 @@ namespace: aac
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/admin/preview/00/kustomization.yaml
+++ b/apps/admin/preview/00/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-
 patches:
 - path: ../../traefik2/preview/00.yaml
 - path: ../../external-dns-2/preview/00-external-dns-private.yaml
+sortOptions:
+  order: fifo

--- a/apps/admin/preview/01/kustomization.yaml
+++ b/apps/admin/preview/01/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-
 patches:
 - path: ../../traefik2/preview/01.yaml
 - path: ../../external-dns-2/preview/01-external-dns-private.yaml
+sortOptions:
+  order: fifo

--- a/apps/admin/preview/base/kustomization.yaml
+++ b/apps/admin/preview/base/kustomization.yaml
@@ -17,3 +17,5 @@ patches:
 - path: ../../traefik2/preview/internal-cert-release-patch.yaml
 - path: ../../external-dns-2/preview/external-dns-private.yaml
 - path: ../service-account-patch.yaml
+sortOptions:
+  order: fifo

--- a/apps/adoption/preview/base/kustomization.yaml
+++ b/apps/adoption/preview/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-   - ../../../base/workload-identity
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml

--- a/apps/adoption/preview/base/kustomization.yaml
+++ b/apps/adoption/preview/base/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+   - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: adoption
 patches:
   - path: ../../identity/aat.yaml
@@ -14,3 +14,5 @@ patches:
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/am/preview/00/kustomization.yaml
+++ b/apps/am/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: am
+sortOptions:
+  order: fifo

--- a/apps/am/preview/01/kustomization.yaml
+++ b/apps/am/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: am
+sortOptions:
+  order: fifo

--- a/apps/am/preview/base/kustomization.yaml
+++ b/apps/am/preview/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-   ../../../base/workload-identity
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml

--- a/apps/am/preview/base/kustomization.yaml
+++ b/apps/am/preview/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+   ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: am
 patches:
   - path: ../../identity/aat.yaml
   - path: ../aso/am-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/bar/preview/base/kustomization.yaml
+++ b/apps/bar/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: bar
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/base/kustomization.yaml
+++ b/apps/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - alert.yaml
   - namespace.yaml
-  - provider.yaml
   - service-account.yaml
   - tests-service-account.yaml
+  - alert.yaml
+  - provider.yaml

--- a/apps/bsp/preview/base/kustomization.yaml
+++ b/apps/bsp/preview/base/kustomization.yaml
@@ -2,14 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../sops-secrets
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../aso/resource-group-old.yaml
-  - ../../../base/workload-identity
 namespace: bsp
 patches:
   - path: ../../identity/aat.yaml
   - path: ../aso/bsp-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/camunda/preview/base/kustomization.yaml
+++ b/apps/camunda/preview/base/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 namespace: camunda
 patches:
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/ccd/preview/00/kustomization.yaml
+++ b/apps/ccd/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: ccd
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/ccd/preview/01/kustomization.yaml
+++ b/apps/ccd/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: ccd
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/ccd/preview/base/kustomization.yaml
+++ b/apps/ccd/preview/base/kustomization.yaml
@@ -2,16 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../sealed-secrets
   - ../../identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: ccd
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../aso/ccd-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/chart-tests/preview/base/kustomization.yaml
+++ b/apps/chart-tests/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../sealed-secrets
   - ../../../bsp/identity/identity.yaml
   - ../../../money-claims/identity/identity.yaml
@@ -11,7 +12,6 @@ resources:
   - ../../azure-service-operator/chart-tests-postgres-config.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: chart-tests
 patches:
   - path: ../../../bsp/identity/aat.yaml
@@ -19,3 +19,5 @@ patches:
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/civil/preview/00/kustomization.yaml
+++ b/apps/civil/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: civil
+sortOptions:
+  order: fifo

--- a/apps/civil/preview/01/kustomization.yaml
+++ b/apps/civil/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: civil
+sortOptions:
+  order: fifo

--- a/apps/civil/preview/base/kustomization.yaml
+++ b/apps/civil/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../hmc/identity/identity.yaml
@@ -18,7 +19,6 @@ resources:
   - ../aso/civil-postgres-config.yaml
   - resource-limits.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: civil
 patches:
   - path: ../../identity/aat.yaml
@@ -33,3 +33,5 @@ patches:
   - path: ../aso/civil-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../aso/civil-postgres.yaml
+sortOptions:
+  order: fifo

--- a/apps/cnp/preview/base/kustomization.yaml
+++ b/apps/cnp/preview/base/kustomization.yaml
@@ -10,3 +10,5 @@ namespace: cnp
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/cpo/preview/base/kustomization.yaml
+++ b/apps/cpo/preview/base/kustomization.yaml
@@ -8,3 +8,5 @@ namespace: cpo
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/cui/preview/base/kustomization.yaml
+++ b/apps/cui/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: cui
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/dg/preview/base/kustomization.yaml
+++ b/apps/dg/preview/base/kustomization.yaml
@@ -2,11 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: dg
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/disposer/preview/00/kustomization.yaml
+++ b/apps/disposer/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: disposer
+sortOptions:
+  order: fifo

--- a/apps/disposer/preview/01/kustomization.yaml
+++ b/apps/disposer/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: disposer
+sortOptions:
+  order: fifo

--- a/apps/disposer/preview/base/kustomization.yaml
+++ b/apps/disposer/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: disposer
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/divorce/preview/base/kustomization.yaml
+++ b/apps/divorce/preview/base/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../aac/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: divorce
 patches:
   - path: ../../identity/aat.yaml
@@ -16,3 +16,5 @@ patches:
   - path: ../../../am/identity/aat.yaml
   - path: ../../../aac/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/dm-store/preview/base/kustomization.yaml
+++ b/apps/dm-store/preview/base/kustomization.yaml
@@ -2,14 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: dm-store
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/dtsse/preview/00/kustomization.yaml
+++ b/apps/dtsse/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: dtsse
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/dtsse/preview/01/kustomization.yaml
+++ b/apps/dtsse/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: dtsse
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/dtsse/preview/base/kustomization.yaml
+++ b/apps/dtsse/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: dtsse
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/em/preview/00/kustomization.yaml
+++ b/apps/em/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: em
+sortOptions:
+  order: fifo

--- a/apps/em/preview/01/kustomization.yaml
+++ b/apps/em/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: em
+sortOptions:
+  order: fifo

--- a/apps/em/preview/base/kustomization.yaml
+++ b/apps/em/preview/base/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../ia/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
-  - ../../../base/workload-identity
 namespace: em
 patches:
   - path: ../../identity/aat.yaml
@@ -15,3 +15,5 @@ patches:
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../ia/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/et-pet/preview/base/kustomization.yaml
+++ b/apps/et-pet/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: et-pet
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/et/preview/00/kustomization.yaml
+++ b/apps/et/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: et
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/et/preview/01/kustomization.yaml
+++ b/apps/et/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: et
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/et/preview/base/kustomization.yaml
+++ b/apps/et/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
@@ -18,7 +19,6 @@ resources:
   - ../../../ethos/identity/identity.yaml
   - ../aso/et-postgres-config.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: et
 patches:
   - path: ../../identity/aat.yaml
@@ -34,3 +34,5 @@ patches:
   - path: ../aso/et-servicebus.yaml
   - path: ../aso/et-postgres.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/ethos/preview/base/kustomization.yaml
+++ b/apps/ethos/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: ethos
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/fact/preview/base/kustomization.yaml
+++ b/apps/fact/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: fact
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/family-public-law/preview/00/kustomization.yaml
+++ b/apps/family-public-law/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: family-public-law
+sortOptions:
+  order: fifo

--- a/apps/family-public-law/preview/01/kustomization.yaml
+++ b/apps/family-public-law/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: family-public-law
+sortOptions:
+  order: fifo

--- a/apps/family-public-law/preview/base/kustomization.yaml
+++ b/apps/family-public-law/preview/base/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../aac/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../base/workload-identity
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
@@ -21,3 +21,5 @@ patches:
   - path: ../../../am/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../aso/fpl-postgres.yaml
+sortOptions:
+  order: fifo

--- a/apps/fees-pay/preview/00/kustomization.yaml
+++ b/apps/fees-pay/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: fees-pay
+sortOptions:
+  order: fifo

--- a/apps/fees-pay/preview/01/kustomization.yaml
+++ b/apps/fees-pay/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: fees-pay
+sortOptions:
+  order: fifo

--- a/apps/fees-pay/preview/base/kustomization.yaml
+++ b/apps/fees-pay/preview/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: fees-pay
 patches:
   - path: ../../identity/aat.yaml
   - path: ../aso/fees-pay-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/financial-remedy/preview/00/kustomization.yaml
+++ b/apps/financial-remedy/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: financial-remedy
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/financial-remedy/preview/01/kustomization.yaml
+++ b/apps/financial-remedy/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: financial-remedy
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/financial-remedy/preview/base/kustomization.yaml
+++ b/apps/financial-remedy/preview/base/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../aac/identity/identity.yaml
-  - ../../../base/workload-identity
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
@@ -22,3 +22,5 @@ patches:
   - path: ../../../aac/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../aso/finrem-postgres.yaml
+sortOptions:
+  order: fifo

--- a/apps/fis/preview/base/kustomization.yaml
+++ b/apps/fis/preview/base/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: fis
 patches:
   - path: ../../identity/aat.yaml
@@ -14,3 +14,5 @@ patches:
   - path: ../../../am/identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/help-with-fees/preview/base/kustomization.yaml
+++ b/apps/help-with-fees/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: help-with-fees
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/hmc/preview/00/kustomization.yaml
+++ b/apps/hmc/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: hmc
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/hmc/preview/01/kustomization.yaml
+++ b/apps/hmc/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: hmc
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/hmc/preview/base/kustomization.yaml
+++ b/apps/hmc/preview/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: hmc
 patches:
   - path: ../../identity/aat.yaml
   - path: ../aso/hmc-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/ia/preview/00/kustomization.yaml
+++ b/apps/ia/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: ia
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/ia/preview/01/kustomization.yaml
+++ b/apps/ia/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: ia
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/ia/preview/base/kustomization.yaml
+++ b/apps/ia/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../rpe/identity/identity.yaml
@@ -19,7 +20,6 @@ resources:
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../aso/ia-postgres-config.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: ia
 patches:
   - path: ../../identity/aat.yaml
@@ -35,3 +35,5 @@ patches:
   - path: ../aso/ia-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../aso/ia-postgres.yaml
+sortOptions:
+  order: fifo

--- a/apps/idam/preview/base/kustomization.yaml
+++ b/apps/idam/preview/base/kustomization.yaml
@@ -13,3 +13,5 @@ patches:
   - path: ../../idam-hmcts-access/preview.yaml
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/jps/preview/00/kustomization.yaml
+++ b/apps/jps/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: jps
 bases:
 - ../base
+sortOptions:
+  order: fifo

--- a/apps/jps/preview/01/kustomization.yaml
+++ b/apps/jps/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: jps
 bases:
 - ../base
+sortOptions:
+  order: fifo

--- a/apps/jps/preview/base/kustomization.yaml
+++ b/apps/jps/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: jps
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/labs/preview/base/kustomization.yaml
+++ b/apps/labs/preview/base/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
 namespace: labs
+sortOptions:
+  order: fifo

--- a/apps/lau/preview/base/kustomization.yaml
+++ b/apps/lau/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: lau
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/money-claims/preview/base/kustomization.yaml
+++ b/apps/money-claims/preview/base/kustomization.yaml
@@ -5,15 +5,17 @@ namespace: money-claims
 #  - resource-limits.yaml
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../sealed-secrets
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../base/workload-identity
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/nfdiv/preview/00/kustomization.yaml
+++ b/apps/nfdiv/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: nfdiv
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/nfdiv/preview/01/kustomization.yaml
+++ b/apps/nfdiv/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: nfdiv
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/nfdiv/preview/base/kustomization.yaml
+++ b/apps/nfdiv/preview/base/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../aac/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: nfdiv
 patches:
   - path: ../../identity/aat.yaml
@@ -16,3 +16,5 @@ patches:
   - path: ../../../aac/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/pcq/preview/00/kustomization.yaml
+++ b/apps/pcq/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: pcq
+sortOptions:
+  order: fifo

--- a/apps/pcq/preview/01/kustomization.yaml
+++ b/apps/pcq/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: pcq
+sortOptions:
+  order: fifo

--- a/apps/pcq/preview/base/kustomization.yaml
+++ b/apps/pcq/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: pcq
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/private-law/preview/00/kustomization.yaml
+++ b/apps/private-law/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: private-law
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/private-law/preview/01/kustomization.yaml
+++ b/apps/private-law/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: private-law
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/private-law/preview/base/kustomization.yaml
+++ b/apps/private-law/preview/base/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../em/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: private-law
 patches:
   - path: ../../identity/aat.yaml
@@ -16,3 +16,5 @@ patches:
   - path: ../../../am/identity/aat.yaml
   - path: ../../../em/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/probate/preview/00/kustomization.yaml
+++ b/apps/probate/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: probate
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/probate/preview/01/kustomization.yaml
+++ b/apps/probate/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: probate
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/probate/preview/base/kustomization.yaml
+++ b/apps/probate/preview/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: probate
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/rd/preview/00/kustomization.yaml
+++ b/apps/rd/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: rd
+sortOptions:
+  order: fifo

--- a/apps/rd/preview/01/kustomization.yaml
+++ b/apps/rd/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: rd
+sortOptions:
+  order: fifo

--- a/apps/rd/preview/base/kustomization.yaml
+++ b/apps/rd/preview/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: rd
 patches:
   - path: ../../identity/aat.yaml
   - path: ../aso/rd-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/reform-scan/preview/base/kustomization.yaml
+++ b/apps/reform-scan/preview/base/kustomization.yaml
@@ -2,13 +2,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: reform-scan
 patches:
   - path: ../../identity/aat.yaml
   - path: ../aso/reform-scan-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/rpe/preview/base/kustomization.yaml
+++ b/apps/rpe/preview/base/kustomization.yaml
@@ -2,15 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../../base/resourcequota-pvc.yaml
   - ../../identity/send-letter-identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../../draft-store-service/sops-secrets
-  - ../../../base/workload-identity
 namespace: rpe
 patches:
   - path: ../../identity/send-letter-identity-aat.yaml
   - path: ../../draft-store-service/aso/postgres.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/rpts/preview/base/kustomization.yaml
+++ b/apps/rpts/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: rpts
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/sptribs/preview/base/kustomization.yaml
+++ b/apps/sptribs/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
@@ -17,7 +18,6 @@ resources:
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../aso/sptribs-postgres-config.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: sptribs
 patches:
   - path: ../../identity/aat.yaml
@@ -32,3 +32,5 @@ patches:
   - path: ../aso/sptribs-servicebus.yaml
   - path: ../aso/sptribs-postgres.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/sscs/preview/00/kustomization.yaml
+++ b/apps/sscs/preview/00/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
 namespace: sscs
 sortOptions:
   order: fifo
-

--- a/apps/sscs/preview/00/kustomization.yaml
+++ b/apps/sscs/preview/00/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
   - ../base
 namespace: sscs
+sortOptions:
+  order: fifo
+

--- a/apps/sscs/preview/01/kustomization.yaml
+++ b/apps/sscs/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../base
 namespace: sscs
+sortOptions:
+  order: fifo

--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../rpe/identity/identity.yaml
@@ -16,7 +17,6 @@ resources:
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../sops-secrets
-  - ../../../base/workload-identity
 namespace: sscs
 patches:
   - path: ../../identity/aat.yaml
@@ -31,3 +31,5 @@ patches:
   - path: ../aso/sscs-servicebus.yaml
   - path: ../aso/sscs-postgres.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/tax-tribunals/preview/base/kustomization.yaml
+++ b/apps/tax-tribunals/preview/base/kustomization.yaml
@@ -7,3 +7,5 @@ namespace: tax-tribunals
 patches:
   - path: ../../base/workload-identity.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/ts/preview/base/kustomization.yaml
+++ b/apps/ts/preview/base/kustomization.yaml
@@ -2,11 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: ts
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/wa/preview/00/kustomization.yaml
+++ b/apps/wa/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: wa
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/wa/preview/01/kustomization.yaml
+++ b/apps/wa/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 namespace: wa
 resources:
   - ../base
+sortOptions:
+  order: fifo

--- a/apps/wa/preview/base/kustomization.yaml
+++ b/apps/wa/preview/base/kustomization.yaml
@@ -2,10 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
+  - ../../../base/workload-identity
   - ../sealed-secrets
   - ../../identity/identity.yaml
-  - ../../../base/workload-identity
 namespace: wa
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/xui/preview/base/kustomization.yaml
+++ b/apps/xui/preview/base/kustomization.yaml
@@ -2,9 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base
-  - ../../identity/identity.yaml
   - ../../../base/workload-identity
+  - ../../identity/identity.yaml
 namespace: xui
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15109


### Change description ###

Kustomize has a bug in it's legacy sort provider which ranks namespaces with a group above regular namespaces.
This prevents namespace creation with servicebus resources that use `kind: Namespace` as well. 

Tested with:

```
./kustomize build --load-restrictor LoadRestrictionsNone apps/sscs/preview/00
```

I ran it before and after the change comparing the outputs.
Kudos to @danielwilsonkainos for finding this was the issue in the first place.

This is a similar bug to https://github.com/kubernetes-sigs/kustomize/issues/5072 but not quite the same.
@danielwilsonkainos has a fix for kustomize but it's a bit hacky and we found this other solution instead:

https://github.com/kubernetes-sigs/kustomize/compare/master...danielwilsonkainos:kustomize:sortorder

<details>
<summary>Patch 1 to kustomize</summary>

```diff
diff --git a/api/types/kustomization.go b/api/types/kustomization.go
index 41376bedd..5c3237d5c 100644
--- a/api/types/kustomization.go
+++ b/api/types/kustomization.go
@@ -22,6 +22,7 @@ const (
 	MetadataNamespacePath       = "metadata/namespace"
 	MetadataNamespaceApiVersion = "v1"
 	MetadataNamePath            = "metadata/name"
+	NamespaceKind               = "Namespace"
 
 	OriginAnnotations      = "originAnnotations"
 	TransformerAnnotations = "transformerAnnotations"
diff --git a/plugin/builtin/sortordertransformer/SortOrderTransformer.go b/plugin/builtin/sortordertransformer/SortOrderTransformer.go
index fefc810d7..61c62f29c 100644
--- a/plugin/builtin/sortordertransformer/SortOrderTransformer.go
+++ b/plugin/builtin/sortordertransformer/SortOrderTransformer.go
@@ -163,6 +163,9 @@ func gvkLessThan(gvk1, gvk2 resid.Gvk, typeOrders map[string]int) bool {
 	if index1 != index2 {
 		return index1 < index2
 	}
+	if (gvk1.Kind == types.NamespaceKind && gvk2.Kind == types.NamespaceKind) && (gvk1.Group == "" || gvk2.Group == "") {
+		return legacyGVKSortString(gvk1) > legacyGVKSortString(gvk2)
+	}
 	return legacyGVKSortString(gvk1) < legacyGVKSortString(gvk2)
 }
 
diff --git a/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go b/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go
index 77dffafa4..64bd3b4b1 100644
--- a/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go
+++ b/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go
@@ -69,6 +69,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -108,6 +114,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Role
 metadata:
@@ -228,6 +240,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -306,6 +324,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Deployment
 metadata:
```

</details>

<details>
<summary>Alternative slightly less patch to kustomize</summary>

```diff
diff --git a/plugin/builtin/sortordertransformer/SortOrderTransformer.go b/plugin/builtin/sortordertransformer/SortOrderTransformer.go
index fefc810d7..41fdf0c15 100644
--- a/plugin/builtin/sortordertransformer/SortOrderTransformer.go
+++ b/plugin/builtin/sortordertransformer/SortOrderTransformer.go
@@ -163,13 +163,14 @@ func gvkLessThan(gvk1, gvk2 resid.Gvk, typeOrders map[string]int) bool {
 	if index1 != index2 {
 		return index1 < index2
 	}
+
 	return legacyGVKSortString(gvk1) < legacyGVKSortString(gvk2)
 }
 
 // legacyGVKSortString returns a string representation of given GVK used for
 // stable sorting.
 func legacyGVKSortString(x resid.Gvk) string {
-	legacyNoGroup := "~G"
+	legacyNoGroup := "a[noGrp]"
 	legacyNoVersion := "~V"
 	legacyNoKind := "~K"
 	legacyFieldSeparator := "_"
diff --git a/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go b/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go
index 77dffafa4..64bd3b4b1 100644
--- a/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go
+++ b/plugin/builtin/sortordertransformer/SortOrderTransformer_test.go
@@ -69,6 +69,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -108,6 +114,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Role
 metadata:
@@ -228,6 +240,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Deployment
 metadata:
@@ -306,6 +324,12 @@ kind: Namespace
 metadata:
   name: apple
 ---
+apiVersion: servicebus.azure.com/v1api20210101preview
+kind: Namespace
+metadata:
+  name: aso-namespace
+  namespace: default
+---
 apiVersion: v1
 kind: Deployment
 metadata:

```

</details>



[sort provider docs](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/sortoptions/)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
