### PR TITLE
Adding namespace label patch file for env-injector, updating all demo namespaces to add patch reference

### DIFF
--- a/apps/aac/demo/base/kustomization.yaml
+++ b/apps/aac/demo/base/kustomization.yaml
@@ -10,3 +10,4 @@ patches:
   - path: ../../manage-case-assignment/demo.yaml
   - path: ../../aac-ac-int-manage-case-assignment/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/adoption/demo/base/kustomization.yaml
+++ b/apps/adoption/demo/base/kustomization.yaml
@@ -11,3 +11,4 @@ patches:
   - path: ../../adoption-cron-draft-case-deletion-alert/demo.yaml
   - path: ../../adoption-cron-multi-child-draft-application-alert/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/am/demo/base/kustomization.yaml
+++ b/apps/am/demo/base/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
   - path: ../../am-org-role-mapping-service/demo.yaml
   - path: ../../am-judicial-booking-service/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/bar/demo/base/kustomization.yaml
+++ b/apps/bar/demo/base/kustomization.yaml
@@ -13,3 +13,4 @@ patches:
   - path: ../../bar-api/demo.yaml
   - path: ../../bar-web-int/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/base/namespace-injector-label.yaml
+++ b/apps/base/namespace-injector-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE}
+  labels:
+    hmcts.github.com/envInjector: enabled
+    slackChannel: ${TEAM_NOTIFICATION_CHANNEL}

--- a/apps/base/namespace-injector-label.yaml
+++ b/apps/base/namespace-injector-label.yaml
@@ -4,4 +4,3 @@ metadata:
   name: ${NAMESPACE}
   labels:
     hmcts.github.com/envInjector: enabled
-    slackChannel: ${TEAM_NOTIFICATION_CHANNEL}

--- a/apps/bsp/demo/base/kustomization.yaml
+++ b/apps/bsp/demo/base/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
   - path: ../../bulk-scan-sample-app/demo.yaml
   - path: ../../bulk-scan-processor/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/camunda/demo/base/kustomization.yaml
+++ b/apps/camunda/demo/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../camunda-api/demo.yaml
   - path: ../../camunda-ui/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/ccd/demo/base/kustomization.yaml
+++ b/apps/ccd/demo/base/kustomization.yaml
@@ -34,3 +34,4 @@ patches:
   - path: ../../ccd-ac-int-data-store-api/demo.yaml
   - path: ../../ccd-test-stubs-service/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/civil/demo/base/kustomization.yaml
+++ b/apps/civil/demo/base/kustomization.yaml
@@ -24,3 +24,4 @@ patches:
   - path: ../../civil-general-applications/demo.yaml
   - path: ../../serviceaccount/demo.yaml
   - path: ../../civil-sdt-gateway/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/cnp/demo/base/kustomization.yaml
+++ b/apps/cnp/demo/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../plum-recipe-backend/demo.yaml
   - path: ../../plum-recipe-receiver/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/cpo/demo/base/kustomization.yaml
+++ b/apps/cpo/demo/base/kustomization.yaml
@@ -10,3 +10,4 @@ patches:
   - path: ../../case-payment-orders-api/demo.yaml
   - path: ../../case-payment-orders-api-int/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/cui/demo/base/kustomization.yaml
+++ b/apps/cui/demo/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: cui
 patches:
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/dg/demo/base/kustomization.yaml
+++ b/apps/dg/demo/base/kustomization.yaml
@@ -8,3 +8,4 @@ patches:
   - path: ../../dg-docassembly/demo.yaml
   - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/disposer/demo/base/kustomization.yaml
+++ b/apps/disposer/demo/base/kustomization.yaml
@@ -7,3 +7,4 @@ namespace: disposer
 patches:
   - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/divorce/demo/base/kustomization.yaml
+++ b/apps/divorce/demo/base/kustomization.yaml
@@ -17,3 +17,4 @@ patches:
   - path: ../../div-rfe/demo.yaml
   - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/dm-store/demo/base/kustomization.yaml
+++ b/apps/dm-store/demo/base/kustomization.yaml
@@ -8,3 +8,4 @@ patches:
   - path: ../../identity/demo.yaml
   - path: ../../dm-store/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/docmosis/demo/base/kustomization.yaml
