### PR TITLE
Cron: fix cron-test gitrepo url, remove concurrentCronCluster global

### DIFF
--- a/apps/base/kustomize.yaml
+++ b/apps/base/kustomize.yaml
@@ -33,7 +33,6 @@ spec:
               tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
               enableKeyVaults: true
               activeCronCluster: ${ACTIVE_CRON_CLUSTER}
-              concurrentCronJob: false
             java:
               environment:
                 CLUSTER_NAME: "cft-${ENVIRONMENT}-${CLUSTER}-aks"

--- a/apps/flux-system/base/chart-job-cron-test-gitrepo.yaml
+++ b/apps/flux-system/base/chart-job-cron-test-gitrepo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  url: ssh://github.com/hmcts/chart-job
+  url: ssh://git@github.com:hmcts/chart-job
   ref:
     branch: https://github.com/hmcts/chart-job/tree/dtspo-16035-cron-active-standby
   secretRef:

--- a/apps/flux-system/base/chart-job-cron-test-gitrepo.yaml
+++ b/apps/flux-system/base/chart-job-cron-test-gitrepo.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  url: ssh://git@github.com:hmcts/chart-job
+  url: ssh://git@github.com/hmcts/chart-job
   ref:
-    branch: https://github.com/hmcts/chart-job/tree/dtspo-16035-cron-active-standby
+    branch: dtspo-16035-cron-active-standby
   secretRef:
     name: git-credentials
   ignore: |


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16035


### Change description ###

- remove experimental global 'concurrentCronCluster' - this has changed name and been defined in the chart rather than apps/base/kustomize
- fix the SSH URL for the test GitRepository


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
