### PR TITLE
DTSPO-16194: upgrade non-prod envs to flux 2.2.2

### DIFF
--- a/apps/flux-system/aat/base/kustomization.yaml
+++ b/apps/flux-system/aat/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_2_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_2_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/ithc/base/kustomization.yaml
+++ b/apps/flux-system/ithc/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_2_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/perftest/base/kustomization.yaml
+++ b/apps/flux-system/perftest/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_2_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/sbox-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/sbox-intsvc/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_2_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ../../base/gotk-components.yaml
+- ../../base/patches/gotk-components-flux-v2_2_2.yaml
 - aks-sops-aadpodidentity.yaml
 patches:
 - path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16194


### Change description ###

* upgrade non-prod envs to flux 2.2.2 (aat, ithc, sbox, ptlsbox, demo, perftest)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
