### PR TITLE
Plum: bump HelmRelease & ImageRepository kinds API version

### DIFF
--- a/apps/cnp/plum-batch/plum-batch.yaml
+++ b/apps/cnp/plum-batch/plum-batch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-batch

--- a/apps/cnp/plum-batch/sbox.yaml
+++ b/apps/cnp/plum-batch/sbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-batch

--- a/apps/cnp/plum-frontend/aat.yaml
+++ b/apps/cnp/plum-frontend/aat.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/image-repo.yaml
+++ b/apps/cnp/plum-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/ithc.yaml
+++ b/apps/cnp/plum-frontend/ithc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/perftest.yaml
+++ b/apps/cnp/plum-frontend/perftest.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/plum-frontend.yaml
+++ b/apps/cnp/plum-frontend/plum-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/prod.yaml
+++ b/apps/cnp/plum-frontend/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-recipe-backend/aat.yaml
+++ b/apps/cnp/plum-recipe-backend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/demo.yaml
+++ b/apps/cnp/plum-recipe-backend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/image-repo.yaml
+++ b/apps/cnp/plum-recipe-backend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/ithc.yaml
+++ b/apps/cnp/plum-recipe-backend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/perftest.yaml
+++ b/apps/cnp/plum-recipe-backend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/plum-recipe-backend.yaml
+++ b/apps/cnp/plum-recipe-backend/plum-recipe-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/prod.yaml
+++ b/apps/cnp/plum-recipe-backend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/recipe-backend-test-image-repo.yaml
+++ b/apps/cnp/plum-recipe-backend/recipe-backend-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: plum-recipe-backend-recipe-backend-test

--- a/apps/cnp/plum-recipe-backend/sbox.yaml
+++ b/apps/cnp/plum-recipe-backend/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-receiver/aat.yaml
+++ b/apps/cnp/plum-recipe-receiver/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/demo.yaml
+++ b/apps/cnp/plum-recipe-receiver/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/image-policy.yaml
+++ b/apps/cnp/plum-recipe-receiver/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/ithc.yaml
+++ b/apps/cnp/plum-recipe-receiver/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/perftest.yaml
+++ b/apps/cnp/plum-recipe-receiver/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/plum-recipe-receiver.yaml
+++ b/apps/cnp/plum-recipe-receiver/plum-recipe-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/prod.yaml
+++ b/apps/cnp/plum-recipe-receiver/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver

--- a/apps/cnp/plum-recipe-receiver/sbox.yaml
+++ b/apps/cnp/plum-recipe-receiver/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: plum-recipe-receiver


### PR DESCRIPTION
### Change description ###
 * bump HelmRelease & ImageRepository kinds API version after flux 2.2.0 upgrade to test before mass migration


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
