### PR TITLE
Preview - sscs: move sortOrder placement in kustomization manifest for testing

### DIFF
--- a/apps/sscs/preview/00/kustomization.yaml
+++ b/apps/sscs/preview/00/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+sortOptions:
+  order: fifo
 resources:
   - ../base
 namespace: sscs
-sortOptions:
-  order: fifo

--- a/apps/sscs/preview/01/kustomization.yaml
+++ b/apps/sscs/preview/01/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+sortOptions:
+  order: fifo
 resources:
   - ../base
 namespace: sscs
-sortOptions:
-  order: fifo

--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+sortOptions:
+  order: fifo
 resources:
   - ../../../base
   - ../../../base/workload-identity
@@ -31,5 +33,3 @@ patches:
   - path: ../aso/sscs-servicebus.yaml
   - path: ../aso/sscs-postgres.yaml
   - path: ../../serviceaccount/aat.yaml
-sortOptions:
-  order: fifo


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15109


### Change description ###

- Test reordering of Kustomization parameter 'sortOrder' above resources/patches etc. Kustomize-controller isn't obeying this currently and al examples have this option in this position


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
