### PR TITLE
Update neuvector federated ingress ITHC

### DIFF
--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -12,7 +12,8 @@ spec:
           managedsvc:
             type: ClusterIP
             ingress:
-              host: cft-neuvector01.ithc.platform.hmcts.net
+              enabled: true
+              host: cft-neuvector01-fed.ithc.platform.hmcts.net
               ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret


### PR DESCRIPTION
Trying to get access to the managedsvc for multi-cluster management. Perhaps a separate ingress record would help with accessing the service

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
