### PR TITLE
Preview: GOTK kustomize-controller temporarily set to pre-release build for preview clusters

### DIFF
--- a/apps/flux-system/base/patches/gotk-components-flux-v2_1_2.yaml
+++ b/apps/flux-system/base/patches/gotk-components-flux-v2_1_2.yaml
@@ -5299,7 +5299,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/fluxcd/kustomize-controller:v1.1.1
+        image: ghcr.io/fluxcd/kustomize-controller:preview-250f620f
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/apps/flux-system/preview/00/kustomization.yaml
+++ b/apps/flux-system/preview/00/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../base
-- ../../base/patches/gotk-components-flux-v2_1_2.yaml

--- a/apps/flux-system/preview/01/kustomization.yaml
+++ b/apps/flux-system/preview/01/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../base
-- ../../base/gotk-components.yaml

--- a/apps/flux-system/preview/base/kustomization.yaml
+++ b/apps/flux-system/preview/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_1_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15109


### Change description ###

* Add GOTK components for flux v2.1.2 - update the kustomize-controller in this to a [pre-release build supplied by flux](https://github.com/fluxcd/pkg/issues/689#issuecomment-1830274498)
* This a temporary fix for preview cluster namespace issue for implementation until Flux v2.2.0 is released


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
