### PR TITLE
Hardcode reference to latest for now

### DIFF
--- a/apps/slack-help-bot/ccd-slack-help-bot/ccd-slack-help-bot.yaml
+++ b/apps/slack-help-bot/ccd-slack-help-bot/ccd-slack-help-bot.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: ccd-slack-help-bot
   values:
     replicas: 1
-    image: hmctspublic.azurecr.io/ccd/slack-help-bot:prod-87e78f9-40 #{"$imagepolicy": "flux-system:ccd-slack-help-bot"}
+    image: hmctspublic.azurecr.io/ccd/slack-help-bot:prod-a838897-20240103110509
     environment:
       CCD_SLACK_REPORT_CHANNEL: ccd_support
       CCD_SLACK_REPORT_CHANNEL_ID: CG1QC1L66


### PR DESCRIPTION
### Change description ###
Until the older image tagging convention gets removed by cleanup jobs - as older images with previous convention are currently considered newer.