### PR TITLE
FPET-805-added LA email domain to allowed list

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -55,6 +55,7 @@ spec:
           - adoptionlancashireblackpool.org.uk
           - adoptioncounts.org.uk
           - arcadoptionne.org.uk
+          - coram.org.uk
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FPET-805


### Change description ###
Adoption - LA email's not ending with gov.uk to be allowed