+++ b/apps/docmosis/demo/base/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - docmosis-secret.yaml
 namespace: docmosis
 patches:
-- path: ../../docmosis/demo.yaml
+  - path: ../../docmosis/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/docmosis/demo/base/kustomization.yaml
+++ b/apps/docmosis/demo/base/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- ../../../rbac/nonprod-role.yaml
-- docmosis-secret.yaml
+  - ../../base
+  - ../../../rbac/nonprod-role.yaml
+  - docmosis-secret.yaml
 namespace: docmosis
 patches:
   - path: ../../docmosis/demo.yaml

--- a/apps/em/demo/base/kustomization.yaml
+++ b/apps/em/demo/base/kustomization.yaml
@@ -13,3 +13,4 @@ patches:
   - path: ../../em-stitching/demo.yaml
   - path: ../../em-hrs-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/et-pet/demo/base/kustomization.yaml
+++ b/apps/et-pet/demo/base/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
   - path: ../../et-pet-api/demo.yaml
   - path: ../../et-pet-admin/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/et/demo/base/kustomization.yaml
+++ b/apps/et/demo/base/kustomization.yaml
@@ -13,3 +13,4 @@ patches:
   - path: ../../et-sya/demo.yaml
   - path: ../../et-sya-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/ethos/demo/base/kustomization.yaml
+++ b/apps/ethos/demo/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../ecm-consumer/demo.yaml
   - path: ../../repl-docmosis-service/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/fact/demo/base/kustomization.yaml
+++ b/apps/fact/demo/base/kustomization.yaml
@@ -10,3 +10,4 @@ patches:
   - path: ../../fact-frontend/demo.yaml
   - path: ../../fact-admin/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/family-public-law/demo/base/kustomization.yaml
+++ b/apps/family-public-law/demo/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../fpl-case-service/demo.yaml
   - path: ../../fpl-cron-ccd-data-migration-tool/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/fees-pay/demo/base/kustomization.yaml
+++ b/apps/fees-pay/demo/base/kustomization.yaml
@@ -58,3 +58,4 @@ patches:
   - path: ../../unprocessed-payment-update-int/demo.yaml
   - path: ../../duplicate-payment-process/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/financial-remedy/demo/base/kustomization.yaml
+++ b/apps/financial-remedy/demo/base/kustomization.yaml
@@ -8,3 +8,4 @@ patches:
   - path: ../../finrem-cos/demo.yaml
   - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/fis/demo/base/kustomization.yaml
+++ b/apps/fis/demo/base/kustomization.yaml
@@ -15,3 +15,4 @@ patches:
   - path: ../../fis-cos-api/demo.yaml
   - path: ../../fis-ds-update-web/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/help-with-fees/demo/base/kustomization.yaml
+++ b/apps/help-with-fees/demo/base/kustomization.yaml
@@ -10,3 +10,4 @@ patches:
   - path: ../../help-with-fees-staffapp/demo.yaml
   - path: ../../help-with-fees-benefit-checker-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/hmc/demo/base/kustomization.yaml
+++ b/apps/hmc/demo/base/kustomization.yaml
@@ -17,3 +17,4 @@ patches:
   - path: ../../hmc-hmi-outbound-adapter/demo.yaml
   - path: ../../hmc-hmi-inbound-adapter/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/ia/demo/base/kustomization.yaml
+++ b/apps/ia/demo/base/kustomization.yaml
@@ -21,3 +21,4 @@ patches:
   - path: ../../ia-case-notifications-api/demo.yaml
   - path: ../../ia-hearings-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/idam/demo/base/kustomization.yaml
+++ b/apps/idam/demo/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
   - path: ../../idam-user-profile-bridge/demo.yaml
   - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/jps/demo/base/kustomization.yaml
+++ b/apps/jps/demo/base/kustomization.yaml
@@ -10,3 +10,4 @@ patches:
   - path: ../../jps-judicial-payment-service/demo.yaml
   - path: ../../serviceaccount/demo.yaml
   - path: ../../jps-judicial-payment-frontend/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/lau/demo/base/kustomization.yaml
+++ b/apps/lau/demo/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
   - path: ../../lau-idam-backend-int/demo.yaml
   - path: ../../lau-frontend/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/money-claims/demo/base/kustomization.yaml
