### PR TITLE
ccd-5104: message publisher down

### DIFF
--- a/apps/ccd/automation/kustomization.yaml
+++ b/apps/ccd/automation/kustomization.yaml
@@ -43,3 +43,4 @@ resources:
   - ../ccd-next-hearing-date-updater/image-policy.yaml
   - ../ccd-next-hearing-date-updater/image-repo.yaml
   - ../ccd-next-hearing-date-updater/demo-image-policy.yaml
+  - ../ccd-message-publisher/demo-image-policy.yaml

--- a/apps/ccd/automation/kustomization.yaml
+++ b/apps/ccd/automation/kustomization.yaml
@@ -43,4 +43,4 @@ resources:
   - ../ccd-next-hearing-date-updater/image-policy.yaml
   - ../ccd-next-hearing-date-updater/image-repo.yaml
   - ../ccd-next-hearing-date-updater/demo-image-policy.yaml
-  - ../ccd-message-publisher/demo-image-policy.yaml
+  - ../message-publisher/demo-image-policy.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/CCD-5104

### Change description ###

Currently can't see any work allocation tasks being created in demo when events normally would trigger them. in wa-demo appinsights it is consistently logging that there are no task(s) to initiate.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
