### PR TITLE
Re-added tribunals frontend to sscs perftest

### DIFF
--- a/apps/sscs/perftest/base/kustomization.yaml
+++ b/apps/sscs/perftest/base/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../sscs-hearings-api/sscs-hearings-api.yaml
   - ../../sscs-bulk-scan/sscs-bulk-scan.yaml
+  - ../../sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
 namespace: sscs
-  - ../../sscs-tribunals-frontend/perftest.yaml
 patches:
   - path: ../../identity/perftest.yaml
   - path: ../../sscs-cor-frontend/perftest.yaml
@@ -14,6 +14,7 @@ patches:
   - path: ../../sscs-ccd-callback-orchestrator/perftest.yaml
   - path: ../../sscs-hearings-api/perftest.yaml
   - path: ../../sscs-tya-notif/perftest.yaml
+  - path: ../../sscs-tribunals-frontend/perftest.yaml
   - path: ../../sscs-evidence-share/perftest.yaml
   - path: ../../sscs-bulk-scan/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16076


### Change description ###
Added sscs-tribunals-frontend to fix 502 error. Was removed previously due to outdated redis version but this should be fixed now.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
