### PR TITLE
increase aat and prod memoryLimits - bulk scan

### DIFF
--- a/apps/bsp/bulk-scan-processor/aat.yaml
+++ b/apps/bsp/bulk-scan-processor/aat.yaml
@@ -8,7 +8,7 @@ spec:
       environment:
         DELETE_ME: "dummy_var"
       testsConfig:
-        memoryLimits: "3072Mi"
+        memoryLimits: "4096Mi"
         serviceAccountName: tests-service-account
         keyVaults:
           bulk-scan:

--- a/apps/bsp/bulk-scan-processor/prod.yaml
+++ b/apps/bsp/bulk-scan-processor/prod.yaml
@@ -16,7 +16,7 @@ spec:
         STORAGE_BLOB_LEASE_TIMEOUT: 60
         UPLOAD_MAX_TRIES: 30
       testsConfig:
-        memoryLimits: "3072Mi"
+        memoryLimits: "4096Mi"
         serviceAccountName: tests-service-account
         keyVaults:
           bulk-scan:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FACT-1433


### Change description ###
Coming across 'Exception: java.lang.OutOfMemoryError' errors. Attempting to increase to 4GB to see if it helps
build below
https://build.hmcts.net/job/HMCTS_a_to_c/job/bulk-scan-processor/job/PR-3181/20/console

### Checklist 

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
