### PR TITLE
DTSAM-78 enable disposer_1_0 flag on RAS in AAT

### DIFF
--- a/apps/am/am-role-assignment-service/aat.yaml
+++ b/apps/am/am-role-assignment-service/aat.yaml
@@ -14,5 +14,6 @@ spec:
         AM_INFO: false
         APPLICATION_LOGGING_LEVEL: INFO
         BYPASS_ORG_DROOL_RULE: true
+        DB_FEATURE_FLAG_ENABLE: disposer_1_0
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api
         MAX_POOL_SIZE: 20


### PR DESCRIPTION
### Jira link (if applicable)

[DTSAM-78](https://tools.hmcts.net/jira/browse/DTSAM-78) _"Add RAS drool rule to allow disposer-idam-user to create CITIZEN case roles"_

### Change description ###

Enable the `disposer_1_0` flag on RAS in AAT.

> NB: this PR is dependent on hmcts/am-role-assignment-service#2115.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change - NO
