### PR TITLE
disabling scan for release

### DIFF
--- a/apps/reform-scan/reform-scan-blob-router/prod.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/prod.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctspublic.azurecr.io/reform-scan/blob-router:pr-2137-c604301-20231122121729
       environment:
         HANDLE_REJECTED_FILES_CRON: "0 0 7 * * *"
         REJECT_DUPLICATES_CRON: "0 0 6 * * *"


### PR DESCRIPTION
Disabling scanning of new envelopes as a part of V15 flex release for EM