### PR TITLE
AM-3070 Enable ORM switch to eLinks V2 in Prod

### DIFF
--- a/apps/am/am-org-role-mapping-service/prod.yaml
+++ b/apps/am/am-org-role-mapping-service/prod.yaml
@@ -7,6 +7,8 @@ spec:
     java:
       environment:
         AM_INFO: false
+        JUDICIAL_REF_APP_V2_ACTIVE: true
+        JUDICIAL_REF_APP_V2_FILTER_AUTHS_BY_APP_ID: true
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
         IDAM_USER_URL: https://idam-api.platform.hmcts.net
         APPLICATION_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION
### Jira link (if applicable)

[AM-3070](https://tools.hmcts.net/jira/browse/AM-3070) _"Enable eLinks V2 in PROD"_

### Change description ###

Enable ORM switch to eLinks V2 in Prod.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change - NO
