### PR TITLE
CCD logstash: add scalar back to extrEnv but keep indentation change

### DIFF
--- a/apps/ccd/ccd-logstash/ccd-logstash.yaml
+++ b/apps/ccd/ccd-logstash/ccd-logstash.yaml
@@ -19,7 +19,7 @@ spec:
     envFrom:
       - secretRef:
           name: logstash-secret
-    extraEnvs:
+    extraEnvs: |
       - name: DUMMY_RESTART_VAR
         value: true
     extraInitContainers: |


### PR DESCRIPTION
### Change description ###

* add scalar back to extrEnv but keep indentation change

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