+++ b/apps/money-claims/demo/base/kustomization.yaml
@@ -20,3 +20,4 @@ patches:
   - path: ../../../dg/identity/demo.yaml
   - path: ../../../xui/identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/nfdiv/demo/base/kustomization.yaml
+++ b/apps/nfdiv/demo/base/kustomization.yaml
@@ -18,3 +18,4 @@ patches:
   - path: ../../nfdiv-frontend/demo.yaml
   - path: ../../nfdiv-case-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/pcq/demo/base/kustomization.yaml
+++ b/apps/pcq/demo/base/kustomization.yaml
@@ -15,3 +15,4 @@ patches:
   - path: ../../pcq-backend/demo.yaml
   - path: ../../pcq-frontend/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/private-law/demo/base/kustomization.yaml
+++ b/apps/private-law/demo/base/kustomization.yaml
@@ -11,3 +11,4 @@ patches:
   - path: ../../prl-dgs/demo.yaml
   - path: ../../prl-ccd-case-migration/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/probate/demo/base/kustomization.yaml
+++ b/apps/probate/demo/base/kustomization.yaml
@@ -18,3 +18,4 @@ patches:
   - path: ../../probate-submit-service/demo.yaml
   - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/rd/demo/base/kustomization.yaml
+++ b/apps/rd/demo/base/kustomization.yaml
@@ -35,3 +35,4 @@ patches:
   - path: ../../rd-location-ref-api/demo.yaml
   - path: ../../rd-judicial-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/reform-scan/demo/base/kustomization.yaml
+++ b/apps/reform-scan/demo/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../reform-scan-notification-service/demo.yaml
   - path: ../../reform-scan-blob-router/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/rpe/demo/base/kustomization.yaml
+++ b/apps/rpe/demo/base/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
   - path: ../../pdf-service/demo.yaml
   - path: ../../rpe-send-letter-service/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/rpts/demo/base/kustomization.yaml
+++ b/apps/rpts/demo/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../rpts-api/demo.yaml
   - path: ../../rpts-frontend/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/sptribs/demo/base/kustomization.yaml
+++ b/apps/sptribs/demo/base/kustomization.yaml
@@ -11,3 +11,4 @@ patches:
   - path: ../../sptribs-case-api/demo.yaml
   - path: ../../sptribs-frontend/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/sscs/demo/base/kustomization.yaml
+++ b/apps/sscs/demo/base/kustomization.yaml
@@ -18,3 +18,4 @@ patches:
   - path: ../../sscs-evidence-share/demo.yaml
   - path: ../../sscs-bulk-scan/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/tax-tribunals/demo/base/kustomization.yaml
+++ b/apps/tax-tribunals/demo/base/kustomization.yaml
@@ -7,3 +7,4 @@ namespace: tax-tribunals
 patches:
   - path: ../../tax-tribunals-application/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/ts/demo/base/kustomization.yaml
+++ b/apps/ts/demo/base/kustomization.yaml
@@ -10,3 +10,4 @@ patches:
   - path: ../../ts-translation-service/demo.yaml
   - path: ../../ts-translation-service-int/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/wa/demo/base/kustomization.yaml
+++ b/apps/wa/demo/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
   - path: ../../wa-task-management-api/demo.yaml
   - path: ../../wa-workflow-api/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml

--- a/apps/xui/demo/base/kustomization.yaml
+++ b/apps/xui/demo/base/kustomization.yaml
@@ -27,3 +27,4 @@ patches:
   - path: ../../xui-webapp-wa-integration/demo.yaml
   - path: ../../xui-webapp-ac-integration/demo.yaml
   - path: ../../serviceaccount/demo.yaml
+  - path: ../../../base/namespace-injector-label.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16162


### Change description ###
Adding namespace label patch file for env-injector, updating all demo namespaces to add patch reference

Example of kustomize build output:
```
╰─$ kustomize build --load-restrictor LoadRestrictionsNone apps/money-claims/demo/base/ | head                  
apiVersion: v1
kind: Namespace
metadata:
  labels:
    hmcts.github.com/envInjector: enabled
    slackChannel: ${TEAM_NOTIFICATION_CHANNEL}
  name: money-claims
```

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] tests have been updated / new tests has been added (if needed)