### PR TITLE
Preview: remove gotk components from preview base (now defined at cluster level)

### DIFF
--- a/apps/flux-system/base/flux-config-gitrepo.yaml
+++ b/apps/flux-system/base/flux-config-gitrepo.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1m0s
   timeout: 3m0s
   ref:
-    branch: master
+    branch: flux-v2.1.2-preview-base
   secretRef:
     name: git-credentials
   url: ssh://git@github.com/hmcts/cnp-flux-config

--- a/apps/flux-system/preview/00/kustomization.yaml
+++ b/apps/flux-system/preview/00/kustomization.yaml
@@ -1,7 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../base
-- ../../base/patches/gotk-components-flux-v2_1_2.yaml
-patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/00/kustomization.yaml
+++ b/apps/flux-system/preview/00/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
 - ../base
 - ../../base/patches/gotk-components-flux-v2_1_2.yaml
+patches:
+- path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/01/kustomization.yaml
+++ b/apps/flux-system/preview/01/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
 - ../base
 - ../../base/gotk-components.yaml
+patches:
+- path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/01/kustomization.yaml
+++ b/apps/flux-system/preview/01/kustomization.yaml
@@ -1,7 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../base
-- ../../base/gotk-components.yaml
-patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/base/kustomization.yaml
+++ b/apps/flux-system/preview/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/base/kustomization.yaml
+++ b/apps/flux-system/preview/base/kustomization.yaml
@@ -3,5 +3,3 @@ kind: Kustomization
 resources:
 - ../../base
 - aks-sops-aadpodidentity.yaml
-patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/preview/base/kustomization.yaml
+++ b/apps/flux-system/preview/base/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- ../../base/patches/gotk-components-flux-v2_1_2.yaml
 - aks-sops-aadpodidentity.yaml
+patches:
+- path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15109


### Change description ###

* Remove reference to gotk components in flux-system preview base as they are now at cluster level
* Move patches of gotk-components to cluster level


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
