### PR TITLE
dtspo-15812: move ado chart spec from base to ptl patch to avoid ptlsbox clash

### DIFF
--- a/apps/azure-devops/azure-devops-agent/azure-devops-agent.yaml
+++ b/apps/azure-devops/azure-devops-agent/azure-devops-agent.yaml
@@ -35,11 +35,3 @@ spec:
     cpuLimits: 2000m
     successfulJobsHistoryLimit: 5
     failedJobsHistoryLimit: 5
-  chart:
-    spec:
-      chart: function
-      version: 2.3.4
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/azure-devops/azure-devops-agent/ptl-intsvc.yaml
+++ b/apps/azure-devops/azure-devops-agent/ptl-intsvc.yaml
@@ -11,3 +11,11 @@ spec:
         poolID: "26"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
+  chart:
+    spec:
+      chart: function
+      version: 2.3.4
+      sourceRef:
+        kind: HelmRepository
+        name: hmctspublic
+        namespace: flux-system


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15812


### Change description ###

* move ado chart spec from base to ptl patch to avoid ptlsbox clash


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
