### PR TITLE
DTSPO-15526 - Enable dynatrace in neuvector ns on AAT

### DIFF
--- a/apps/dynatrace/aat/base/dynakube.yaml
+++ b/apps/dynatrace/aat/base/dynakube.yaml
@@ -9,9 +9,3 @@ spec:
     cloudNativeFullStack:
       args:
         - --set-host-group=AAT_CFT
-  namespaceSelector:
-    matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: NotIn
-        values:
-          - neuvector


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15526

### Change description ###
Re-enable dynatrace on neuvector namespace in AAT
This was disabled by https://github.com/hmcts/cnp-flux-config/pull/24787/ to prevent a reoccurrence of the P1 issue related to the Palo Alto back in September 2023
Will be monitored by Dynatrace team to see if excess logs are once again being generated

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
