### PR TITLE
FPET-796-Updated LA email domain to allowed list

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -39,7 +39,7 @@ spec:
           - adoptioninmerseyside.co.uk
           - adoptionconnects.co.uk
           - lgsslaw.co.uk
-          - jigsawadoption.org
+          - jigsawadoption.org.uk
           - scottishadoption.org
           - ccsadoption.org
           - adoptionwest.co.uk


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FPET-796


### Change description ###
Adoption - LA email's not ending with gov.uk to be allowed 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
