### PR TITLE
More resources for fact-api

### DIFF
--- a/apps/fact/fact-api/fact-api.yaml
+++ b/apps/fact/fact-api/fact-api.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       replicas: 2
-      memoryRequests: "1Gi"
+      memoryRequests: "1.5Gi"
       cpuRequests: "500m"
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/fact/api:prod-97b2445-20231220130657 #{"$imagepolicy": "flux-system:fact-api"}


### PR DESCRIPTION
memory is still too high for replica count to drop, should be cheaper to increase memory requests than run (9 * 800 = 7.2Gi)

```
❯ kubectl get hpa
NAME                   REFERENCE                         TARGETS            MINPODS   MAXPODS   REPLICAS   AGE
fact-api-java          Deployment/fact-api-java          2%/80%, 78%/80%    2         9         9          179d
```

```
❯ kubectl top  pod
fact-api-java-6cfdfcc4d6-gngj6          11m          823Mi
fact-api-java-6cfdfcc4d6-grd2z          9m           807Mi
fact-api-java-6cfdfcc4d6-hdk24          17m          800Mi
fact-api-java-6cfdfcc4d6-kvmq2          17m          798Mi
fact-api-java-6cfdfcc4d6-mrwmf          22m          797Mi
fact-api-java-6cfdfcc4d6-plshs          18m          817Mi
fact-api-java-6cfdfcc4d6-snlcg          11m          802Mi
fact-api-java-6cfdfcc4d6-vtqc7          9m           811Mi
fact-api-java-6cfdfcc4d6-wzbvj          13m          810Mi
```