### PR TITLE
DTSPO-14876 - enabling grafana for aat 00 cluster

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/aat/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/aat/00.yaml
@@ -28,3 +28,13 @@ spec:
                 title: 'AAT-00 - {{ template "slack.default.title" . }}'
                 text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
           - name: "null"
+    grafana:
+      enabled: true
+      ingress:
+        hosts:
+          - grafana.aat.platform.hmcts.net
+      additionalDataSources:
+        - name: prometheus-00
+          type: prometheus
+          url: http://prometheus-server.prometheus.svc
+          access: proxy


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-14876

### Change description ###

Enabling Grafana for aat-00 cluster to integrate with opencost
