### PR TITLE
Add ingressroutes for ITHC&PTL, remove ingress

### DIFF
--- a/apps/neuvector/base/fed-svc-ingressroutetcp.yaml
+++ b/apps/neuvector/base/fed-svc-ingressroutetcp.yaml
@@ -1,0 +1,11 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: nv-ingressroute
+  namespace: neuvector
+spec:
+  entryPoints:
+    - websecure
+    - web
+  tls:
+    passthrough: true

--- a/apps/neuvector/ithc/00/ingress-route-patch.yaml
+++ b/apps/neuvector/ithc/00/ingress-route-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: nv-ingressroute
+  namespace: neuvector
+spec:
+  routes:
+  - match: HostSNI(`cft-neuvector00-multi-cluster.ithc.platform.hmcts.net`)
+    services:
+    - name: neuvector-svc-controller-fed-managed
+      port: 10443

--- a/apps/neuvector/ithc/00/kustomization.yaml
+++ b/apps/neuvector/ithc/00/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../../base/fed-svc-ingressroutetcp.yaml
 
 patches:
 - path: ../../neuvector/ithc/00.yaml
+- path: ingress-route-patch.yaml

--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -11,10 +11,6 @@ spec:
         federation:
           managedsvc:
             type: ClusterIP
-            ingress:
-              enabled: true
-              host: cft-neuvector00-multi-cluster.ithc.platform.hmcts.net
-              ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret
           shareName: neuvector-data-00

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -11,10 +11,6 @@ spec:
         federation:
           managedsvc:
             type: ClusterIP
-            ingress:
-              enabled: true
-              host: cft-neuvector01-multi-cluster.ithc.platform.hmcts.net
-              ingressClassName: traefik
         azureFileShare:
           secretName: nv-storage-secret
           shareName: neuvector-data-01

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -22,10 +22,6 @@ spec:
         federation:
           mastersvc:
             type: ClusterIP
-            ingress:
-              enabled: true
-              host: cft-neuvector-multi-cluster.platform.hmcts.net
-              ingressClassName: traefik
         ingress:
           host: cft-neuvector-api.platform.hmcts.net
           enabled: true

--- a/apps/neuvector/ptl-intsvc/base/ingress-route-patch.yaml
+++ b/apps/neuvector/ptl-intsvc/base/ingress-route-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: nv-ingressroute
+  namespace: neuvector
+spec:
+  routes:
+  - match: HostSNI(`cft-neuvector-multi-cluster.platform.hmcts.net`)
+    services:
+    - name: neuvector-svc-controller-fed-master
+      port: 11443

--- a/apps/neuvector/ptl-intsvc/base/kustomization.yaml
+++ b/apps/neuvector/ptl-intsvc/base/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../base/fed-svc-ingressroutetcp.yaml
   - fluentbit-log.yaml
   - nv-storage-secret.yaml
 patches:
   - path: ../../neuvector/ptl-intsvc/ptl-intsvc.yaml
   - path: ../../serviceaccount/ptl.yaml
+  - path: ingress-route-patch.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15525

Going via traditional ingress route for multi-cluster management was not possible;
```
2023/11/30 15:30:21 reverseproxy.go:667: httputil: ReverseProxy read error during body copy: read tcp 10.10.72.18:38564->10.10.72.111:11443: read: connection reset by peer
```
Traefik terminates SSL by default, and requests being passed to the fed services for multi-cluster management were not in the correct format even though reaching the controller lead pods.

Also tried by setting the services to have LoadBalancer type and be exposed, but faced issues this way too, and generally not ideal as there's no chart support to specify a static IP, and we'd be exposing another endpoint.

To get around this, using `IngressRouteTCP` CRD from Traefik which lets you pass requests through Traefik to the end service untouched, https://doc.traefik.io/traefik/routing/routers/#passthrough. Once manually disabling ingress, and applying these objects on each master and managed side, I was able to join a remote cluster to the primary.  This PR also disables the ingress I added previously

I wanted to leave more of this in base files (apps/neuvector/base/fed-svc-ingressroutetcp.yaml) but the patches didn't work as expected and left some code missing.



<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
