### PR TITLE
Disable automatic jenkins docker update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,9 @@
   "extends": [
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/flux"
+  ],
+  "ignorePaths": [
+    "apps/jenkins/jenkins/jenkins-controller-version.yaml",
+    "apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml"
   ]
 }


### PR DESCRIPTION
### Change description ###
Temporarily disabling updates from renovate to the jenkins docker image until the issue with Sonar plugin 2.17 is resolved
Manual updates can still be made

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
