### PR TITLE
Sbox - plum-batch: test activeOnBothClusters flag in pre-release chart-job

### DIFF
--- a/apps/cnp/plum-batch/sbox.yaml
+++ b/apps/cnp/plum-batch/sbox.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   values:
     schedule: "*/1 * * * *"
+    activeOnBothClusters: true
     nodeSelector:
       agentpool: spotinstance
     tolerations:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16035


### Change description ###

* test activeOnBothClusters flag in pre-release chart-job using plum-batch


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
