### PR TITLE
turn off elastic search to verify the root cause of MYA document upload failures

### DIFF
--- a/apps/sscs/sscs-tribunals-api/prod.yaml
+++ b/apps/sscs/sscs-tribunals-api/prod.yaml
@@ -34,4 +34,4 @@ spec:
         POST_HEARINGS_FEATURE: true
         POST_HEARINGS_B_FEATURE: true
         ELINKS_V2_FEATURE_ENABLED: false
-        ELASTIC_SEARCH_FEATURE: true
+        ELASTIC_SEARCH_FEATURE: false


### PR DESCRIPTION
### Jira link (if applicable)
- https://mojcppprod.service-now.com/incident.do?sys_id=4324f5941b437d901af721f0b24bcb46&sysparm_record_target=incident&sysparm_record_row=7&sysparm_record_rows=7&sysparm_record_list=major_incident_state%3Daccepted%5Eactive%3Dtrue%5EstateNOT+IN6%2C7%5Esys_class_name%3Dincident%5EORDERBYsys_updated_on

### Change description ###
- this is to verify whether this is the root cause of MYA document upload failures
