### PR TITLE
upgrade HelmRelease apiVersion from v2beta1 to v2beta2 introudced in flux 2.2.0

### DIFF
--- a/apps/aac/aac-ac-int-manage-case-assignment/aac-ac-int-manage-case-assignment.yaml
+++ b/apps/aac/aac-ac-int-manage-case-assignment/aac-ac-int-manage-case-assignment.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: aac-ac-int-manage-case-assignment

--- a/apps/aac/aac-ac-int-manage-case-assignment/demo.yaml
+++ b/apps/aac/aac-ac-int-manage-case-assignment/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: aac-ac-int-manage-case-assignment

--- a/apps/aac/manage-case-assignment/aat.yaml
+++ b/apps/aac/manage-case-assignment/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: manage-case-assignment

--- a/apps/aac/manage-case-assignment/demo.yaml
+++ b/apps/aac/manage-case-assignment/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: manage-case-assignment

--- a/apps/aac/manage-case-assignment/ithc.yaml
+++ b/apps/aac/manage-case-assignment/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: manage-case-assignment

--- a/apps/aac/manage-case-assignment/manage-case-assignment.yaml
+++ b/apps/aac/manage-case-assignment/manage-case-assignment.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: manage-case-assignment

--- a/apps/aac/manage-case-assignment/perftest.yaml
+++ b/apps/aac/manage-case-assignment/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: manage-case-assignment

--- a/apps/aac/manage-case-assignment/prod.yaml
+++ b/apps/aac/manage-case-assignment/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: manage-case-assignment

--- a/apps/admin/aat/01/traefik-neuvector-api.yaml
+++ b/apps/admin/aat/01/traefik-neuvector-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik-neuvector-api

--- a/apps/admin/delete-hung-pods/cron.yaml
+++ b/apps/admin/delete-hung-pods/cron.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: restart-pods

--- a/apps/admin/env-injector/demo.yaml
+++ b/apps/admin/env-injector/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: env-injector-webhook

--- a/apps/admin/env-injector/env-injector.yaml
+++ b/apps/admin/env-injector/env-injector.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: env-injector-webhook

--- a/apps/admin/env-injector/sbox.yaml
+++ b/apps/admin/env-injector/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: env-injector-webhook

--- a/apps/admin/external-dns-2/external-dns-private/external-dns-private.yaml
+++ b/apps/admin/external-dns-2/external-dns-private/external-dns-private.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/apps/admin/external-dns-2/external-dns.yaml
+++ b/apps/admin/external-dns-2/external-dns.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/apps/admin/external-dns-2/preview/00-external-dns-private.yaml
+++ b/apps/admin/external-dns-2/preview/00-external-dns-private.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns-private

--- a/apps/admin/external-dns-2/preview/01-external-dns-private.yaml
+++ b/apps/admin/external-dns-2/preview/01-external-dns-private.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns-private

--- a/apps/admin/external-dns-2/preview/external-dns-private.yaml
+++ b/apps/admin/external-dns-2/preview/external-dns-private.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns-private

--- a/apps/admin/perftest/00/keda-patch.yaml
+++ b/apps/admin/perftest/00/keda-patch.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: keda

--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/aat/01.yaml
+++ b/apps/admin/traefik2/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/aat/internal-cert-patch.yaml
+++ b/apps/admin/traefik2/aat/internal-cert-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/preview/01.yaml
+++ b/apps/admin/traefik2/preview/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/preview/internal-cert-release-patch.yaml
+++ b/apps/admin/traefik2/preview/internal-cert-release-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/prod/00.yaml
+++ b/apps/admin/traefik2/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/prod/01.yaml
+++ b/apps/admin/traefik2/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ptl-intsvc/00.yaml
+++ b/apps/admin/traefik2/ptl-intsvc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ptl-intsvc/hmcts-wildcard-release-patch.yaml
+++ b/apps/admin/traefik2/ptl-intsvc/hmcts-wildcard-release-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/sbox-intsvc/00.yaml
+++ b/apps/admin/traefik2/sbox-intsvc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/sbox-intsvc/hmcts-wildcard-release-patch.yaml
+++ b/apps/admin/traefik2/sbox-intsvc/hmcts-wildcard-release-patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/adoption/adoption-cos-api/aat.yaml
+++ b/apps/adoption/adoption-cos-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-cos-api/adoption-cos-api.yaml
+++ b/apps/adoption/adoption-cos-api/adoption-cos-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-cos-api/demo.yaml
+++ b/apps/adoption/adoption-cos-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-cos-api/perftest.yaml
+++ b/apps/adoption/adoption-cos-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-cos-api/prod.yaml
+++ b/apps/adoption/adoption-cos-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/aat.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cron-draft-case-deletion-alert

--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cron-draft-case-deletion-alert

--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/demo.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cron-draft-case-deletion-alert

--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/ithc.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cron-draft-case-deletion-alert

--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/perftest.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cron-draft-case-deletion-alert

--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/prod.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-cron-draft-case-deletion-alert

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/aat.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-multi-child-draft-application-alert

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-multi-child-draft-application-alert

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/demo.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-multi-child-draft-application-alert

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/ithc.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-multi-child-draft-application-alert

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/perftest.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-multi-child-draft-application-alert

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/prod.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-multi-child-draft-application-alert

--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-web

--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-web

--- a/apps/adoption/adoption-web/demo.yaml
+++ b/apps/adoption/adoption-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-web

--- a/apps/adoption/adoption-web/ithc.yaml
+++ b/apps/adoption/adoption-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-web

--- a/apps/adoption/adoption-web/perftest.yaml
+++ b/apps/adoption/adoption-web/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-web

--- a/apps/adoption/adoption-web/prod.yaml
+++ b/apps/adoption/adoption-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: adoption-web

--- a/apps/am/am-judicial-booking-service/aat.yaml
+++ b/apps/am/am-judicial-booking-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-judicial-booking-service/am-judicial-booking-service.yaml
+++ b/apps/am/am-judicial-booking-service/am-judicial-booking-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-judicial-booking-service/demo.yaml
+++ b/apps/am/am-judicial-booking-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-judicial-booking-service/ithc.yaml
+++ b/apps/am/am-judicial-booking-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-judicial-booking-service/perftest.yaml
+++ b/apps/am/am-judicial-booking-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-judicial-booking-service/prod.yaml
+++ b/apps/am/am-judicial-booking-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-org-role-mapping-service/aat.yaml
+++ b/apps/am/am-org-role-mapping-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-org-role-mapping-service/am-org-role-mapping-service.yaml
+++ b/apps/am/am-org-role-mapping-service/am-org-role-mapping-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-org-role-mapping-service/ithc.yaml
+++ b/apps/am/am-org-role-mapping-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-org-role-mapping-service/perftest.yaml
+++ b/apps/am/am-org-role-mapping-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-org-role-mapping-service/prod.yaml
+++ b/apps/am/am-org-role-mapping-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-role-assignment-batch-service/aat.yaml
+++ b/apps/am/am-role-assignment-batch-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
+++ b/apps/am/am-role-assignment-batch-service/am-role-assignment-batch-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-batch-service/demo.yaml
+++ b/apps/am/am-role-assignment-batch-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-batch-service/ithc.yaml
+++ b/apps/am/am-role-assignment-batch-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-batch-service/perftest.yaml
+++ b/apps/am/am-role-assignment-batch-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-batch-service/prod.yaml
+++ b/apps/am/am-role-assignment-batch-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-refresh-batch/aat.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/am-role-assignment-refresh-batch.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-refresh-batch/demo.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-refresh-batch/ithc.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-refresh-batch/perftest.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-refresh-batch/prod.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-service/aat.yaml
+++ b/apps/am/am-role-assignment-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-service

--- a/apps/am/am-role-assignment-service/am-role-assignment-service.yaml
+++ b/apps/am/am-role-assignment-service/am-role-assignment-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-service

--- a/apps/am/am-role-assignment-service/demo.yaml
+++ b/apps/am/am-role-assignment-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-service

--- a/apps/am/am-role-assignment-service/ithc.yaml
+++ b/apps/am/am-role-assignment-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-service

--- a/apps/am/am-role-assignment-service/perftest.yaml
+++ b/apps/am/am-role-assignment-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-service

--- a/apps/am/am-role-assignment-service/prod.yaml
+++ b/apps/am/am-role-assignment-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: am-role-assignment-service

--- a/apps/azure-devops/azure-devops-agent/azure-devops-agent.yaml
+++ b/apps/azure-devops/azure-devops-agent/azure-devops-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent/ptl-intsvc.yaml
+++ b/apps/azure-devops/azure-devops-agent/ptl-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent/sbox-intsvc.yaml
+++ b/apps/azure-devops/azure-devops-agent/sbox-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/backstage/backstage/backstage.yaml
+++ b/apps/backstage/backstage/backstage.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: backstage

--- a/apps/backstage/backstage/cftptl-intsvc.yaml
+++ b/apps/backstage/backstage/cftptl-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: backstage

--- a/apps/backstage/backstage/sbox-intsvc.yaml
+++ b/apps/backstage/backstage/sbox-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: backstage

--- a/apps/bar/bar-api-int/bar-api-int.yaml
+++ b/apps/bar/bar-api-int/bar-api-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api-int

--- a/apps/bar/bar-api-int/demo.yaml
+++ b/apps/bar/bar-api-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api-int

--- a/apps/bar/bar-api/aat.yaml
+++ b/apps/bar/bar-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/apps/bar/bar-api/bar-api.yaml
+++ b/apps/bar/bar-api/bar-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/apps/bar/bar-api/demo.yaml
+++ b/apps/bar/bar-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/apps/bar/bar-api/ithc.yaml
+++ b/apps/bar/bar-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/apps/bar/bar-api/perftest.yaml
+++ b/apps/bar/bar-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/apps/bar/bar-api/prod.yaml
+++ b/apps/bar/bar-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-api

--- a/apps/bar/bar-web-int/bar-web-int.yaml
+++ b/apps/bar/bar-web-int/bar-web-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web-int

--- a/apps/bar/bar-web-int/demo.yaml
+++ b/apps/bar/bar-web-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web-int

--- a/apps/bar/bar-web/aat.yaml
+++ b/apps/bar/bar-web/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web

--- a/apps/bar/bar-web/bar-web.yaml
+++ b/apps/bar/bar-web/bar-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web

--- a/apps/bar/bar-web/demo.yaml
+++ b/apps/bar/bar-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web

--- a/apps/bar/bar-web/ithc.yaml
+++ b/apps/bar/bar-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web

--- a/apps/bar/bar-web/perftest.yaml
+++ b/apps/bar/bar-web/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web

--- a/apps/bar/bar-web/prod.yaml
+++ b/apps/bar/bar-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-web

--- a/apps/base/kustomize.yaml
+++ b/apps/base/kustomize.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: flux-system
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2beta2
         kind: HelmRelease
         metadata:
           name: test-helmrelease

--- a/apps/bsp/bulk-scan-orchestrator/aat.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator

--- a/apps/bsp/bulk-scan-orchestrator/bulk-scan-orchestrator.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/bulk-scan-orchestrator.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator

--- a/apps/bsp/bulk-scan-orchestrator/demo.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator

--- a/apps/bsp/bulk-scan-orchestrator/perftest.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator

--- a/apps/bsp/bulk-scan-orchestrator/prod.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-orchestrator

--- a/apps/bsp/bulk-scan-payment-processor/aat.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-payment-processor

--- a/apps/bsp/bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/bulk-scan-payment-processor.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-payment-processor

--- a/apps/bsp/bulk-scan-payment-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-payment-processor

--- a/apps/bsp/bulk-scan-payment-processor/prod.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-payment-processor

--- a/apps/bsp/bulk-scan-processor/aat.yaml
+++ b/apps/bsp/bulk-scan-processor/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor

--- a/apps/bsp/bulk-scan-processor/bulk-scan-processor.yaml
+++ b/apps/bsp/bulk-scan-processor/bulk-scan-processor.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor

--- a/apps/bsp/bulk-scan-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-processor/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor

--- a/apps/bsp/bulk-scan-processor/perftest.yaml
+++ b/apps/bsp/bulk-scan-processor/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor

--- a/apps/bsp/bulk-scan-processor/prod.yaml
+++ b/apps/bsp/bulk-scan-processor/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-processor

--- a/apps/bsp/bulk-scan-sample-app/aat.yaml
+++ b/apps/bsp/bulk-scan-sample-app/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-sample-app

--- a/apps/bsp/bulk-scan-sample-app/bulk-scan-sample-app.yaml
+++ b/apps/bsp/bulk-scan-sample-app/bulk-scan-sample-app.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-sample-app

--- a/apps/bsp/bulk-scan-sample-app/demo.yaml
+++ b/apps/bsp/bulk-scan-sample-app/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bulk-scan-sample-app

--- a/apps/camunda/camunda-api/aat.yaml
+++ b/apps/camunda/camunda-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-api

--- a/apps/camunda/camunda-api/camunda-api.yaml
+++ b/apps/camunda/camunda-api/camunda-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-api

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-api

--- a/apps/camunda/camunda-api/ithc.yaml
+++ b/apps/camunda/camunda-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-api

--- a/apps/camunda/camunda-api/perftest.yaml
+++ b/apps/camunda/camunda-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-api

--- a/apps/camunda/camunda-api/prod.yaml
+++ b/apps/camunda/camunda-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-api

--- a/apps/camunda/camunda-optimize/aat.yaml
+++ b/apps/camunda/camunda-optimize/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda-optimize/camunda-optimize.yaml
+++ b/apps/camunda/camunda-optimize/camunda-optimize.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda-optimize/demo.yaml
+++ b/apps/camunda/camunda-optimize/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda-optimize/ithc.yaml
+++ b/apps/camunda/camunda-optimize/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda-optimize/perftest.yaml
+++ b/apps/camunda/camunda-optimize/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda-optimize/prod.yaml
+++ b/apps/camunda/camunda-optimize/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda-ui/camunda-ui.yaml
+++ b/apps/camunda/camunda-ui/camunda-ui.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-ui

--- a/apps/camunda/camunda-ui/demo.yaml
+++ b/apps/camunda/camunda-ui/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-ui

--- a/apps/camunda/camunda-ui/ithc.yaml
+++ b/apps/camunda/camunda-ui/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-ui

--- a/apps/camunda/camunda-ui/perftest.yaml
+++ b/apps/camunda/camunda-ui/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-ui

--- a/apps/camunda/camunda-ui/prod.yaml
+++ b/apps/camunda/camunda-ui/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: camunda-ui

--- a/apps/ccd/ccd-ac-int-api-gateway-web/ccd-ac-int-api-gateway-web.yaml
+++ b/apps/ccd/ccd-ac-int-api-gateway-web/ccd-ac-int-api-gateway-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-ac-int-api-gateway-web

--- a/apps/ccd/ccd-ac-int-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-ac-int-api-gateway-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-ac-int-api-gateway-web

--- a/apps/ccd/ccd-ac-int-data-store-api/ccd-ac-int-data-store-api.yaml
+++ b/apps/ccd/ccd-ac-int-data-store-api/ccd-ac-int-data-store-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-ac-int-data-store-api

--- a/apps/ccd/ccd-ac-int-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-ac-int-data-store-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-ac-int-data-store-api

--- a/apps/ccd/ccd-ac-int-definition-store-api/ccd-ac-int-definition-store-api.yaml
+++ b/apps/ccd/ccd-ac-int-definition-store-api/ccd-ac-int-definition-store-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-ac-int-definition-store-api

--- a/apps/ccd/ccd-ac-int-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-ac-int-definition-store-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-ac-int-definition-store-api

--- a/apps/ccd/ccd-admin-web/ccd-admin-web.yaml
+++ b/apps/ccd/ccd-admin-web/ccd-admin-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-admin-web

--- a/apps/ccd/ccd-admin-web/demo.yaml
+++ b/apps/ccd/ccd-admin-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-admin-web

--- a/apps/ccd/ccd-admin-web/perftest.yaml
+++ b/apps/ccd/ccd-admin-web/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-admin-web

--- a/apps/ccd/ccd-admin-web/prod.yaml
+++ b/apps/ccd/ccd-admin-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-admin-web

--- a/apps/ccd/ccd-api-gateway-web/aat.yaml
+++ b/apps/ccd/ccd-api-gateway-web/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-api-gateway-web/ccd-api-gateway-web.yaml
+++ b/apps/ccd/ccd-api-gateway-web/ccd-api-gateway-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-api-gateway-web/ithc.yaml
+++ b/apps/ccd/ccd-api-gateway-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-api-gateway-web/perftest.yaml
+++ b/apps/ccd/ccd-api-gateway-web/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-api-gateway-web/prod.yaml
+++ b/apps/ccd/ccd-api-gateway-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-case-activity-api/aat.yaml
+++ b/apps/ccd/ccd-case-activity-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-activity-api

--- a/apps/ccd/ccd-case-activity-api/ccd-case-activity-api.yaml
+++ b/apps/ccd/ccd-case-activity-api/ccd-case-activity-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-activity-api

--- a/apps/ccd/ccd-case-activity-api/demo.yaml
+++ b/apps/ccd/ccd-case-activity-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-activity-api

--- a/apps/ccd/ccd-case-activity-api/perftest.yaml
+++ b/apps/ccd/ccd-case-activity-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-activity-api

--- a/apps/ccd/ccd-case-activity-api/prod.yaml
+++ b/apps/ccd/ccd-case-activity-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-activity-api

--- a/apps/ccd/ccd-case-disposer/aat.yaml
+++ b/apps/ccd/ccd-case-disposer/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-disposer/ccd-case-disposer.yaml
+++ b/apps/ccd/ccd-case-disposer/ccd-case-disposer.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-disposer/demo.yaml
+++ b/apps/ccd/ccd-case-disposer/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-disposer/ithc.yaml
+++ b/apps/ccd/ccd-case-disposer/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-disposer/perftest.yaml
+++ b/apps/ccd/ccd-case-disposer/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-disposer/prod.yaml
+++ b/apps/ccd/ccd-case-disposer/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-document-am-api/aat.yaml
+++ b/apps/ccd/ccd-case-document-am-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-document-am-api/ccd-case-document-am-api.yaml
+++ b/apps/ccd/ccd-case-document-am-api/ccd-case-document-am-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-document-am-api/demo.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-document-am-api/ithc.yaml
+++ b/apps/ccd/ccd-case-document-am-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-document-am-api/perftest.yaml
+++ b/apps/ccd/ccd-case-document-am-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-document-am-api/prod.yaml
+++ b/apps/ccd/ccd-case-document-am-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-print-service/ccd-case-print-service.yaml
+++ b/apps/ccd/ccd-case-print-service/ccd-case-print-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-print-service

--- a/apps/ccd/ccd-case-print-service/demo.yaml
+++ b/apps/ccd/ccd-case-print-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-print-service

--- a/apps/ccd/ccd-case-print-service/prod.yaml
+++ b/apps/ccd/ccd-case-print-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-case-print-service

--- a/apps/ccd/ccd-data-store-api/aat.yaml
+++ b/apps/ccd/ccd-data-store-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
+++ b/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/ithc.yaml
+++ b/apps/ccd/ccd-data-store-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/prod.yaml
+++ b/apps/ccd/ccd-data-store-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-definition-store-api/aat.yaml
+++ b/apps/ccd/ccd-definition-store-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-definition-store-api/ccd-definition-store-api.yaml
+++ b/apps/ccd/ccd-definition-store-api/ccd-definition-store-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-definition-store-api/ithc.yaml
+++ b/apps/ccd/ccd-definition-store-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-definition-store-api/perftest.yaml
+++ b/apps/ccd/ccd-definition-store-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-definition-store-api/prod.yaml
+++ b/apps/ccd/ccd-definition-store-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-int/ccd-int.yaml.disabled
+++ b/apps/ccd/ccd-int/ccd-int.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-int

--- a/apps/ccd/ccd-logstash-cmc/ccd-logstash-cmc.yaml
+++ b/apps/ccd/ccd-logstash-cmc/ccd-logstash-cmc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-cmc/ithc.yaml
+++ b/apps/ccd/ccd-logstash-cmc/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-cmc

--- a/apps/ccd/ccd-logstash-divorce/ccd-logstash-divorce.yaml
+++ b/apps/ccd/ccd-logstash-divorce/ccd-logstash-divorce.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-divorce/demo.yaml
+++ b/apps/ccd/ccd-logstash-divorce/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-divorce

--- a/apps/ccd/ccd-logstash-divorce/ithc.yaml
+++ b/apps/ccd/ccd-logstash-divorce/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-divorce

--- a/apps/ccd/ccd-logstash-ethos/ccd-logstash-ethos.yaml
+++ b/apps/ccd/ccd-logstash-ethos/ccd-logstash-ethos.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-ethos/ithc.yaml
+++ b/apps/ccd/ccd-logstash-ethos/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-ethos

--- a/apps/ccd/ccd-logstash-ethos/perftest.yaml
+++ b/apps/ccd/ccd-logstash-ethos/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-ethos

--- a/apps/ccd/ccd-logstash-indexer/aat.yaml
+++ b/apps/ccd/ccd-logstash-indexer/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer

--- a/apps/ccd/ccd-logstash-indexer/ccd-logstash-indexer.yaml
+++ b/apps/ccd/ccd-logstash-indexer/ccd-logstash-indexer.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-indexer/demo.yaml
+++ b/apps/ccd/ccd-logstash-indexer/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer

--- a/apps/ccd/ccd-logstash-indexer/ithc.yaml
+++ b/apps/ccd/ccd-logstash-indexer/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer

--- a/apps/ccd/ccd-logstash-indexer/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer

--- a/apps/ccd/ccd-logstash-indexer/prod.yaml
+++ b/apps/ccd/ccd-logstash-indexer/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer

--- a/apps/ccd/ccd-logstash-indexer2/ccd-logstash-indexer2.yaml
+++ b/apps/ccd/ccd-logstash-indexer2/ccd-logstash-indexer2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-indexer2/prod.yaml
+++ b/apps/ccd/ccd-logstash-indexer2/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer2

--- a/apps/ccd/ccd-logstash-indexer3/ccd-logstash-indexer3.yaml
+++ b/apps/ccd/ccd-logstash-indexer3/ccd-logstash-indexer3.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-indexer3/prod.yaml
+++ b/apps/ccd/ccd-logstash-indexer3/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer3

--- a/apps/ccd/ccd-logstash-indexer4/ccd-logstash-indexer4.yaml
+++ b/apps/ccd/ccd-logstash-indexer4/ccd-logstash-indexer4.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-indexer4/prod.yaml
+++ b/apps/ccd/ccd-logstash-indexer4/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer4

--- a/apps/ccd/ccd-logstash-indexer5/ccd-logstash-indexer5.yaml
+++ b/apps/ccd/ccd-logstash-indexer5/ccd-logstash-indexer5.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-indexer5/prod.yaml
+++ b/apps/ccd/ccd-logstash-indexer5/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer5

--- a/apps/ccd/ccd-logstash-indexer6/aat.yaml
+++ b/apps/ccd/ccd-logstash-indexer6/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-indexer6

--- a/apps/ccd/ccd-logstash-indexer6/ccd-logstash-indexer6.yaml
+++ b/apps/ccd/ccd-logstash-indexer6/ccd-logstash-indexer6.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-probate/ccd-logstash-probate.yaml
+++ b/apps/ccd/ccd-logstash-probate/ccd-logstash-probate.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-probate/ithc.yaml
+++ b/apps/ccd/ccd-logstash-probate/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-probate

--- a/apps/ccd/ccd-logstash-probateman/ccd-logstash-probateman.yaml
+++ b/apps/ccd/ccd-logstash-probateman/ccd-logstash-probateman.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-probateman

--- a/apps/ccd/ccd-logstash-probateman/demo.yaml
+++ b/apps/ccd/ccd-logstash-probateman/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-probateman

--- a/apps/ccd/ccd-logstash-sscs/ccd-logstash-sscs.yaml
+++ b/apps/ccd/ccd-logstash-sscs/ccd-logstash-sscs.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash-sscs/ithc.yaml
+++ b/apps/ccd/ccd-logstash-sscs/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-sscs

--- a/apps/ccd/ccd-logstash/aat.yaml
+++ b/apps/ccd/ccd-logstash/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-logstash/ccd-logstash-probateman.yaml
+++ b/apps/ccd/ccd-logstash/ccd-logstash-probateman.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash-probateman

--- a/apps/ccd/ccd-logstash/ccd-logstash.yaml
+++ b/apps/ccd/ccd-logstash/ccd-logstash.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-logstash

--- a/apps/ccd/ccd-next-hearing-date-updater/aat/00.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/aat/01.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/ccd-next-hearing-date-updater.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/ccd-next-hearing-date-updater.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/demo/00.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/demo/01.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/ithc/00.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/ithc/01.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/perftest/00.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/perftest/01.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/prod/00.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-next-hearing-date-updater/prod/01.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-test-stubs-service/aat.yaml
+++ b/apps/ccd/ccd-test-stubs-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-test-stubs-service

--- a/apps/ccd/ccd-test-stubs-service/ccd-test-stubs-service.yaml
+++ b/apps/ccd/ccd-test-stubs-service/ccd-test-stubs-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-test-stubs-service

--- a/apps/ccd/ccd-test-stubs-service/demo.yaml
+++ b/apps/ccd/ccd-test-stubs-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-test-stubs-service

--- a/apps/ccd/ccd-user-profile-api/aat.yaml
+++ b/apps/ccd/ccd-user-profile-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/ccd-user-profile-api/ccd-user-profile-api.yaml
+++ b/apps/ccd/ccd-user-profile-api/ccd-user-profile-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/ccd-user-profile-api/demo.yaml
+++ b/apps/ccd/ccd-user-profile-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/ccd-user-profile-api/ithc.yaml
+++ b/apps/ccd/ccd-user-profile-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/ccd-user-profile-api/perftest.yaml
+++ b/apps/ccd/ccd-user-profile-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/ccd-user-profile-api/prod.yaml
+++ b/apps/ccd/ccd-user-profile-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/demo-disabled/ccd-backend-frontend.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-backend-frontend.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-back-front

--- a/apps/ccd/demo-disabled/ccd-backend.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-backend.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-backend

--- a/apps/ccd/demo-disabled/ccd-demo.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-demo.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-demo

--- a/apps/ccd/demo-disabled/ccd-develop.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-develop.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-develop

--- a/apps/ccd/demo-disabled/ccd-full-with-pay.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-full-with-pay.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-full-with-pay

--- a/apps/ccd/demo-disabled/ccd-full.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-full.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-full

--- a/apps/ccd/demo-disabled/ccd-importer.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-importer.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-import

--- a/apps/ccd/demo-disabled/ccd-integration.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-integration.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-integration

--- a/apps/ccd/demo-disabled/latest-ccd-chart.yaml.disabled
+++ b/apps/ccd/demo-disabled/latest-ccd-chart.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-demo

--- a/apps/ccd/message-publisher/aat-00.yaml
+++ b/apps/ccd/message-publisher/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/aat-01.yaml
+++ b/apps/ccd/message-publisher/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/aat.yaml
+++ b/apps/ccd/message-publisher/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/demo.yaml
+++ b/apps/ccd/message-publisher/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/ithc-00.yaml
+++ b/apps/ccd/message-publisher/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/ithc-01.yaml
+++ b/apps/ccd/message-publisher/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/message-publisher.yaml
+++ b/apps/ccd/message-publisher/message-publisher.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/perftest-00.yaml
+++ b/apps/ccd/message-publisher/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/perftest-01.yaml
+++ b/apps/ccd/message-publisher/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/perftest.yaml
+++ b/apps/ccd/message-publisher/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/prod-00.yaml
+++ b/apps/ccd/message-publisher/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/ccd/message-publisher/prod-01.yaml
+++ b/apps/ccd/message-publisher/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: message-publisher

--- a/apps/civil/civil-citizen-ui/aat.yaml
+++ b/apps/civil/civil-citizen-ui/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/civil-citizen-ui.yaml
+++ b/apps/civil/civil-citizen-ui/civil-citizen-ui.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/demo.yaml
+++ b/apps/civil/civil-citizen-ui/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/prod.yaml
+++ b/apps/civil/civil-citizen-ui/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-citizen-ui

--- a/apps/civil/civil-general-applications/aat.yaml
+++ b/apps/civil/civil-general-applications/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-general-applications/civil-general-applications.yaml
+++ b/apps/civil/civil-general-applications/civil-general-applications.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-general-applications/demo.yaml
+++ b/apps/civil/civil-general-applications/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-general-applications/ithc.yaml
+++ b/apps/civil/civil-general-applications/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-general-applications/perftest.yaml
+++ b/apps/civil/civil-general-applications/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-general-applications/prod.yaml
+++ b/apps/civil/civil-general-applications/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-orchestrator-service/aat.yaml
+++ b/apps/civil/civil-orchestrator-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-orchestrator-service

--- a/apps/civil/civil-orchestrator-service/civil-orchestrator-service.yaml
+++ b/apps/civil/civil-orchestrator-service/civil-orchestrator-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-orchestrator-service

--- a/apps/civil/civil-orchestrator-service/demo.yaml
+++ b/apps/civil/civil-orchestrator-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-orchestrator-service

--- a/apps/civil/civil-orchestrator-service/ithc.yaml
+++ b/apps/civil/civil-orchestrator-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-orchestrator-service

--- a/apps/civil/civil-orchestrator-service/perftest.yaml
+++ b/apps/civil/civil-orchestrator-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-orchestrator-service

--- a/apps/civil/civil-sdt-commissioning/civil-sdt-commissioning.yaml
+++ b/apps/civil/civil-sdt-commissioning/civil-sdt-commissioning.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt-commissioning

--- a/apps/civil/civil-sdt-gateway/civil-sdt-gateway.yaml
+++ b/apps/civil/civil-sdt-gateway/civil-sdt-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt-gateway

--- a/apps/civil/civil-sdt-gateway/demo.yaml
+++ b/apps/civil/civil-sdt-gateway/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt-gateway

--- a/apps/civil/civil-sdt/civil-sdt.yaml
+++ b/apps/civil/civil-sdt/civil-sdt.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/demo-00.yaml
+++ b/apps/civil/civil-sdt/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/demo-01.yaml
+++ b/apps/civil/civil-sdt/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/ithc-00.yaml
+++ b/apps/civil/civil-sdt/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/ithc-01.yaml
+++ b/apps/civil/civil-sdt/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/perftest-00.yaml
+++ b/apps/civil/civil-sdt/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/perftest-01.yaml
+++ b/apps/civil/civil-sdt/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/prod-00.yaml
+++ b/apps/civil/civil-sdt/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-sdt/prod-01.yaml
+++ b/apps/civil/civil-sdt/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-service

--- a/apps/civil/civil-service/civil-service.yaml
+++ b/apps/civil/civil-service/civil-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-service

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-service

--- a/apps/civil/civil-service/ithc.yaml
+++ b/apps/civil/civil-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-service

--- a/apps/civil/civil-service/perftest.yaml
+++ b/apps/civil/civil-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-service

--- a/apps/civil/civil-service/prod.yaml
+++ b/apps/civil/civil-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: civil-service

--- a/apps/clamav-mirror/clamav/clamav.yaml
+++ b/apps/clamav-mirror/clamav/clamav.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: clamav-mirror

--- a/apps/cpo/case-payment-orders-api-int/case-payment-orders-api-int.yaml
+++ b/apps/cpo/case-payment-orders-api-int/case-payment-orders-api-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api-int

--- a/apps/cpo/case-payment-orders-api-int/demo.yaml
+++ b/apps/cpo/case-payment-orders-api-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api-int

--- a/apps/cpo/case-payment-orders-api/aat.yaml
+++ b/apps/cpo/case-payment-orders-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api

--- a/apps/cpo/case-payment-orders-api/case-payment-orders-api.yaml
+++ b/apps/cpo/case-payment-orders-api/case-payment-orders-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api

--- a/apps/cpo/case-payment-orders-api/demo.yaml
+++ b/apps/cpo/case-payment-orders-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api

--- a/apps/cpo/case-payment-orders-api/ithc.yaml
+++ b/apps/cpo/case-payment-orders-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api

--- a/apps/cpo/case-payment-orders-api/perftest.yaml
+++ b/apps/cpo/case-payment-orders-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api

--- a/apps/cpo/case-payment-orders-api/prod.yaml
+++ b/apps/cpo/case-payment-orders-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: case-payment-orders-api

--- a/apps/cui/cui-ra/aat.yaml
+++ b/apps/cui/cui-ra/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cui-ra

--- a/apps/cui/cui-ra/cui-ra.yaml
+++ b/apps/cui/cui-ra/cui-ra.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cui-ra

--- a/apps/cui/cui-ra/prod.yaml
+++ b/apps/cui/cui-ra/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cui-ra

--- a/apps/dg/dg-docassembly/demo.yaml
+++ b/apps/dg/dg-docassembly/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dg-docassembly

--- a/apps/dg/dg-docassembly/dg-docassembly.yaml
+++ b/apps/dg/dg-docassembly/dg-docassembly.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dg-docassembly

--- a/apps/dg/dg-docassembly/prod.yaml
+++ b/apps/dg/dg-docassembly/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dg-docassembly

--- a/apps/disposer/disposer-idam-user/aat-00.yaml
+++ b/apps/disposer/disposer-idam-user/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/aat-01.yaml
+++ b/apps/disposer/disposer-idam-user/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/demo-00.yaml
+++ b/apps/disposer/disposer-idam-user/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/demo-01.yaml
+++ b/apps/disposer/disposer-idam-user/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/disposer-idam-user.yaml
+++ b/apps/disposer/disposer-idam-user/disposer-idam-user.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/ithc-00.yaml
+++ b/apps/disposer/disposer-idam-user/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/ithc-01.yaml
+++ b/apps/disposer/disposer-idam-user/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/perftest-00.yaml
+++ b/apps/disposer/disposer-idam-user/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/perftest-01.yaml
+++ b/apps/disposer/disposer-idam-user/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/prod-00.yaml
+++ b/apps/disposer/disposer-idam-user/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/disposer/disposer-idam-user/prod-01.yaml
+++ b/apps/disposer/disposer-idam-user/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: disposer-idam-user

--- a/apps/divorce/div-cfs/demo.yaml
+++ b/apps/divorce/div-cfs/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cfs

--- a/apps/divorce/div-cfs/div-cfs.yaml
+++ b/apps/divorce/div-cfs/div-cfs.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cfs

--- a/apps/divorce/div-cms/aat.yaml
+++ b/apps/divorce/div-cms/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/apps/divorce/div-cms/demo.yaml
+++ b/apps/divorce/div-cms/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/apps/divorce/div-cms/div-cms.yaml
+++ b/apps/divorce/div-cms/div-cms.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/apps/divorce/div-cms/ithc.yaml
+++ b/apps/divorce/div-cms/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/apps/divorce/div-cms/perftest.yaml
+++ b/apps/divorce/div-cms/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/apps/divorce/div-cms/prod.yaml
+++ b/apps/divorce/div-cms/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cms

--- a/apps/divorce/div-cos/aat.yaml
+++ b/apps/divorce/div-cos/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/apps/divorce/div-cos/demo.yaml
+++ b/apps/divorce/div-cos/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/apps/divorce/div-cos/div-cos.yaml
+++ b/apps/divorce/div-cos/div-cos.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/apps/divorce/div-cos/ithc.yaml
+++ b/apps/divorce/div-cos/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/apps/divorce/div-cos/perftest.yaml
+++ b/apps/divorce/div-cos/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/apps/divorce/div-cos/prod.yaml
+++ b/apps/divorce/div-cos/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-cos

--- a/apps/divorce/div-da/aat.yaml
+++ b/apps/divorce/div-da/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-da

--- a/apps/divorce/div-da/demo.yaml
+++ b/apps/divorce/div-da/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-da

--- a/apps/divorce/div-da/div-da.yaml
+++ b/apps/divorce/div-da/div-da.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-da

--- a/apps/divorce/div-da/ithc.yaml
+++ b/apps/divorce/div-da/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-da

--- a/apps/divorce/div-da/perftest.yaml
+++ b/apps/divorce/div-da/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-da

--- a/apps/divorce/div-da/prod.yaml
+++ b/apps/divorce/div-da/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-da

--- a/apps/divorce/div-dgs/aat.yaml
+++ b/apps/divorce/div-dgs/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dgs/demo.yaml
+++ b/apps/divorce/div-dgs/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dgs/div-dgs.yaml
+++ b/apps/divorce/div-dgs/div-dgs.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dgs/ithc.yaml
+++ b/apps/divorce/div-dgs/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dgs/perftest.yaml
+++ b/apps/divorce/div-dgs/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dgs/prod.yaml
+++ b/apps/divorce/div-dgs/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dn/aat.yaml
+++ b/apps/divorce/div-dn/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/apps/divorce/div-dn/demo.yaml
+++ b/apps/divorce/div-dn/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/apps/divorce/div-dn/div-dn.yaml
+++ b/apps/divorce/div-dn/div-dn.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/apps/divorce/div-dn/ithc.yaml
+++ b/apps/divorce/div-dn/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/apps/divorce/div-dn/perftest.yaml
+++ b/apps/divorce/div-dn/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/apps/divorce/div-dn/prod.yaml
+++ b/apps/divorce/div-dn/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-dn

--- a/apps/divorce/div-emca/aat.yaml
+++ b/apps/divorce/div-emca/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/apps/divorce/div-emca/demo.yaml
+++ b/apps/divorce/div-emca/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/apps/divorce/div-emca/div-emca.yaml
+++ b/apps/divorce/div-emca/div-emca.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/apps/divorce/div-emca/ithc.yaml
+++ b/apps/divorce/div-emca/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/apps/divorce/div-emca/perftest.yaml
+++ b/apps/divorce/div-emca/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/apps/divorce/div-emca/prod.yaml
+++ b/apps/divorce/div-emca/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-emca

--- a/apps/divorce/div-fps/aat.yaml
+++ b/apps/divorce/div-fps/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/apps/divorce/div-fps/demo.yaml
+++ b/apps/divorce/div-fps/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/apps/divorce/div-fps/div-fps.yaml
+++ b/apps/divorce/div-fps/div-fps.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/apps/divorce/div-fps/ithc.yaml
+++ b/apps/divorce/div-fps/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/apps/divorce/div-fps/perftest.yaml
+++ b/apps/divorce/div-fps/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/apps/divorce/div-fps/prod.yaml
+++ b/apps/divorce/div-fps/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-fps

--- a/apps/divorce/div-pfe/aat.yaml
+++ b/apps/divorce/div-pfe/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/apps/divorce/div-pfe/demo.yaml
+++ b/apps/divorce/div-pfe/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/apps/divorce/div-pfe/div-pfe.yaml
+++ b/apps/divorce/div-pfe/div-pfe.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/apps/divorce/div-pfe/ithc.yaml
+++ b/apps/divorce/div-pfe/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/apps/divorce/div-pfe/perftest.yaml
+++ b/apps/divorce/div-pfe/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/apps/divorce/div-pfe/prod.yaml
+++ b/apps/divorce/div-pfe/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-pfe

--- a/apps/divorce/div-rfe/aat.yaml
+++ b/apps/divorce/div-rfe/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/apps/divorce/div-rfe/demo.yaml
+++ b/apps/divorce/div-rfe/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/apps/divorce/div-rfe/div-rfe.yaml
+++ b/apps/divorce/div-rfe/div-rfe.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/apps/divorce/div-rfe/ithc.yaml
+++ b/apps/divorce/div-rfe/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/apps/divorce/div-rfe/perftest.yaml
+++ b/apps/divorce/div-rfe/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/apps/divorce/div-rfe/prod.yaml
+++ b/apps/divorce/div-rfe/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: div-rfe

--- a/apps/dm-store/dm-store/aat.yaml
+++ b/apps/dm-store/dm-store/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/apps/dm-store/dm-store/demo.yaml
+++ b/apps/dm-store/dm-store/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/apps/dm-store/dm-store/dm-store.yaml
+++ b/apps/dm-store/dm-store/dm-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/apps/dm-store/dm-store/ithc.yaml
+++ b/apps/dm-store/dm-store/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/apps/dm-store/dm-store/perftest.yaml
+++ b/apps/dm-store/dm-store/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/apps/dm-store/dm-store/prod.yaml
+++ b/apps/dm-store/dm-store/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dm-store

--- a/apps/docmosis/docmosis/aat.yaml
+++ b/apps/docmosis/docmosis/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/ithc.yaml
+++ b/apps/docmosis/docmosis/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/prod.yaml
+++ b/apps/docmosis/docmosis/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/docmosis/docmosis/sbox.yaml
+++ b/apps/docmosis/docmosis/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: docmosis

--- a/apps/dtsse/dtsse-ardoq-adapter/dtsse-ardoq-adapter.yaml
+++ b/apps/dtsse/dtsse-ardoq-adapter/dtsse-ardoq-adapter.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dtsse-ardoq-adapter

--- a/apps/dtsse/dtsse-ardoq-adapter/prod.yaml
+++ b/apps/dtsse/dtsse-ardoq-adapter/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dtsse-ardoq-adapter

--- a/apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
+++ b/apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dtsse-dashboard-ingestion

--- a/apps/dtsse/dtsse-dashboard-ingestion/aat/01.yaml
+++ b/apps/dtsse/dtsse-dashboard-ingestion/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dtsse-dashboard-ingestion

--- a/apps/dtsse/dtsse-dashboard-ingestion/dtsse-dashboard-ingestion.yaml
+++ b/apps/dtsse/dtsse-dashboard-ingestion/dtsse-dashboard-ingestion.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dtsse-dashboard-ingestion

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dynatrace-operator

--- a/apps/em/em-anno/aat.yaml
+++ b/apps/em/em-anno/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/apps/em/em-anno/demo.yaml
+++ b/apps/em/em-anno/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/apps/em/em-anno/em-anno.yaml
+++ b/apps/em/em-anno/em-anno.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/apps/em/em-anno/ithc.yaml
+++ b/apps/em/em-anno/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/apps/em/em-anno/perftest.yaml
+++ b/apps/em/em-anno/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/apps/em/em-anno/prod.yaml
+++ b/apps/em/em-anno/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-anno

--- a/apps/em/em-ccd-orchestrator/aat.yaml
+++ b/apps/em/em-ccd-orchestrator/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-ccd-orchestrator/demo.yaml
+++ b/apps/em/em-ccd-orchestrator/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-ccd-orchestrator/em-ccd-orchestrator.yaml
+++ b/apps/em/em-ccd-orchestrator/em-ccd-orchestrator.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-ccd-orchestrator/ithc.yaml
+++ b/apps/em/em-ccd-orchestrator/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-ccd-orchestrator/perftest.yaml
+++ b/apps/em/em-ccd-orchestrator/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-ccd-orchestrator/prod.yaml
+++ b/apps/em/em-ccd-orchestrator/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-hrs-api/aat.yaml
+++ b/apps/em/em-hrs-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-api/demo.yaml
+++ b/apps/em/em-hrs-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-api/em-hrs-api.yaml
+++ b/apps/em/em-hrs-api/em-hrs-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-api/ithc.yaml
+++ b/apps/em/em-hrs-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-api/perftest.yaml
+++ b/apps/em/em-hrs-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-api/prod.yaml
+++ b/apps/em/em-hrs-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-ingestor/demo.yaml
+++ b/apps/em/em-hrs-ingestor/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/em-hrs-ingestor.yaml
+++ b/apps/em/em-hrs-ingestor/em-hrs-ingestor.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/ithc.yaml
+++ b/apps/em/em-hrs-ingestor/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/perftest.yaml
+++ b/apps/em/em-hrs-ingestor/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/prod-00.yaml
+++ b/apps/em/em-hrs-ingestor/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/prod-01.yaml
+++ b/apps/em/em-hrs-ingestor/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/prod.yaml
+++ b/apps/em/em-hrs-ingestor/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/schedule-cluster-0.yaml
+++ b/apps/em/em-hrs-ingestor/schedule-cluster-0.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/schedule-cluster-1.yaml
+++ b/apps/em/em-hrs-ingestor/schedule-cluster-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-hrs-ingestor/schedule-off.yaml
+++ b/apps/em/em-hrs-ingestor/schedule-off.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-icp/em-icp.yaml
+++ b/apps/em/em-icp/em-icp.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-icp

--- a/apps/em/em-icp/prod.yaml
+++ b/apps/em/em-icp/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-icp

--- a/apps/em/em-media-viewer/em-media-viewer.yaml
+++ b/apps/em/em-media-viewer/em-media-viewer.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-media-viewer

--- a/apps/em/em-npa/aat.yaml
+++ b/apps/em/em-npa/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/apps/em/em-npa/demo.yaml
+++ b/apps/em/em-npa/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/apps/em/em-npa/em-npa.yaml
+++ b/apps/em/em-npa/em-npa.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/apps/em/em-npa/ithc.yaml
+++ b/apps/em/em-npa/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/apps/em/em-npa/perftest.yaml
+++ b/apps/em/em-npa/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/apps/em/em-npa/prod.yaml
+++ b/apps/em/em-npa/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-npa

--- a/apps/em/em-showcase/em-showcase.yaml
+++ b/apps/em/em-showcase/em-showcase.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-showcase

--- a/apps/em/em-stitching/aat.yaml
+++ b/apps/em/em-stitching/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/apps/em/em-stitching/demo.yaml
+++ b/apps/em/em-stitching/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/apps/em/em-stitching/em-stitching.yaml
+++ b/apps/em/em-stitching/em-stitching.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/apps/em/em-stitching/ithc.yaml
+++ b/apps/em/em-stitching/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/apps/em/em-stitching/perftest.yaml
+++ b/apps/em/em-stitching/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/apps/em/em-stitching/prod.yaml
+++ b/apps/em/em-stitching/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-stitching

--- a/apps/et-pet/et-pet-admin/admin.yaml
+++ b/apps/et-pet/et-pet-admin/admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: admin

--- a/apps/et-pet/et-pet-admin/demo.yaml
+++ b/apps/et-pet/et-pet-admin/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: admin

--- a/apps/et-pet/et-pet-admin/ithc.yaml
+++ b/apps/et-pet/et-pet-admin/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: admin

--- a/apps/et-pet/et-pet-admin/prod.yaml
+++ b/apps/et-pet/et-pet-admin/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: admin

--- a/apps/et-pet/et-pet-api/api.yaml
+++ b/apps/et-pet/et-pet-api/api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: api

--- a/apps/et-pet/et-pet-api/demo.yaml
+++ b/apps/et-pet/et-pet-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: api

--- a/apps/et-pet/et-pet-ccd-export/ccd-export.yaml
+++ b/apps/et-pet/et-pet-ccd-export/ccd-export.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-export

--- a/apps/et-pet/et-pet-ccd-export/demo.yaml
+++ b/apps/et-pet/et-pet-ccd-export/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-export

--- a/apps/et-pet/et-pet-ccd-export/prod.yaml
+++ b/apps/et-pet/et-pet-ccd-export/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-export

--- a/apps/et-pet/et-pet-et1/demo.yaml
+++ b/apps/et-pet/et-pet-et1/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et1

--- a/apps/et-pet/et-pet-et1/et1.yaml
+++ b/apps/et-pet/et-pet-et1/et1.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et1

--- a/apps/et-pet/et-pet-et1/prod.yaml
+++ b/apps/et-pet/et-pet-et1/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et1

--- a/apps/et-pet/et-pet-et3/demo.yaml
+++ b/apps/et-pet/et-pet-et3/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et3

--- a/apps/et-pet/et-pet-et3/et3.yaml
+++ b/apps/et-pet/et-pet-et3/et3.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et3

--- a/apps/et-pet/et-pet-et3/prod.yaml
+++ b/apps/et-pet/et-pet-et3/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et3

--- a/apps/et/et-ccd-case-migration/aat.yaml
+++ b/apps/et/et-ccd-case-migration/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-ccd-case-migration

--- a/apps/et/et-ccd-case-migration/demo.yaml
+++ b/apps/et/et-ccd-case-migration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-ccd-case-migration

--- a/apps/et/et-ccd-case-migration/et-ccd-case-migration.yaml
+++ b/apps/et/et-ccd-case-migration/et-ccd-case-migration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-ccd-case-migration

--- a/apps/et/et-ccd-case-migration/prod.yaml
+++ b/apps/et/et-ccd-case-migration/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-ccd-case-migration

--- a/apps/et/et-cos/aat.yaml
+++ b/apps/et/et-cos/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-cos

--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-cos

--- a/apps/et/et-cos/et-cos.yaml
+++ b/apps/et/et-cos/et-cos.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-cos

--- a/apps/et/et-cos/ithc.yaml
+++ b/apps/et/et-cos/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-cos

--- a/apps/et/et-cos/perftest.yaml
+++ b/apps/et/et-cos/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-cos

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-cos

--- a/apps/et/et-hearings-api/aat.yaml
+++ b/apps/et/et-hearings-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-hearings-api

--- a/apps/et/et-hearings-api/demo.yaml
+++ b/apps/et/et-hearings-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-hearings-api

--- a/apps/et/et-hearings-api/et-hearings-api.yaml
+++ b/apps/et/et-hearings-api/et-hearings-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-hearings-api

--- a/apps/et/et-hearings-api/ithc.yaml
+++ b/apps/et/et-hearings-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-hearings-api

--- a/apps/et/et-hearings-api/perftest.yaml
+++ b/apps/et/et-hearings-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-hearings-api

--- a/apps/et/et-hearings-api/prod.yaml
+++ b/apps/et/et-hearings-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-hearings-api

--- a/apps/et/et-msg-handler/aat.yaml
+++ b/apps/et/et-msg-handler/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-msg-handler

--- a/apps/et/et-msg-handler/demo.yaml
+++ b/apps/et/et-msg-handler/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-msg-handler

--- a/apps/et/et-msg-handler/et-msg-handler.yaml
+++ b/apps/et/et-msg-handler/et-msg-handler.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-msg-handler

--- a/apps/et/et-msg-handler/ithc.yaml
+++ b/apps/et/et-msg-handler/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-msg-handler

--- a/apps/et/et-msg-handler/perftest.yaml
+++ b/apps/et/et-msg-handler/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-msg-handler

--- a/apps/et/et-msg-handler/prod.yaml
+++ b/apps/et/et-msg-handler/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-msg-handler

--- a/apps/et/et-sya-api/aat.yaml
+++ b/apps/et/et-sya-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya-api/demo.yaml
+++ b/apps/et/et-sya-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya-api/et-sya-api.yaml
+++ b/apps/et/et-sya-api/et-sya-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya-api/ithc.yaml
+++ b/apps/et/et-sya-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya-api/perftest.yaml
+++ b/apps/et/et-sya-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya-api/prod.yaml
+++ b/apps/et/et-sya-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya/aat.yaml
+++ b/apps/et/et-sya/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya

--- a/apps/et/et-sya/demo.yaml
+++ b/apps/et/et-sya/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya

--- a/apps/et/et-sya/et-sya.yaml
+++ b/apps/et/et-sya/et-sya.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya

--- a/apps/et/et-sya/ithc.yaml
+++ b/apps/et/et-sya/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya

--- a/apps/et/et-sya/perftest.yaml
+++ b/apps/et/et-sya/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya

--- a/apps/et/et-sya/prod.yaml
+++ b/apps/et/et-sya/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: et-sya

--- a/apps/ethos/ecm-consumer/aat.yaml
+++ b/apps/ethos/ecm-consumer/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ecm-consumer

--- a/apps/ethos/ecm-consumer/demo.yaml
+++ b/apps/ethos/ecm-consumer/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ecm-consumer

--- a/apps/ethos/ecm-consumer/ecm-consumer.yaml
+++ b/apps/ethos/ecm-consumer/ecm-consumer.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ecm-consumer

--- a/apps/ethos/ecm-consumer/ithc.yaml
+++ b/apps/ethos/ecm-consumer/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ecm-consumer

--- a/apps/ethos/ecm-consumer/perftest.yaml
+++ b/apps/ethos/ecm-consumer/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ecm-consumer

--- a/apps/ethos/ecm-consumer/prod.yaml
+++ b/apps/ethos/ecm-consumer/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ecm-consumer

--- a/apps/ethos/repl-docmosis-service/aat.yaml
+++ b/apps/ethos/repl-docmosis-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/apps/ethos/repl-docmosis-service/demo.yaml
+++ b/apps/ethos/repl-docmosis-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/apps/ethos/repl-docmosis-service/ithc.yaml
+++ b/apps/ethos/repl-docmosis-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/apps/ethos/repl-docmosis-service/perftest.yaml
+++ b/apps/ethos/repl-docmosis-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/apps/ethos/repl-docmosis-service/prod.yaml
+++ b/apps/ethos/repl-docmosis-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/apps/ethos/repl-docmosis-service/repl-docmosis-service.yaml
+++ b/apps/ethos/repl-docmosis-service/repl-docmosis-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: repl-docmosis-service

--- a/apps/fact/fact-admin/demo.yaml
+++ b/apps/fact/fact-admin/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-admin

--- a/apps/fact/fact-admin/fact-admin.yaml
+++ b/apps/fact/fact-admin/fact-admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-admin

--- a/apps/fact/fact-admin/prod.yaml
+++ b/apps/fact/fact-admin/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-admin

--- a/apps/fact/fact-api/demo.yaml
+++ b/apps/fact/fact-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-api

--- a/apps/fact/fact-api/fact-api.yaml
+++ b/apps/fact/fact-api/fact-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-api

--- a/apps/fact/fact-api/prod.yaml
+++ b/apps/fact/fact-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-api

--- a/apps/fact/fact-frontend/demo.yaml
+++ b/apps/fact/fact-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-frontend

--- a/apps/fact/fact-frontend/fact-frontend.yaml
+++ b/apps/fact/fact-frontend/fact-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-frontend

--- a/apps/fact/fact-frontend/prod.yaml
+++ b/apps/fact/fact-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-frontend

--- a/apps/family-public-law/fpl-case-service/aat.yaml
+++ b/apps/family-public-law/fpl-case-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/apps/family-public-law/fpl-case-service/demo.yaml
+++ b/apps/family-public-law/fpl-case-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/apps/family-public-law/fpl-case-service/fpl-case-service.yaml
+++ b/apps/family-public-law/fpl-case-service/fpl-case-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   labels:

--- a/apps/family-public-law/fpl-case-service/ithc.yaml
+++ b/apps/family-public-law/fpl-case-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/apps/family-public-law/fpl-case-service/perftest.yaml
+++ b/apps/family-public-law/fpl-case-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/apps/family-public-law/fpl-case-service/prod.yaml
+++ b/apps/family-public-law/fpl-case-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-case-service

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/demo.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/demo/00.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/demo/01.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/fpl-cron-ccd-data-migration-tool.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/fpl-cron-ccd-data-migration-tool.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/perftest.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/perftest/00.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/perftest/01.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/01.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/fees-pay/bar-payment-job-int/bar-payment-job-int.yaml
+++ b/apps/fees-pay/bar-payment-job-int/bar-payment-job-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-payment-job-int

--- a/apps/fees-pay/bar-payment-job-int/demo.yaml
+++ b/apps/fees-pay/bar-payment-job-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-payment-job-int

--- a/apps/fees-pay/bar-payment-job/aat-00.yaml
+++ b/apps/fees-pay/bar-payment-job/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-payment-job

--- a/apps/fees-pay/bar-payment-job/bar-payment-job.yaml
+++ b/apps/fees-pay/bar-payment-job/bar-payment-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-payment-job

--- a/apps/fees-pay/bar-payment-job/demo-00.yaml
+++ b/apps/fees-pay/bar-payment-job/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-payment-job

--- a/apps/fees-pay/bar-payment-job/prod-00.yaml
+++ b/apps/fees-pay/bar-payment-job/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: bar-payment-job

--- a/apps/fees-pay/card-payment-job-int/card-payment-job-int.yaml
+++ b/apps/fees-pay/card-payment-job-int/card-payment-job-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: card-payment-job-int

--- a/apps/fees-pay/card-payment-job-int/demo.yaml
+++ b/apps/fees-pay/card-payment-job-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: card-payment-job-int

--- a/apps/fees-pay/card-payment-job/aat-00.yaml
+++ b/apps/fees-pay/card-payment-job/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: card-payment-job

--- a/apps/fees-pay/card-payment-job/card-payment-job.yaml
+++ b/apps/fees-pay/card-payment-job/card-payment-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: card-payment-job

--- a/apps/fees-pay/card-payment-job/demo-00.yaml
+++ b/apps/fees-pay/card-payment-job/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: card-payment-job

--- a/apps/fees-pay/card-payment-job/prod-00.yaml
+++ b/apps/fees-pay/card-payment-job/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: card-payment-job

--- a/apps/fees-pay/ccpay-bubble-frontend-int/ccpay-bubble-frontend-int.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend-int/ccpay-bubble-frontend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend-int

--- a/apps/fees-pay/ccpay-bubble-frontend-int/demo.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend-int

--- a/apps/fees-pay/ccpay-bubble-frontend/aat.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bubble-frontend/ithc.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bubble-frontend/perftest.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bubble-frontend/prod.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bulkscanning-api-int/ccpay-bulkscanning-api-int.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api-int/ccpay-bulkscanning-api-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api-int

--- a/apps/fees-pay/ccpay-bulkscanning-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api-int

--- a/apps/fees-pay/ccpay-bulkscanning-api/aat.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-bulkscanning-api/ccpay-bulkscanning-api.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/ccpay-bulkscanning-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-bulkscanning-api/demo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-bulkscanning-api/ithc.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-bulkscanning-api/perftest.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-bulkscanning-api/prod.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-callback-function-int/ccpay-callback-function-int.yaml
+++ b/apps/fees-pay/ccpay-callback-function-int/ccpay-callback-function-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function-int

--- a/apps/fees-pay/ccpay-callback-function-int/demo.yaml
+++ b/apps/fees-pay/ccpay-callback-function-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function-int

--- a/apps/fees-pay/ccpay-callback-function/aat.yaml
+++ b/apps/fees-pay/ccpay-callback-function/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-callback-function/ccpay-callback-function.yaml
+++ b/apps/fees-pay/ccpay-callback-function/ccpay-callback-function.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-callback-function/demo.yaml
+++ b/apps/fees-pay/ccpay-callback-function/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-callback-function/ithc.yaml
+++ b/apps/fees-pay/ccpay-callback-function/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-callback-function/perftest.yaml
+++ b/apps/fees-pay/ccpay-callback-function/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-callback-function/prod.yaml
+++ b/apps/fees-pay/ccpay-callback-function/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-cpo-callback-function-int/ccpay-cpo-callback-function-int.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function-int/ccpay-cpo-callback-function-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-callback-function-int

--- a/apps/fees-pay/ccpay-cpo-callback-function-int/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-callback-function-int

--- a/apps/fees-pay/ccpay-cpo-callback-function/aat.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-callback-function

--- a/apps/fees-pay/ccpay-cpo-callback-function/ccpay-cpo-callback-function.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function/ccpay-cpo-callback-function.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-callback-function

--- a/apps/fees-pay/ccpay-cpo-callback-function/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-callback-function

--- a/apps/fees-pay/ccpay-cpo-callback-function/ithc.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-callback-function

--- a/apps/fees-pay/ccpay-cpo-update-service-int/ccpay-cpo-update-service-int.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service-int/ccpay-cpo-update-service-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service-int

--- a/apps/fees-pay/ccpay-cpo-update-service-int/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service-int

--- a/apps/fees-pay/ccpay-cpo-update-service/aat.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-cpo-update-service/ccpay-cpo-update-service.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/ccpay-cpo-update-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-cpo-update-service/demo.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-cpo-update-service/ithc.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-cpo-update-service/perftest.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-cpo-update-service/prod.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-notifications-service-int/ccpay-notifications-service-int.yaml
+++ b/apps/fees-pay/ccpay-notifications-service-int/ccpay-notifications-service-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service-int

--- a/apps/fees-pay/ccpay-notifications-service-int/demo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service-int

--- a/apps/fees-pay/ccpay-notifications-service/aat.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-notifications-service/ccpay-notifications-service.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/ccpay-notifications-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-notifications-service/demo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-notifications-service/ithc.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-notifications-service/perftest.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-notifications-service/prod.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-payment-api-int/ccpay-payment-api-int.yaml
+++ b/apps/fees-pay/ccpay-payment-api-int/ccpay-payment-api-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api-int

--- a/apps/fees-pay/ccpay-payment-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api-int

--- a/apps/fees-pay/ccpay-payment-api/aat.yaml
+++ b/apps/fees-pay/ccpay-payment-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api

--- a/apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
+++ b/apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api

--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api

--- a/apps/fees-pay/ccpay-payment-api/ithc.yaml
+++ b/apps/fees-pay/ccpay-payment-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api

--- a/apps/fees-pay/ccpay-payment-api/perftest.yaml
+++ b/apps/fees-pay/ccpay-payment-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api

--- a/apps/fees-pay/ccpay-payment-api/prod.yaml
+++ b/apps/fees-pay/ccpay-payment-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-payment-api

--- a/apps/fees-pay/ccpay-paymentoutcome-web-int/ccpay-paymentoutcome-web-int.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web-int/ccpay-paymentoutcome-web-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web-int

--- a/apps/fees-pay/ccpay-paymentoutcome-web-int/demo.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web-int

--- a/apps/fees-pay/ccpay-paymentoutcome-web/aat.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-paymentoutcome-web/ccpay-paymentoutcome-web.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/ccpay-paymentoutcome-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-paymentoutcome-web/demo.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-paymentoutcome-web/ithc.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-paymentoutcome-web/perftest.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-paymentoutcome-web/prod.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-refunds-api-int/ccpay-refunds-api-int.yaml
+++ b/apps/fees-pay/ccpay-refunds-api-int/ccpay-refunds-api-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api-int

--- a/apps/fees-pay/ccpay-refunds-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api-int

--- a/apps/fees-pay/ccpay-refunds-api/aat.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/ccpay-refunds-api/ccpay-refunds-api.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/ccpay-refunds-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/ccpay-refunds-api/demo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/ccpay-refunds-api/ithc.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/ccpay-refunds-api/perftest.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/ccpay-refunds-api/prod.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/dead-letter-queue-process-int/dead-letter-queue-process-int.yaml
+++ b/apps/fees-pay/dead-letter-queue-process-int/dead-letter-queue-process-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dead-letter-queue-process-int

--- a/apps/fees-pay/dead-letter-queue-process-int/demo.yaml
+++ b/apps/fees-pay/dead-letter-queue-process-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dead-letter-queue-process-int

--- a/apps/fees-pay/dead-letter-queue-process/dead-letter-queue-process.yaml
+++ b/apps/fees-pay/dead-letter-queue-process/dead-letter-queue-process.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dead-letter-queue-process

--- a/apps/fees-pay/dead-letter-queue-process/demo.yaml
+++ b/apps/fees-pay/dead-letter-queue-process/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dead-letter-queue-process

--- a/apps/fees-pay/dead-letter-queue-process/prod.yaml
+++ b/apps/fees-pay/dead-letter-queue-process/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dead-letter-queue-process

--- a/apps/fees-pay/duplicate-payment-process/demo.yaml
+++ b/apps/fees-pay/duplicate-payment-process/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: duplicate-payment-process

--- a/apps/fees-pay/duplicate-payment-process/duplicate-payment-process.yaml
+++ b/apps/fees-pay/duplicate-payment-process/duplicate-payment-process.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: duplicate-payment-process

--- a/apps/fees-pay/fees-register-api-int/demo.yaml
+++ b/apps/fees-pay/fees-register-api-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api-int

--- a/apps/fees-pay/fees-register-api-int/fees-register-api-int.yaml
+++ b/apps/fees-pay/fees-register-api-int/fees-register-api-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api-int

--- a/apps/fees-pay/fees-register-api/aat.yaml
+++ b/apps/fees-pay/fees-register-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-api/demo.yaml
+++ b/apps/fees-pay/fees-register-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-api/fees-register-api.yaml
+++ b/apps/fees-pay/fees-register-api/fees-register-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-api/ithc.yaml
+++ b/apps/fees-pay/fees-register-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-api/perftest.yaml
+++ b/apps/fees-pay/fees-register-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-api/prod.yaml
+++ b/apps/fees-pay/fees-register-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-frontend-int/demo.yaml
+++ b/apps/fees-pay/fees-register-frontend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend-int

--- a/apps/fees-pay/fees-register-frontend-int/fees-register-frontend-int.yaml
+++ b/apps/fees-pay/fees-register-frontend-int/fees-register-frontend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend-int

--- a/apps/fees-pay/fees-register-frontend/aat.yaml
+++ b/apps/fees-pay/fees-register-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/fees-register-frontend/demo.yaml
+++ b/apps/fees-pay/fees-register-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/fees-register-frontend/fees-register-frontend.yaml
+++ b/apps/fees-pay/fees-register-frontend/fees-register-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/fees-register-frontend/ithc.yaml
+++ b/apps/fees-pay/fees-register-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/fees-register-frontend/perftest.yaml
+++ b/apps/fees-pay/fees-register-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/fees-register-frontend/prod.yaml
+++ b/apps/fees-pay/fees-register-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/finrem-payment-job-int/demo.yaml
+++ b/apps/fees-pay/finrem-payment-job-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-payment-job-int

--- a/apps/fees-pay/finrem-payment-job-int/finrem-payment-job-int.yaml
+++ b/apps/fees-pay/finrem-payment-job-int/finrem-payment-job-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-payment-job-int

--- a/apps/fees-pay/finrem-payment-job/aat-00.yaml
+++ b/apps/fees-pay/finrem-payment-job/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-payment-job

--- a/apps/fees-pay/finrem-payment-job/demo-00.yaml
+++ b/apps/fees-pay/finrem-payment-job/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-payment-job

--- a/apps/fees-pay/finrem-payment-job/finrem-payment-job.yaml
+++ b/apps/fees-pay/finrem-payment-job/finrem-payment-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-payment-job

--- a/apps/fees-pay/finrem-payment-job/prod-00.yaml
+++ b/apps/fees-pay/finrem-payment-job/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-payment-job

--- a/apps/fees-pay/pba-payment-job-int/demo.yaml
+++ b/apps/fees-pay/pba-payment-job-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pba-payment-job-int

--- a/apps/fees-pay/pba-payment-job-int/pba-payment-job-int.yaml
+++ b/apps/fees-pay/pba-payment-job-int/pba-payment-job-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pba-payment-job-int

--- a/apps/fees-pay/pba-payment-job/aat-00.yaml
+++ b/apps/fees-pay/pba-payment-job/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pba-payment-job

--- a/apps/fees-pay/pba-payment-job/demo.yaml
+++ b/apps/fees-pay/pba-payment-job/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pba-payment-job

--- a/apps/fees-pay/pba-payment-job/pba-payment-job.yaml
+++ b/apps/fees-pay/pba-payment-job/pba-payment-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pba-payment-job

--- a/apps/fees-pay/pba-payment-job/prod-00.yaml
+++ b/apps/fees-pay/pba-payment-job/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pba-payment-job

--- a/apps/fees-pay/refund-notifications-job-int/demo.yaml
+++ b/apps/fees-pay/refund-notifications-job-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: refund-notifications-job-int

--- a/apps/fees-pay/refund-notifications-job-int/refund-notifications-job-int.yaml
+++ b/apps/fees-pay/refund-notifications-job-int/refund-notifications-job-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: refund-notifications-job-int

--- a/apps/fees-pay/refund-notifications-job/demo.yaml
+++ b/apps/fees-pay/refund-notifications-job/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: refund-notifications-job

--- a/apps/fees-pay/refund-notifications-job/ithc.yaml
+++ b/apps/fees-pay/refund-notifications-job/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: refund-notifications-job

--- a/apps/fees-pay/refund-notifications-job/prod.yaml
+++ b/apps/fees-pay/refund-notifications-job/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: refund-notifications-job

--- a/apps/fees-pay/refund-notifications-job/refund-notifications-job.yaml
+++ b/apps/fees-pay/refund-notifications-job/refund-notifications-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: refund-notifications-job

--- a/apps/fees-pay/status-payment-job-int/demo.yaml
+++ b/apps/fees-pay/status-payment-job-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-payment-job-int

--- a/apps/fees-pay/status-payment-job-int/status-payment-job-int.yaml
+++ b/apps/fees-pay/status-payment-job-int/status-payment-job-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-payment-job-int

--- a/apps/fees-pay/status-payment-job/aat-00.yaml
+++ b/apps/fees-pay/status-payment-job/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-payment-job

--- a/apps/fees-pay/status-payment-job/demo-00.yaml
+++ b/apps/fees-pay/status-payment-job/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-payment-job

--- a/apps/fees-pay/status-payment-job/prod-00.yaml
+++ b/apps/fees-pay/status-payment-job/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-payment-job

--- a/apps/fees-pay/status-payment-job/status-payment-job.yaml
+++ b/apps/fees-pay/status-payment-job/status-payment-job.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: status-payment-job

--- a/apps/fees-pay/unprocessed-payment-update-int/demo.yaml
+++ b/apps/fees-pay/unprocessed-payment-update-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update-int

--- a/apps/fees-pay/unprocessed-payment-update-int/unprocessed-payment-update.yaml
+++ b/apps/fees-pay/unprocessed-payment-update-int/unprocessed-payment-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update-int

--- a/apps/fees-pay/unprocessed-payment-update/aat.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update

--- a/apps/fees-pay/unprocessed-payment-update/demo.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update

--- a/apps/fees-pay/unprocessed-payment-update/ithc.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update

--- a/apps/fees-pay/unprocessed-payment-update/perftest.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update

--- a/apps/fees-pay/unprocessed-payment-update/prod.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update

--- a/apps/fees-pay/unprocessed-payment-update/unprocessed-payment-update.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/unprocessed-payment-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: unprocessed-payment-update

--- a/apps/financial-remedy/finrem-cos/aat.yaml
+++ b/apps/financial-remedy/finrem-cos/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cos

--- a/apps/financial-remedy/finrem-cos/demo.yaml
+++ b/apps/financial-remedy/finrem-cos/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cos

--- a/apps/financial-remedy/finrem-cos/finrem-cos.yaml
+++ b/apps/financial-remedy/finrem-cos/finrem-cos.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cos

--- a/apps/financial-remedy/finrem-cos/ithc.yaml
+++ b/apps/financial-remedy/finrem-cos/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cos

--- a/apps/financial-remedy/finrem-cos/perftest.yaml
+++ b/apps/financial-remedy/finrem-cos/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cos

--- a/apps/financial-remedy/finrem-cos/prod.yaml
+++ b/apps/financial-remedy/finrem-cos/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cos

--- a/apps/financial-remedy/finrem-cron-add-application-type/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-add-application-type/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-application-type

--- a/apps/financial-remedy/finrem-cron-add-application-type/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-add-application-type/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-application-type

--- a/apps/financial-remedy/finrem-cron-add-application-type/finrem-cron-add-application-type.yaml
+++ b/apps/financial-remedy/finrem-cron-add-application-type/finrem-cron-add-application-type.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-application-type

--- a/apps/financial-remedy/finrem-cron-add-application-type/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-add-application-type/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-application-type

--- a/apps/financial-remedy/finrem-cron-add-org-policy/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-add-org-policy/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-org-policy

--- a/apps/financial-remedy/finrem-cron-add-org-policy/demo/00.yaml
+++ b/apps/financial-remedy/finrem-cron-add-org-policy/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-org-policy

--- a/apps/financial-remedy/finrem-cron-add-org-policy/demo/01.yaml
+++ b/apps/financial-remedy/finrem-cron-add-org-policy/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-org-policy

--- a/apps/financial-remedy/finrem-cron-add-org-policy/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-add-org-policy/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-org-policy

--- a/apps/financial-remedy/finrem-cron-add-org-policy/finrem-cron-add-org-policy.yaml
+++ b/apps/financial-remedy/finrem-cron-add-org-policy/finrem-cron-add-org-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-org-policy

--- a/apps/financial-remedy/finrem-cron-add-org-policy/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-add-org-policy/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-add-org-policy

--- a/apps/financial-remedy/finrem-cron-court-list-update/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-court-list-update/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-court-list-update

--- a/apps/financial-remedy/finrem-cron-court-list-update/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-court-list-update/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-court-list-update

--- a/apps/financial-remedy/finrem-cron-court-list-update/finrem-cron-court-list-update.yaml
+++ b/apps/financial-remedy/finrem-cron-court-list-update/finrem-cron-court-list-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-court-list-update

--- a/apps/financial-remedy/finrem-cron-court-list-update/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-court-list-update/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-court-list-update

--- a/apps/financial-remedy/finrem-cron-general-application-remove/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-general-application-remove/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-general-application-remove

--- a/apps/financial-remedy/finrem-cron-general-application-remove/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-general-application-remove/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-general-application-remove

--- a/apps/financial-remedy/finrem-cron-general-application-remove/finrem-cron-general-application-remove.yaml
+++ b/apps/financial-remedy/finrem-cron-general-application-remove/finrem-cron-general-application-remove.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-general-application-remove

--- a/apps/financial-remedy/finrem-cron-general-application-remove/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-general-application-remove/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-general-application-remove

--- a/apps/financial-remedy/finrem-cron-list-for-hearing/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-list-for-hearing/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-list-for-hearing

--- a/apps/financial-remedy/finrem-cron-list-for-hearing/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-list-for-hearing/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-list-for-hearing

--- a/apps/financial-remedy/finrem-cron-list-for-hearing/finrem-cron-list-for-hearing.yaml
+++ b/apps/financial-remedy/finrem-cron-list-for-hearing/finrem-cron-list-for-hearing.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-list-for-hearing

--- a/apps/financial-remedy/finrem-cron-list-for-hearing/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-list-for-hearing/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-list-for-hearing

--- a/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-regenerate-draft-form-a

--- a/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-regenerate-draft-form-a

--- a/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/finrem-cron-regenerate-draft-form-a.yaml
+++ b/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/finrem-cron-regenerate-draft-form-a.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-regenerate-draft-form-a

--- a/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-regenerate-draft-form-a/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-regenerate-draft-form-a

--- a/apps/financial-remedy/finrem-cron-send-order/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-send-order/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-send-order

--- a/apps/financial-remedy/finrem-cron-send-order/demo/00.yaml
+++ b/apps/financial-remedy/finrem-cron-send-order/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-send-order

--- a/apps/financial-remedy/finrem-cron-send-order/demo/01.yaml
+++ b/apps/financial-remedy/finrem-cron-send-order/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-send-order

--- a/apps/financial-remedy/finrem-cron-send-order/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-send-order/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-send-order

--- a/apps/financial-remedy/finrem-cron-send-order/finrem-cron-send-order.yaml
+++ b/apps/financial-remedy/finrem-cron-send-order/finrem-cron-send-order.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-send-order

--- a/apps/financial-remedy/finrem-cron-send-order/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-send-order/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: finrem-cron-send-order

--- a/apps/fis/fis-bulk-scan-api/demo.yaml
+++ b/apps/fis/fis-bulk-scan-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-bulk-scan-api

--- a/apps/fis/fis-bulk-scan-api/fis-bulk-scan-api.yaml
+++ b/apps/fis/fis-bulk-scan-api/fis-bulk-scan-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-bulk-scan-api

--- a/apps/fis/fis-cos-api/aat.yaml
+++ b/apps/fis/fis-cos-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-cos-api

--- a/apps/fis/fis-cos-api/demo.yaml
+++ b/apps/fis/fis-cos-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-cos-api

--- a/apps/fis/fis-cos-api/fis-cos-api.yaml
+++ b/apps/fis/fis-cos-api/fis-cos-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-cos-api

--- a/apps/fis/fis-cos-api/ithc.yaml
+++ b/apps/fis/fis-cos-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-cos-api

--- a/apps/fis/fis-cos-api/perftest.yaml
+++ b/apps/fis/fis-cos-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-cos-api

--- a/apps/fis/fis-ds-update-web/aat.yaml
+++ b/apps/fis/fis-ds-update-web/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-ds-update-web

--- a/apps/fis/fis-ds-update-web/demo.yaml
+++ b/apps/fis/fis-ds-update-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-ds-update-web

--- a/apps/fis/fis-ds-update-web/fis-ds-update-web.yaml
+++ b/apps/fis/fis-ds-update-web/fis-ds-update-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-ds-update-web

--- a/apps/fis/fis-ds-update-web/ithc.yaml
+++ b/apps/fis/fis-ds-update-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-ds-update-web

--- a/apps/fis/fis-ds-update-web/perftest.yaml
+++ b/apps/fis/fis-ds-update-web/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-ds-update-web

--- a/apps/fis/fis-ds-web/fis-ds-web.yaml
+++ b/apps/fis/fis-ds-web/fis-ds-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-ds-web

--- a/apps/fis/fis-hmc-api/demo.yaml
+++ b/apps/fis/fis-hmc-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-hmc-api

--- a/apps/fis/fis-hmc-api/fis-hmc-api.yaml
+++ b/apps/fis/fis-hmc-api/fis-hmc-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-hmc-api

--- a/apps/fis/fis-hmc-api/ithc.yaml
+++ b/apps/fis/fis-hmc-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-hmc-api

--- a/apps/fis/fis-hmc-api/perftest.yaml
+++ b/apps/fis/fis-hmc-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-hmc-api

--- a/apps/fis/fis-hmc-api/prod.yaml
+++ b/apps/fis/fis-hmc-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fis-hmc-api

--- a/apps/help-with-fees/help-with-fees-benefit-checker-api/aat.yaml
+++ b/apps/help-with-fees/help-with-fees-benefit-checker-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-benefit-checker-api

--- a/apps/help-with-fees/help-with-fees-benefit-checker-api/demo.yaml
+++ b/apps/help-with-fees/help-with-fees-benefit-checker-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-benefit-checker-api

--- a/apps/help-with-fees/help-with-fees-benefit-checker-api/help-with-fees-benefit-checker-api.yaml
+++ b/apps/help-with-fees/help-with-fees-benefit-checker-api/help-with-fees-benefit-checker-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-benefit-checker-api

--- a/apps/help-with-fees/help-with-fees-benefit-checker-api/prod.yaml
+++ b/apps/help-with-fees/help-with-fees-benefit-checker-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-benefit-checker-api

--- a/apps/help-with-fees/help-with-fees-publicapp/aat.yaml
+++ b/apps/help-with-fees/help-with-fees-publicapp/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-publicapp

--- a/apps/help-with-fees/help-with-fees-publicapp/demo.yaml
+++ b/apps/help-with-fees/help-with-fees-publicapp/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-publicapp

--- a/apps/help-with-fees/help-with-fees-publicapp/help-with-fees-publicapp.yaml
+++ b/apps/help-with-fees/help-with-fees-publicapp/help-with-fees-publicapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-publicapp

--- a/apps/help-with-fees/help-with-fees-publicapp/ithc.yaml
+++ b/apps/help-with-fees/help-with-fees-publicapp/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-publicapp

--- a/apps/help-with-fees/help-with-fees-publicapp/prod.yaml
+++ b/apps/help-with-fees/help-with-fees-publicapp/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-publicapp

--- a/apps/help-with-fees/help-with-fees-staffapp/aat.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-staffapp

--- a/apps/help-with-fees/help-with-fees-staffapp/demo.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-staffapp

--- a/apps/help-with-fees/help-with-fees-staffapp/help-with-fees-staffapp.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/help-with-fees-staffapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-staffapp

--- a/apps/help-with-fees/help-with-fees-staffapp/ithc.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-staffapp

--- a/apps/help-with-fees/help-with-fees-staffapp/prod.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: help-with-fees-staffapp

--- a/apps/hmc/hmc-cft-hearing-service-int/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service-int

--- a/apps/hmc/hmc-cft-hearing-service-int/hmc-cft-hearing-service-int.yaml
+++ b/apps/hmc/hmc-cft-hearing-service-int/hmc-cft-hearing-service-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service-int

--- a/apps/hmc/hmc-cft-hearing-service/aat.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-cft-hearing-service/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-cft-hearing-service/hmc-cft-hearing-service.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/hmc-cft-hearing-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-cft-hearing-service/ithc.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-cft-hearing-service/perftest.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-cft-hearing-service/prod.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-hmi-inbound-adapter-int/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter-int

--- a/apps/hmc/hmc-hmi-inbound-adapter-int/hmc-hmi-inbound-adapter-int.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter-int/hmc-hmi-inbound-adapter-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter-int

--- a/apps/hmc/hmc-hmi-inbound-adapter/aat.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-inbound-adapter/hmc-hmi-inbound-adapter.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/hmc-hmi-inbound-adapter.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-inbound-adapter/ithc.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-inbound-adapter/perftest.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-inbound-adapter/prod.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter-int/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter-int

--- a/apps/hmc/hmc-hmi-outbound-adapter-int/hmc-hmi-outbound-adapter-int.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter-int/hmc-hmi-outbound-adapter-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter-int

--- a/apps/hmc/hmc-hmi-outbound-adapter/aat.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/hmc-hmi-outbound-adapter.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/hmc-hmi-outbound-adapter.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/ithc.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/prod.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-operational-reports-runner-int/demo/00.yaml
+++ b/apps/hmc/hmc-operational-reports-runner-int/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner-int

--- a/apps/hmc/hmc-operational-reports-runner-int/demo/01.yaml
+++ b/apps/hmc/hmc-operational-reports-runner-int/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner-int

--- a/apps/hmc/hmc-operational-reports-runner-int/hmc-operational-reports-runner-int.yaml
+++ b/apps/hmc/hmc-operational-reports-runner-int/hmc-operational-reports-runner-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner-int

--- a/apps/hmc/hmc-operational-reports-runner/aat/00.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/aat/01.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/demo/00.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/demo/01.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/hmc-operational-reports-runner.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/hmc-operational-reports-runner.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/ithc/00.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/ithc/01.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/perftest/00.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/perftest/01.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/prod/00.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/hmc/hmc-operational-reports-runner/prod/01.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/ia/ia-aip-frontend/aat.yaml
+++ b/apps/ia/ia-aip-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-aip-frontend/demo.yaml
+++ b/apps/ia/ia-aip-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-aip-frontend/ia-aip-frontend.yaml
+++ b/apps/ia/ia-aip-frontend/ia-aip-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-aip-frontend/ithc.yaml
+++ b/apps/ia/ia-aip-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-aip-frontend/perftest.yaml
+++ b/apps/ia/ia-aip-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-aip-frontend/prod.yaml
+++ b/apps/ia/ia-aip-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-bail-case-api/aat.yaml
+++ b/apps/ia/ia-bail-case-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-bail-case-api/demo.yaml
+++ b/apps/ia/ia-bail-case-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-bail-case-api/ia-bail-case-api.yaml
+++ b/apps/ia/ia-bail-case-api/ia-bail-case-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-bail-case-api/ithc.yaml
+++ b/apps/ia/ia-bail-case-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-bail-case-api/perftest.yaml
+++ b/apps/ia/ia-bail-case-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-bail-case-api/prod.yaml
+++ b/apps/ia/ia-bail-case-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-case-access-api/aat.yaml
+++ b/apps/ia/ia-case-access-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-access-api/demo.yaml
+++ b/apps/ia/ia-case-access-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-access-api/ia-case-access-api.yaml
+++ b/apps/ia/ia-case-access-api/ia-case-access-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-access-api/ithc.yaml
+++ b/apps/ia/ia-case-access-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-access-api/perftest.yaml
+++ b/apps/ia/ia-case-access-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-access-api/prod.yaml
+++ b/apps/ia/ia-case-access-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-api/aat.yaml
+++ b/apps/ia/ia-case-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-api/ia-case-api.yaml
+++ b/apps/ia/ia-case-api/ia-case-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-api/ithc.yaml
+++ b/apps/ia/ia-case-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-api/perftest.yaml
+++ b/apps/ia/ia-case-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-api/prod.yaml
+++ b/apps/ia/ia-case-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-documents-api/aat.yaml
+++ b/apps/ia/ia-case-documents-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-documents-api/demo.yaml
+++ b/apps/ia/ia-case-documents-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-documents-api/ia-case-documents-api.yaml
+++ b/apps/ia/ia-case-documents-api/ia-case-documents-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-documents-api/ithc.yaml
+++ b/apps/ia/ia-case-documents-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-documents-api/perftest.yaml
+++ b/apps/ia/ia-case-documents-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-documents-api/prod.yaml
+++ b/apps/ia/ia-case-documents-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-notifications-api/aat.yaml
+++ b/apps/ia/ia-case-notifications-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/demo.yaml
+++ b/apps/ia/ia-case-notifications-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/ia-case-notifications-api.yaml
+++ b/apps/ia/ia-case-notifications-api/ia-case-notifications-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/ithc.yaml
+++ b/apps/ia/ia-case-notifications-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/perftest.yaml
+++ b/apps/ia/ia-case-notifications-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/prod.yaml
+++ b/apps/ia/ia-case-notifications-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-payments-api/aat.yaml
+++ b/apps/ia/ia-case-payments-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-case-payments-api/demo.yaml
+++ b/apps/ia/ia-case-payments-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-case-payments-api/ia-case-payments-api.yaml
+++ b/apps/ia/ia-case-payments-api/ia-case-payments-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-case-payments-api/ithc.yaml
+++ b/apps/ia/ia-case-payments-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-case-payments-api/perftest.yaml
+++ b/apps/ia/ia-case-payments-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-case-payments-api/prod.yaml
+++ b/apps/ia/ia-case-payments-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-cron-ccd-migration-tool/aat-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/aat-01.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/demo-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/demo-01.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/ia-cron-ccd-migration-tool.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/ia-cron-ccd-migration-tool.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/ithc-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/ithc-01.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/perftest-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/perftest-01.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/prod-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/prod-01.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-unnotified-hearings-processor/aat-00.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/aat-01.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/demo-00.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/demo-01.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/ia-cron-unnotified-hearings-processor.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/ia-cron-unnotified-hearings-processor.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/ithc-00.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/ithc-01.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/perftest-00.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/perftest-01.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/prod-00.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-cron-unnotified-hearings-processor/prod-01.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-hearings-api/aat.yaml
+++ b/apps/ia/ia-hearings-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-hearings-api/ia-hearings-api.yaml
+++ b/apps/ia/ia-hearings-api/ia-hearings-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-hearings-api/ithc.yaml
+++ b/apps/ia/ia-hearings-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-hearings-api/perftest.yaml
+++ b/apps/ia/ia-hearings-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-hearings-api/prod.yaml
+++ b/apps/ia/ia-hearings-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-home-office-integration-api/aat.yaml
+++ b/apps/ia/ia-home-office-integration-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-integration-api/demo.yaml
+++ b/apps/ia/ia-home-office-integration-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-integration-api/ia-home-office-integration-api.yaml
+++ b/apps/ia/ia-home-office-integration-api/ia-home-office-integration-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-integration-api/ithc.yaml
+++ b/apps/ia/ia-home-office-integration-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-integration-api/perftest.yaml
+++ b/apps/ia/ia-home-office-integration-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-integration-api/prod.yaml
+++ b/apps/ia/ia-home-office-integration-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-mock-api/aat.yaml
+++ b/apps/ia/ia-home-office-mock-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-mock-api

--- a/apps/ia/ia-home-office-mock-api/demo.yaml
+++ b/apps/ia/ia-home-office-mock-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-mock-api

--- a/apps/ia/ia-home-office-mock-api/ia-home-office-mock-api.yaml
+++ b/apps/ia/ia-home-office-mock-api/ia-home-office-mock-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-mock-api

--- a/apps/ia/ia-home-office-mock-api/ithc.yaml
+++ b/apps/ia/ia-home-office-mock-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-mock-api

--- a/apps/ia/ia-home-office-mock-api/perftest.yaml
+++ b/apps/ia/ia-home-office-mock-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-home-office-mock-api

--- a/apps/ia/ia-timed-event-service/aat.yaml
+++ b/apps/ia/ia-timed-event-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-timed-event-service

--- a/apps/ia/ia-timed-event-service/demo.yaml
+++ b/apps/ia/ia-timed-event-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-timed-event-service

--- a/apps/ia/ia-timed-event-service/ia-timed-event-service.yaml
+++ b/apps/ia/ia-timed-event-service/ia-timed-event-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-timed-event-service

--- a/apps/ia/ia-timed-event-service/ithc.yaml
+++ b/apps/ia/ia-timed-event-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-timed-event-service

--- a/apps/ia/ia-timed-event-service/perftest.yaml
+++ b/apps/ia/ia-timed-event-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-timed-event-service

--- a/apps/ia/ia-timed-event-service/prod.yaml
+++ b/apps/ia/ia-timed-event-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ia-timed-event-service

--- a/apps/idam/idam-api/aat.yaml
+++ b/apps/idam/idam-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-api/ithc.yaml
+++ b/apps/idam/idam-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-api/perftest.yaml
+++ b/apps/idam/idam-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-api/preview.yaml
+++ b/apps/idam/idam-api/preview.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-api

--- a/apps/idam/idam-hmcts-access/demo.yaml
+++ b/apps/idam/idam-hmcts-access/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-hmcts-access

--- a/apps/idam/idam-hmcts-access/idam-hmcts-access.yaml
+++ b/apps/idam/idam-hmcts-access/idam-hmcts-access.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-hmcts-access

--- a/apps/idam/idam-hmcts-access/preview.yaml
+++ b/apps/idam/idam-hmcts-access/preview.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-hmcts-access

--- a/apps/idam/idam-hmcts-access/prod.yaml
+++ b/apps/idam/idam-hmcts-access/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-hmcts-access

--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-hmcts-access

--- a/apps/idam/idam-testing-support-api/aat.yaml
+++ b/apps/idam/idam-testing-support-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-testing-support-api/demo.yaml
+++ b/apps/idam/idam-testing-support-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-testing-support-api/idam-testing-support-api.yaml
+++ b/apps/idam/idam-testing-support-api/idam-testing-support-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-testing-support-api/ithc.yaml
+++ b/apps/idam/idam-testing-support-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-testing-support-api/perftest.yaml
+++ b/apps/idam/idam-testing-support-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-testing-support-api/preview.yaml
+++ b/apps/idam/idam-testing-support-api/preview.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-testing-support-api/sbox.yaml
+++ b/apps/idam/idam-testing-support-api/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-user-dashboard/demo.yaml
+++ b/apps/idam/idam-user-dashboard/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-dashboard

--- a/apps/idam/idam-user-dashboard/idam-user-dashboard.yaml
+++ b/apps/idam/idam-user-dashboard/idam-user-dashboard.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-dashboard

--- a/apps/idam/idam-user-dashboard/preview.yaml
+++ b/apps/idam/idam-user-dashboard/preview.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-dashboard

--- a/apps/idam/idam-user-dashboard/prod.yaml
+++ b/apps/idam/idam-user-dashboard/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-dashboard

--- a/apps/idam/idam-user-dashboard/sbox.yaml
+++ b/apps/idam/idam-user-dashboard/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-dashboard

--- a/apps/idam/idam-user-profile-bridge/aat.yaml
+++ b/apps/idam/idam-user-profile-bridge/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-user-profile-bridge/demo.yaml
+++ b/apps/idam/idam-user-profile-bridge/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-user-profile-bridge/idam-user-profile-bridge.yaml
+++ b/apps/idam/idam-user-profile-bridge/idam-user-profile-bridge.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-user-profile-bridge/ithc.yaml
+++ b/apps/idam/idam-user-profile-bridge/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-user-profile-bridge/perftest.yaml
+++ b/apps/idam/idam-user-profile-bridge/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-user-profile-bridge/sbox.yaml
+++ b/apps/idam/idam-user-profile-bridge/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-web-admin/aat.yaml
+++ b/apps/idam/idam-web-admin/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-admin/demo.yaml
+++ b/apps/idam/idam-web-admin/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-admin/idam-web-admin.yaml
+++ b/apps/idam/idam-web-admin/idam-web-admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-admin/ithc.yaml
+++ b/apps/idam/idam-web-admin/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-admin/perftest.yaml
+++ b/apps/idam/idam-web-admin/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-admin/preview.yaml
+++ b/apps/idam/idam-web-admin/preview.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-admin/sbox.yaml
+++ b/apps/idam/idam-web-admin/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/idam-web-public.yaml
+++ b/apps/idam/idam-web-public/idam-web-public.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/preview.yaml
+++ b/apps/idam/idam-web-public/preview.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/prod.yaml
+++ b/apps/idam/idam-web-public/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-web-public

--- a/apps/jenkins/jenkins-webhook-relay/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/jenkins-webhook-relay.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins-webhook-relay/ptl-intsvc/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/ptl-intsvc/jenkins-webhook-relay.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins-webhook-relay/sbox-intsvc/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/sbox-intsvc/jenkins-webhook-relay.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/jenkins-controller-version.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jps/jps-judicial-payment-frontend/aat.yaml
+++ b/apps/jps/jps-judicial-payment-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jps-judicial-payment-frontend

--- a/apps/jps/jps-judicial-payment-frontend/demo.yaml
+++ b/apps/jps/jps-judicial-payment-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jps-judicial-payment-frontend

--- a/apps/jps/jps-judicial-payment-frontend/jps-judicial-payment-frontend.yaml
+++ b/apps/jps/jps-judicial-payment-frontend/jps-judicial-payment-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jps-judicial-payment-frontend

--- a/apps/jps/jps-judicial-payment-service/aat.yaml
+++ b/apps/jps/jps-judicial-payment-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jps-judicial-payment-service

--- a/apps/jps/jps-judicial-payment-service/demo.yaml
+++ b/apps/jps/jps-judicial-payment-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jps-judicial-payment-service

--- a/apps/jps/jps-judicial-payment-service/jps-judicial-payment-service.yaml
+++ b/apps/jps/jps-judicial-payment-service/jps-judicial-payment-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jps-judicial-payment-service

--- a/apps/keda/keda/keda.yaml
+++ b/apps/keda/keda/keda.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: keda

--- a/apps/kured/kured/kured.yaml
+++ b/apps/kured/kured/kured.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kured

--- a/apps/labs/labs-darrenbayliss-dev/labs-darrenbayliss-dev.yaml
+++ b/apps/labs/labs-darrenbayliss-dev/labs-darrenbayliss-dev.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: labs-darrenbayliss-dev

--- a/apps/labs/labs-darrenbayliss-dev2/labs-darrenbayliss-dev2.yaml
+++ b/apps/labs/labs-darrenbayliss-dev2/labs-darrenbayliss-dev2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: labs-darrenbayliss-dev2

--- a/apps/labs/labs-hub-ngfw-poc/labs-hub-ngfw-poc.yaml
+++ b/apps/labs/labs-hub-ngfw-poc/labs-hub-ngfw-poc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: labs-hub-ngfw-poc

--- a/apps/labs/labs-rhodrif/labs-rhodrif.yaml
+++ b/apps/labs/labs-rhodrif/labs-rhodrif.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: labs-rhodrif

--- a/apps/lau/lau-case-backend-int/demo.yaml
+++ b/apps/lau/lau-case-backend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend-int

--- a/apps/lau/lau-case-backend-int/lau-case-backend-int.yaml
+++ b/apps/lau/lau-case-backend-int/lau-case-backend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend-int

--- a/apps/lau/lau-case-backend/aat.yaml
+++ b/apps/lau/lau-case-backend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-case-backend/demo.yaml
+++ b/apps/lau/lau-case-backend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-case-backend/ithc.yaml
+++ b/apps/lau/lau-case-backend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-case-backend/lau-case-backend.yaml
+++ b/apps/lau/lau-case-backend/lau-case-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-case-backend/perftest.yaml
+++ b/apps/lau/lau-case-backend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-case-backend/prod.yaml
+++ b/apps/lau/lau-case-backend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-frontend-int/demo.yaml
+++ b/apps/lau/lau-frontend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-frontend-int

--- a/apps/lau/lau-frontend-int/lau-frontend-int.yaml
+++ b/apps/lau/lau-frontend-int/lau-frontend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-frontend-int

--- a/apps/lau/lau-frontend/demo.yaml
+++ b/apps/lau/lau-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-frontend

--- a/apps/lau/lau-frontend/lau-frontend.yaml
+++ b/apps/lau/lau-frontend/lau-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-frontend

--- a/apps/lau/lau-frontend/prod.yaml
+++ b/apps/lau/lau-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-frontend

--- a/apps/lau/lau-idam-backend-int/demo.yaml
+++ b/apps/lau/lau-idam-backend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend-int

--- a/apps/lau/lau-idam-backend-int/lau-idam-backend-int.yaml
+++ b/apps/lau/lau-idam-backend-int/lau-idam-backend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend-int

--- a/apps/lau/lau-idam-backend/aat.yaml
+++ b/apps/lau/lau-idam-backend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend

--- a/apps/lau/lau-idam-backend/demo.yaml
+++ b/apps/lau/lau-idam-backend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend

--- a/apps/lau/lau-idam-backend/ithc.yaml
+++ b/apps/lau/lau-idam-backend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend

--- a/apps/lau/lau-idam-backend/lau-idam-backend.yaml
+++ b/apps/lau/lau-idam-backend/lau-idam-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend

--- a/apps/lau/lau-idam-backend/perftest.yaml
+++ b/apps/lau/lau-idam-backend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend

--- a/apps/lau/lau-idam-backend/prod.yaml
+++ b/apps/lau/lau-idam-backend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lau-idam-backend

--- a/apps/money-claims/cmc-ccd/cmc-ccd.yaml
+++ b/apps/money-claims/cmc-ccd/cmc-ccd.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-ccd

--- a/apps/money-claims/cmc-ccd/demo.yaml
+++ b/apps/money-claims/cmc-ccd/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-ccd

--- a/apps/money-claims/cmc-citizen-frontend/aat.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-citizen-frontend/cmc-citizen-frontend.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/cmc-citizen-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-citizen-frontend/demo.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-citizen-frontend/ithc.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-citizen-frontend/perftest.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-citizen-frontend/prod.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-claim-store/aat.yaml
+++ b/apps/money-claims/cmc-claim-store/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-claim-store/cmc-claim-store.yaml
+++ b/apps/money-claims/cmc-claim-store/cmc-claim-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-claim-store/demo.yaml
+++ b/apps/money-claims/cmc-claim-store/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-claim-store/ithc.yaml
+++ b/apps/money-claims/cmc-claim-store/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-claim-store/perftest.yaml
+++ b/apps/money-claims/cmc-claim-store/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-claim-store/prod.yaml
+++ b/apps/money-claims/cmc-claim-store/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-demo/cmc-demo.yaml
+++ b/apps/money-claims/cmc-demo/cmc-demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-demo

--- a/apps/money-claims/cmc-demo/demo.yaml
+++ b/apps/money-claims/cmc-demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-demo

--- a/apps/money-claims/cmc-dg-docassembly/cmc-dg-docassembly.yaml
+++ b/apps/money-claims/cmc-dg-docassembly/cmc-dg-docassembly.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-dg-docassembly

--- a/apps/money-claims/cmc-dg-docassembly/demo.yaml
+++ b/apps/money-claims/cmc-dg-docassembly/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-dg-docassembly

--- a/apps/money-claims/cmc-draft-store/cmc-draft-store.yaml
+++ b/apps/money-claims/cmc-draft-store/cmc-draft-store.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-draft-store

--- a/apps/money-claims/cmc-draft-store/demo.yaml
+++ b/apps/money-claims/cmc-draft-store/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-draft-store

--- a/apps/money-claims/cmc-pay/cmc-pay.yaml
+++ b/apps/money-claims/cmc-pay/cmc-pay.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-pay

--- a/apps/money-claims/cmc-pay/demo.yaml
+++ b/apps/money-claims/cmc-pay/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-pay

--- a/apps/money-claims/cmc-s2s/cmc-s2s.yaml
+++ b/apps/money-claims/cmc-s2s/cmc-s2s.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-s2s

--- a/apps/money-claims/cmc-s2s/demo.yaml
+++ b/apps/money-claims/cmc-s2s/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-s2s

--- a/apps/money-claims/cmc-send-letter-service/cmc-send-letter-service.yaml
+++ b/apps/money-claims/cmc-send-letter-service/cmc-send-letter-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-send-letter-service

--- a/apps/money-claims/cmc-send-letter-service/demo.yaml
+++ b/apps/money-claims/cmc-send-letter-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cmc-send-letter-service

--- a/apps/monitoring/botkube/botkube.yaml
+++ b/apps/monitoring/botkube/botkube.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: botkube

--- a/apps/monitoring/kube-prometheus-stack/aat/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/aat/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/demo/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/demo/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ithc/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ithc/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/jenkins-service-monitors.yaml
+++ b/apps/monitoring/kube-prometheus-stack/jenkins-service-monitors.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/perftest/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/perftest/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/preview/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/preview/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/preview/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/preview/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/prod/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/prod/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ptl-intsvc/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ptl-intsvc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/sbox-intsvc/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/sbox-intsvc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/sbox/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/sbox/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/sbox/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/sbox/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/node-problem-detector/node-problem-detector.yaml
+++ b/apps/monitoring/node-problem-detector/node-problem-detector.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: node-problem-detector

--- a/apps/monitoring/opentelemetry-collector/opentelemetry-collector.yaml
+++ b/apps/monitoring/opentelemetry-collector/opentelemetry-collector.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opentelemetry-collector

--- a/apps/monitoring/opentelemetry-collector/ptl-intsvc/00.yaml
+++ b/apps/monitoring/opentelemetry-collector/ptl-intsvc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opentelemetry-collector

--- a/apps/monitoring/opentelemetry-collector/sbox-intsvc/00.yaml
+++ b/apps/monitoring/opentelemetry-collector/sbox-intsvc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opentelemetry-collector

--- a/apps/neuvector/fluentbit-log/fluentbit-log.yaml
+++ b/apps/neuvector/fluentbit-log/fluentbit-log.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fluentbit-log

--- a/apps/neuvector/neuvector/aat/00.yaml
+++ b/apps/neuvector/neuvector/aat/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/aat/01.yaml
+++ b/apps/neuvector/neuvector/aat/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/aat/aat.yaml
+++ b/apps/neuvector/neuvector/aat/aat.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/perftest/00.yaml
+++ b/apps/neuvector/neuvector/perftest/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/perftest/01.yaml
+++ b/apps/neuvector/neuvector/perftest/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/perftest/perftest.yaml
+++ b/apps/neuvector/neuvector/perftest/perftest.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/prod/00.yaml
+++ b/apps/neuvector/neuvector/prod/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/prod/01.yaml
+++ b/apps/neuvector/neuvector/prod/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/prod/prod.yaml
+++ b/apps/neuvector/neuvector/prod/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ptl-intsvc/00.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ptl-intsvc/01.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
+++ b/apps/neuvector/neuvector/ptl-intsvc/ptl-intsvc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/nfdiv/nfdiv-case-api/aat.yaml
+++ b/apps/nfdiv/nfdiv-case-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-case-api

--- a/apps/nfdiv/nfdiv-case-api/demo.yaml
+++ b/apps/nfdiv/nfdiv-case-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-case-api

--- a/apps/nfdiv/nfdiv-case-api/nfdiv-case-api.yaml
+++ b/apps/nfdiv/nfdiv-case-api/nfdiv-case-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-case-api

--- a/apps/nfdiv/nfdiv-case-api/prod.yaml
+++ b/apps/nfdiv/nfdiv-case-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-case-api

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/nfdiv-cron-applicant-can-sts-after-intention-fo.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/nfdiv-cron-applicant-can-sts-after-intention-fo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-application-approved-reminder

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/demo-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/nfdiv-cron-eligible-for-switch-to-sole.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/nfdiv-cron-eligible-for-switch-to-sole.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/nfdiv-cron-final-order-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/nfdiv-cron-final-order-overdue.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-final-order-overdue

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-find-cases-with-successful-payments

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/nfdiv-cron-find-cases-with-successful-payments.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/nfdiv-cron-find-cases-with-successful-payments.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-find-cases-with-successful-payments

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-find-cases-with-successful-payments

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-find-cases-with-successful-payments

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/nfdiv-cron-js-disputed-answer-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/nfdiv-cron-js-disputed-answer-overdue.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/nfdiv-cron-notify-applicant-dispute-form-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/nfdiv-cron-notify-applicant-dispute-form-overdue.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicant-dispute-form-overdue

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/demo-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/nfdiv-cron-notify-applicants-apply-co.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/nfdiv-cron-notify-applicants-apply-co.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-applicants-apply-co

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-notify-respondent-apply-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/nfdiv-cron-partner-not-applied-for-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/nfdiv-cron-partner-not-applied-for-final-order.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/nfdiv-cron-process-cases-to-be-removed.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/nfdiv-cron-process-cases-to-be-removed.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-cases-to-be-removed

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/nfdiv-cron-process-failed-pronounced-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/nfdiv-cron-process-failed-pronounced-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-pronounced-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/nfdiv-cron-process-failed-scheduled-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/nfdiv-cron-process-failed-scheduled-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-scheduled-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/nfdiv-cron-process-failed-to-unlink-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/nfdiv-cron-process-failed-to-unlink-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-process-failed-to-unlink-cases

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/nfdiv-cron-progress-cases-to-aos-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/nfdiv-cron-progress-cases-to-aos-overdue.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-cases-to-aos-overdue

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/demo-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/nfdiv-cron-progress-held-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/nfdiv-cron-progress-held-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-held-cases

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/demo-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-progress-to-awaiting-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/nfdiv-cron-remind-applicant2.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/nfdiv-cron-remind-applicant2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicant2

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-applicants-apply-for-fo

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/nfdiv-cron-remind-awaiting-joint-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/nfdiv-cron-remind-awaiting-joint-final-order.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/aat-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/demo-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/ithc-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/perftest-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-remind-respondent-solicitor

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/aat/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/aat/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/demo/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/demo/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/ithc/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/ithc/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/nfdiv-cron-resend-co-pronounced-cover-letters.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/nfdiv-cron-resend-co-pronounced-cover-letters.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/perftest/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/perftest/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/prod/00.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/prod/01.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-frontend/aat.yaml
+++ b/apps/nfdiv/nfdiv-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-frontend

--- a/apps/nfdiv/nfdiv-frontend/demo.yaml
+++ b/apps/nfdiv/nfdiv-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-frontend

--- a/apps/nfdiv/nfdiv-frontend/nfdiv-frontend.yaml
+++ b/apps/nfdiv/nfdiv-frontend/nfdiv-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-frontend

--- a/apps/nfdiv/nfdiv-frontend/prod.yaml
+++ b/apps/nfdiv/nfdiv-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: nfdiv-frontend

--- a/apps/pact-broker/pact-broker/pact-broker.yaml
+++ b/apps/pact-broker/pact-broker/pact-broker.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pact-broker

--- a/apps/pact-broker/pact-broker/ptl-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/ptl-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pact-broker

--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pact-broker

--- a/apps/pcq/pcq-backend-int/demo.yaml
+++ b/apps/pcq/pcq-backend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend-int

--- a/apps/pcq/pcq-backend-int/pcq-backend-int.yaml
+++ b/apps/pcq/pcq-backend-int/pcq-backend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend-int

--- a/apps/pcq/pcq-backend/aat.yaml
+++ b/apps/pcq/pcq-backend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-backend/demo.yaml
+++ b/apps/pcq/pcq-backend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-backend/ithc.yaml
+++ b/apps/pcq/pcq-backend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-backend/pcq-backend.yaml
+++ b/apps/pcq/pcq-backend/pcq-backend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-backend/perftest.yaml
+++ b/apps/pcq/pcq-backend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-backend/prod.yaml
+++ b/apps/pcq/pcq-backend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-consolidation-service/aat.yaml
+++ b/apps/pcq/pcq-consolidation-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-consolidation-service/demo.yaml
+++ b/apps/pcq/pcq-consolidation-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-consolidation-service/ithc.yaml
+++ b/apps/pcq/pcq-consolidation-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-consolidation-service/pcq-consolidation-service.yaml
+++ b/apps/pcq/pcq-consolidation-service/pcq-consolidation-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-consolidation-service/perftest.yaml
+++ b/apps/pcq/pcq-consolidation-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-consolidation-service/prod.yaml
+++ b/apps/pcq/pcq-consolidation-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-frontend-int/demo.yaml
+++ b/apps/pcq/pcq-frontend-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend-int

--- a/apps/pcq/pcq-frontend-int/pcq-frontend-int.yaml
+++ b/apps/pcq/pcq-frontend-int/pcq-frontend-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend-int

--- a/apps/pcq/pcq-frontend/aat.yaml
+++ b/apps/pcq/pcq-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-frontend/demo.yaml
+++ b/apps/pcq/pcq-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-frontend/ithc.yaml
+++ b/apps/pcq/pcq-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-frontend/pcq-frontend.yaml
+++ b/apps/pcq/pcq-frontend/pcq-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-frontend/perftest.yaml
+++ b/apps/pcq/pcq-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-frontend/prod.yaml
+++ b/apps/pcq/pcq-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-loader/aat.yaml
+++ b/apps/pcq/pcq-loader/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-loader

--- a/apps/pcq/pcq-loader/demo.yaml
+++ b/apps/pcq/pcq-loader/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-loader

--- a/apps/pcq/pcq-loader/ithc.yaml
+++ b/apps/pcq/pcq-loader/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-loader

--- a/apps/pcq/pcq-loader/pcq-loader.yaml
+++ b/apps/pcq/pcq-loader/pcq-loader.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-loader

--- a/apps/pcq/pcq-loader/perftest.yaml
+++ b/apps/pcq/pcq-loader/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-loader

--- a/apps/pcq/pcq-loader/prod.yaml
+++ b/apps/pcq/pcq-loader/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pcq-loader

--- a/apps/private-law/prl-ccd-case-migration/demo.yaml
+++ b/apps/private-law/prl-ccd-case-migration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/demo/00.yaml
+++ b/apps/private-law/prl-ccd-case-migration/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/demo/01.yaml
+++ b/apps/private-law/prl-ccd-case-migration/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/perftest.yaml
+++ b/apps/private-law/prl-ccd-case-migration/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/perftest/00.yaml
+++ b/apps/private-law/prl-ccd-case-migration/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/perftest/01.yaml
+++ b/apps/private-law/prl-ccd-case-migration/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/prl-ccd-case-migration.yaml
+++ b/apps/private-law/prl-ccd-case-migration/prl-ccd-case-migration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/prod.yaml
+++ b/apps/private-law/prl-ccd-case-migration/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/prod/00.yaml
+++ b/apps/private-law/prl-ccd-case-migration/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-ccd-case-migration/prod/01.yaml
+++ b/apps/private-law/prl-ccd-case-migration/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-citizen-frontend/aat.yaml
+++ b/apps/private-law/prl-citizen-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-citizen-frontend/demo.yaml
+++ b/apps/private-law/prl-citizen-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-citizen-frontend/ithc.yaml
+++ b/apps/private-law/prl-citizen-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-citizen-frontend/perftest.yaml
+++ b/apps/private-law/prl-citizen-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-citizen-frontend/prl-citizen-frontend.yaml
+++ b/apps/private-law/prl-citizen-frontend/prl-citizen-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-citizen-frontend/prod.yaml
+++ b/apps/private-law/prl-citizen-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-cos/aat.yaml
+++ b/apps/private-law/prl-cos/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-cos/demo.yaml
+++ b/apps/private-law/prl-cos/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-cos/ithc.yaml
+++ b/apps/private-law/prl-cos/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-cos/perftest.yaml
+++ b/apps/private-law/prl-cos/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-cos/prl-cos.yaml
+++ b/apps/private-law/prl-cos/prl-cos.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-cos/prod.yaml
+++ b/apps/private-law/prl-cos/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-dgs/aat.yaml
+++ b/apps/private-law/prl-dgs/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-dgs

--- a/apps/private-law/prl-dgs/demo.yaml
+++ b/apps/private-law/prl-dgs/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-dgs

--- a/apps/private-law/prl-dgs/ithc.yaml
+++ b/apps/private-law/prl-dgs/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-dgs

--- a/apps/private-law/prl-dgs/perftest.yaml
+++ b/apps/private-law/prl-dgs/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-dgs

--- a/apps/private-law/prl-dgs/prl-dgs.yaml
+++ b/apps/private-law/prl-dgs/prl-dgs.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-dgs

--- a/apps/private-law/prl-dgs/prod.yaml
+++ b/apps/private-law/prl-dgs/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: prl-dgs

--- a/apps/probate/probate-back-office/aat.yaml
+++ b/apps/probate/probate-back-office/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-back-office/demo.yaml
+++ b/apps/probate/probate-back-office/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-back-office/ithc.yaml
+++ b/apps/probate/probate-back-office/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-back-office/perftest.yaml
+++ b/apps/probate/probate-back-office/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-back-office/probate-back-office.yaml
+++ b/apps/probate/probate-back-office/probate-back-office.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-back-office/prod.yaml
+++ b/apps/probate/probate-back-office/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-business-service/demo.yaml
+++ b/apps/probate/probate-business-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-business-service

--- a/apps/probate/probate-business-service/probate-business-service.yaml
+++ b/apps/probate/probate-business-service/probate-business-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-business-service

--- a/apps/probate/probate-business-service/prod.yaml
+++ b/apps/probate/probate-business-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-business-service

--- a/apps/probate/probate-caveats-fe/aat.yaml
+++ b/apps/probate/probate-caveats-fe/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-caveats-fe/demo.yaml
+++ b/apps/probate/probate-caveats-fe/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-caveats-fe/ithc.yaml
+++ b/apps/probate/probate-caveats-fe/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-caveats-fe/perftest.yaml
+++ b/apps/probate/probate-caveats-fe/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-caveats-fe/probate-caveats-fe.yaml
+++ b/apps/probate/probate-caveats-fe/probate-caveats-fe.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-caveats-fe/prod.yaml
+++ b/apps/probate/probate-caveats-fe/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-cron-ccd-data-migration-tool/demo/00.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-ccd-data-migration-tool/demo/01.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-ccd-data-migration-tool/perftest/00.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-ccd-data-migration-tool/perftest/01.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-ccd-data-migration-tool/probate-cron-ccd-data-migration-tool.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/probate-cron-ccd-data-migration-tool.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-ccd-data-migration-tool/prod/00.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-ccd-data-migration-tool/prod/01.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-hmrc-extract/aat/00.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/aat/01.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/demo/00.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/demo/01.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/perftest/00.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/perftest/01.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/probate-cron-hmrc-extract.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/probate-cron-hmrc-extract.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/prod/00.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-hmrc-extract/prod/01.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-make-dormant-cases/aat/aat.yaml
+++ b/apps/probate/probate-cron-make-dormant-cases/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-make-dormant-cases

--- a/apps/probate/probate-cron-make-dormant-cases/demo/demo.yaml
+++ b/apps/probate/probate-cron-make-dormant-cases/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-make-dormant-cases

--- a/apps/probate/probate-cron-make-dormant-cases/perftest/perftest.yaml
+++ b/apps/probate/probate-cron-make-dormant-cases/perftest/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-make-dormant-cases

--- a/apps/probate/probate-cron-make-dormant-cases/probate-cron-make-dormant-cases.yaml
+++ b/apps/probate/probate-cron-make-dormant-cases/probate-cron-make-dormant-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-make-dormant-cases

--- a/apps/probate/probate-cron-make-dormant-cases/prod/prod.yaml
+++ b/apps/probate/probate-cron-make-dormant-cases/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-make-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/aat/aat.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/aat/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/demo/00.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/demo/01.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/perftest/00.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/perftest/01.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/probate-cron-reactivate-dormant-cases.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/probate-cron-reactivate-dormant-cases.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/prod/00.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/prod/01.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-cron-smee-and-ford-extract/aat/00.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-cron-smee-and-ford-extract/demo/demo.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/demo/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-cron-smee-and-ford-extract/perftest/perftest.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/perftest/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-cron-smee-and-ford-extract/probate-cron-smee-and-ford-extract.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/probate-cron-smee-and-ford-extract.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-cron-smee-and-ford-extract/prod/prod-00.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/prod/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-cron-smee-and-ford-extract/prod/prod-01.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/prod/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-cron-smee-and-ford-extract/prod/prod.yaml
+++ b/apps/probate/probate-cron-smee-and-ford-extract/prod/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-cron-smee-and-ford-extract

--- a/apps/probate/probate-frontend/aat.yaml
+++ b/apps/probate/probate-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-frontend/demo.yaml
+++ b/apps/probate/probate-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-frontend/ithc.yaml
+++ b/apps/probate/probate-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-frontend/perftest.yaml
+++ b/apps/probate/probate-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-frontend/probate-frontend.yaml
+++ b/apps/probate/probate-frontend/probate-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-frontend/prod.yaml
+++ b/apps/probate/probate-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-orchestrator-service/aat.yaml
+++ b/apps/probate/probate-orchestrator-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-orchestrator-service/demo.yaml
+++ b/apps/probate/probate-orchestrator-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-orchestrator-service/ithc.yaml
+++ b/apps/probate/probate-orchestrator-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-orchestrator-service/perftest.yaml
+++ b/apps/probate/probate-orchestrator-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
+++ b/apps/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-orchestrator-service/prod.yaml
+++ b/apps/probate/probate-orchestrator-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-submit-service/demo.yaml
+++ b/apps/probate/probate-submit-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-submit-service

--- a/apps/probate/probate-submit-service/perftest.yaml
+++ b/apps/probate/probate-submit-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-submit-service

--- a/apps/probate/probate-submit-service/probate-submit-service.yaml
+++ b/apps/probate/probate-submit-service/probate-submit-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-submit-service

--- a/apps/probate/probate-submit-service/prod.yaml
+++ b/apps/probate/probate-submit-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: probate-submit-service

--- a/apps/rd/rd-caseworker-ref-api-integration/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api-integration

--- a/apps/rd/rd-caseworker-ref-api-integration/rd-caseworker-ref-api-integration.yaml
+++ b/apps/rd/rd-caseworker-ref-api-integration/rd-caseworker-ref-api-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api-integration

--- a/apps/rd/rd-caseworker-ref-api/aat.yaml
+++ b/apps/rd/rd-caseworker-ref-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-caseworker-ref-api/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-caseworker-ref-api/ithc.yaml
+++ b/apps/rd/rd-caseworker-ref-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-caseworker-ref-api/perftest.yaml
+++ b/apps/rd/rd-caseworker-ref-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-caseworker-ref-api/prod.yaml
+++ b/apps/rd/rd-caseworker-ref-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
+++ b/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-commondata-api/aat.yaml
+++ b/apps/rd/rd-commondata-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-api/demo.yaml
+++ b/apps/rd/rd-commondata-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-api/ithc.yaml
+++ b/apps/rd/rd-commondata-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-api/perftest.yaml
+++ b/apps/rd/rd-commondata-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-api/prod.yaml
+++ b/apps/rd/rd-commondata-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-api/rd-commondata-api.yaml
+++ b/apps/rd/rd-commondata-api/rd-commondata-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-dataload/aat-00.yaml
+++ b/apps/rd/rd-commondata-dataload/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/aat-01.yaml
+++ b/apps/rd/rd-commondata-dataload/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/demo-00.yaml
+++ b/apps/rd/rd-commondata-dataload/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/demo-01.yaml
+++ b/apps/rd/rd-commondata-dataload/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/ithc-00.yaml
+++ b/apps/rd/rd-commondata-dataload/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/ithc-01.yaml
+++ b/apps/rd/rd-commondata-dataload/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/perftest-00.yaml
+++ b/apps/rd/rd-commondata-dataload/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/perftest-01.yaml
+++ b/apps/rd/rd-commondata-dataload/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/prod-00.yaml
+++ b/apps/rd/rd-commondata-dataload/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/prod-01.yaml
+++ b/apps/rd/rd-commondata-dataload/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-commondata-dataload/rd-commondata-dataload.yaml
+++ b/apps/rd/rd-commondata-dataload/rd-commondata-dataload.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-judicial-api-integration/demo.yaml
+++ b/apps/rd/rd-judicial-api-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api-integration

--- a/apps/rd/rd-judicial-api-integration/rd-judicial-api-integration.yaml
+++ b/apps/rd/rd-judicial-api-integration/rd-judicial-api-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api-integration

--- a/apps/rd/rd-judicial-api/aat.yaml
+++ b/apps/rd/rd-judicial-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-api/demo.yaml
+++ b/apps/rd/rd-judicial-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-api/ithc.yaml
+++ b/apps/rd/rd-judicial-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-api/perftest.yaml
+++ b/apps/rd/rd-judicial-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-api/prod.yaml
+++ b/apps/rd/rd-judicial-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-api/rd-judicial-api.yaml
+++ b/apps/rd/rd-judicial-api/rd-judicial-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-data-load-integration/demo-00.yaml
+++ b/apps/rd/rd-judicial-data-load-integration/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load-integration

--- a/apps/rd/rd-judicial-data-load-integration/demo-01.yaml
+++ b/apps/rd/rd-judicial-data-load-integration/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load-integration

--- a/apps/rd/rd-judicial-data-load-integration/rd-judicial-data-load-integration.yaml
+++ b/apps/rd/rd-judicial-data-load-integration/rd-judicial-data-load-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load-integration

--- a/apps/rd/rd-judicial-data-load/aat-00.yaml
+++ b/apps/rd/rd-judicial-data-load/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/aat-01.yaml
+++ b/apps/rd/rd-judicial-data-load/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/demo-00.yaml
+++ b/apps/rd/rd-judicial-data-load/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/demo-01.yaml
+++ b/apps/rd/rd-judicial-data-load/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/ithc-00.yaml
+++ b/apps/rd/rd-judicial-data-load/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/ithc-01.yaml
+++ b/apps/rd/rd-judicial-data-load/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/perftest-00.yaml
+++ b/apps/rd/rd-judicial-data-load/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/perftest-01.yaml
+++ b/apps/rd/rd-judicial-data-load/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/prod-00.yaml
+++ b/apps/rd/rd-judicial-data-load/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/prod-01.yaml
+++ b/apps/rd/rd-judicial-data-load/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-judicial-data-load/rd-judicial-data-load.yaml
+++ b/apps/rd/rd-judicial-data-load/rd-judicial-data-load.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-location-ref-api-integration/demo.yaml
+++ b/apps/rd/rd-location-ref-api-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api-integration

--- a/apps/rd/rd-location-ref-api-integration/rd-location-ref-api-integration.yaml
+++ b/apps/rd/rd-location-ref-api-integration/rd-location-ref-api-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api-integration

--- a/apps/rd/rd-location-ref-api/aat.yaml
+++ b/apps/rd/rd-location-ref-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-api/demo.yaml
+++ b/apps/rd/rd-location-ref-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-api/ithc.yaml
+++ b/apps/rd/rd-location-ref-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-api/perftest.yaml
+++ b/apps/rd/rd-location-ref-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-api/prod.yaml
+++ b/apps/rd/rd-location-ref-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
+++ b/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-data-load-integration/demo-00.yaml
+++ b/apps/rd/rd-location-ref-data-load-integration/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load-integration

--- a/apps/rd/rd-location-ref-data-load-integration/demo-01.yaml
+++ b/apps/rd/rd-location-ref-data-load-integration/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load-integration

--- a/apps/rd/rd-location-ref-data-load-integration/rd-location-ref-data-load-integration.yaml
+++ b/apps/rd/rd-location-ref-data-load-integration/rd-location-ref-data-load-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load-integration

--- a/apps/rd/rd-location-ref-data-load/aat-00.yaml
+++ b/apps/rd/rd-location-ref-data-load/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/aat-01.yaml
+++ b/apps/rd/rd-location-ref-data-load/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/demo-00.yaml
+++ b/apps/rd/rd-location-ref-data-load/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/demo-01.yaml
+++ b/apps/rd/rd-location-ref-data-load/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/ithc-00.yaml
+++ b/apps/rd/rd-location-ref-data-load/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/ithc-01.yaml
+++ b/apps/rd/rd-location-ref-data-load/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/perftest-00.yaml
+++ b/apps/rd/rd-location-ref-data-load/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/perftest-01.yaml
+++ b/apps/rd/rd-location-ref-data-load/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/prod-00.yaml
+++ b/apps/rd/rd-location-ref-data-load/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/prod-01.yaml
+++ b/apps/rd/rd-location-ref-data-load/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-location-ref-data-load/rd-location-ref-data-load.yaml
+++ b/apps/rd/rd-location-ref-data-load/rd-location-ref-data-load.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-professional-api-integration/demo.yaml
+++ b/apps/rd/rd-professional-api-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api-integration

--- a/apps/rd/rd-professional-api-integration/rd-professional-api-integration.yaml
+++ b/apps/rd/rd-professional-api-integration/rd-professional-api-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api-integration

--- a/apps/rd/rd-professional-api/aat.yaml
+++ b/apps/rd/rd-professional-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-professional-api/demo.yaml
+++ b/apps/rd/rd-professional-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-professional-api/ithc.yaml
+++ b/apps/rd/rd-professional-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-professional-api/perftest.yaml
+++ b/apps/rd/rd-professional-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-professional-api/prod.yaml
+++ b/apps/rd/rd-professional-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-professional-api/rd-professional-api.yaml
+++ b/apps/rd/rd-professional-api/rd-professional-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-profile-sync-integration/demo.yaml
+++ b/apps/rd/rd-profile-sync-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync-integration

--- a/apps/rd/rd-profile-sync-integration/rd-profile-sync-integration.yaml
+++ b/apps/rd/rd-profile-sync-integration/rd-profile-sync-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync-integration

--- a/apps/rd/rd-profile-sync/aat.yaml
+++ b/apps/rd/rd-profile-sync/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-profile-sync/demo.yaml
+++ b/apps/rd/rd-profile-sync/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-profile-sync/ithc.yaml
+++ b/apps/rd/rd-profile-sync/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-profile-sync/perftest.yaml
+++ b/apps/rd/rd-profile-sync/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-profile-sync/prod.yaml
+++ b/apps/rd/rd-profile-sync/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-profile-sync/rd-profile-sync.yaml
+++ b/apps/rd/rd-profile-sync/rd-profile-sync.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-user-profile-api-integration/demo.yaml
+++ b/apps/rd/rd-user-profile-api-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api-integration

--- a/apps/rd/rd-user-profile-api-integration/rd-user-profile-api-integration.yaml
+++ b/apps/rd/rd-user-profile-api-integration/rd-user-profile-api-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api-integration

--- a/apps/rd/rd-user-profile-api/aat.yaml
+++ b/apps/rd/rd-user-profile-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/apps/rd/rd-user-profile-api/demo.yaml
+++ b/apps/rd/rd-user-profile-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/apps/rd/rd-user-profile-api/ithc.yaml
+++ b/apps/rd/rd-user-profile-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/apps/rd/rd-user-profile-api/perftest.yaml
+++ b/apps/rd/rd-user-profile-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/apps/rd/rd-user-profile-api/prod.yaml
+++ b/apps/rd/rd-user-profile-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
+++ b/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-user-profile-api

--- a/apps/reform-scan/reform-scan-blob-router/aat.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router

--- a/apps/reform-scan/reform-scan-blob-router/demo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router

--- a/apps/reform-scan/reform-scan-blob-router/perftest.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router

--- a/apps/reform-scan/reform-scan-blob-router/prod.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router

--- a/apps/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/reform-scan-blob-router.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-blob-router

--- a/apps/reform-scan/reform-scan-notification-service/aat.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-notification-service

--- a/apps/reform-scan/reform-scan-notification-service/demo.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-notification-service

--- a/apps/reform-scan/reform-scan-notification-service/perftest.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-notification-service

--- a/apps/reform-scan/reform-scan-notification-service/prod.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-notification-service

--- a/apps/reform-scan/reform-scan-notification-service/reform-scan-notification-service.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/reform-scan-notification-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: reform-scan-notification-service

--- a/apps/response/api/response-api.yaml
+++ b/apps/response/api/response-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-response-api

--- a/apps/response/frontend/response-frontend.yaml
+++ b/apps/response/frontend/response-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-response-frontend

--- a/apps/rpe/draft-store-service/aat.yaml
+++ b/apps/rpe/draft-store-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/demo.yaml
+++ b/apps/rpe/draft-store-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/draft-store-service.yaml
+++ b/apps/rpe/draft-store-service/draft-store-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/ithc.yaml
+++ b/apps/rpe/draft-store-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/perftest.yaml
+++ b/apps/rpe/draft-store-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/prod.yaml
+++ b/apps/rpe/draft-store-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/sbox.yaml
+++ b/apps/rpe/draft-store-service/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: draft-store-service

--- a/apps/rpe/pdf-service/aat.yaml
+++ b/apps/rpe/pdf-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pdf-service

--- a/apps/rpe/pdf-service/demo.yaml
+++ b/apps/rpe/pdf-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pdf-service

--- a/apps/rpe/pdf-service/pdf-service.yaml
+++ b/apps/rpe/pdf-service/pdf-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pdf-service

--- a/apps/rpe/rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-new/rpe-send-letter-service-container-new.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service-container-new

--- a/apps/rpe/rpe-send-letter-service-container-proc/perftest.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-proc/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service-container-proc

--- a/apps/rpe/rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-proc/rpe-send-letter-service-container-proc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service-container-proc

--- a/apps/rpe/rpe-send-letter-service-container-zip/perftest.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-zip/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service-container-zip

--- a/apps/rpe/rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-zip/rpe-send-letter-service-container-zip.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service-container-zip

--- a/apps/rpe/rpe-send-letter-service/aat.yaml
+++ b/apps/rpe/rpe-send-letter-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-send-letter-service/demo.yaml
+++ b/apps/rpe/rpe-send-letter-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-send-letter-service/ithc.yaml
+++ b/apps/rpe/rpe-send-letter-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-send-letter-service/perftest.yaml
+++ b/apps/rpe/rpe-send-letter-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-send-letter-service/prod.yaml
+++ b/apps/rpe/rpe-send-letter-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-send-letter-service/rpe-send-letter-service.yaml
+++ b/apps/rpe/rpe-send-letter-service/rpe-send-letter-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-service-auth-provider/demo.yaml
+++ b/apps/rpe/rpe-service-auth-provider/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-service-auth-provider

--- a/apps/rpe/rpe-service-auth-provider/prod.yaml
+++ b/apps/rpe/rpe-service-auth-provider/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-service-auth-provider

--- a/apps/rpe/rpe-service-auth-provider/rpe-service-auth-provider.yaml
+++ b/apps/rpe/rpe-service-auth-provider/rpe-service-auth-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpe-service-auth-provider

--- a/apps/rpts/rpts-api/demo.yaml
+++ b/apps/rpts/rpts-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpts-api

--- a/apps/rpts/rpts-api/prod.yaml
+++ b/apps/rpts/rpts-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpts-api

--- a/apps/rpts/rpts-api/rpts-api.yaml
+++ b/apps/rpts/rpts-api/rpts-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpts-api

--- a/apps/rpts/rpts-frontend/demo.yaml
+++ b/apps/rpts/rpts-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpts-frontend

--- a/apps/rpts/rpts-frontend/prod.yaml
+++ b/apps/rpts/rpts-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpts-frontend

--- a/apps/rpts/rpts-frontend/rpts-frontend.yaml
+++ b/apps/rpts/rpts-frontend/rpts-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rpts-frontend

--- a/apps/slack-help-bot/ccd-slack-help-bot/ccd-slack-help-bot.yaml
+++ b/apps/slack-help-bot/ccd-slack-help-bot/ccd-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccd-slack-help-bot

--- a/apps/slack-help-bot/ccpay-slack-help-bot/ccpay-slack-help-bot.yaml
+++ b/apps/slack-help-bot/ccpay-slack-help-bot/ccpay-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ccpay-slack-help-bot

--- a/apps/slack-help-bot/cs-slack-help-bot/cs-slack-help-bot.yaml
+++ b/apps/slack-help-bot/cs-slack-help-bot/cs-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: cs-slack-help-bot

--- a/apps/slack-help-bot/em-slack-help-bot/em-slack-help-bot.yaml
+++ b/apps/slack-help-bot/em-slack-help-bot/em-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: em-slack-help-bot

--- a/apps/slack-help-bot/fact-slack-help-bot/fact-slack-help-bot.yaml
+++ b/apps/slack-help-bot/fact-slack-help-bot/fact-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fact-slack-help-bot

--- a/apps/slack-help-bot/idam-slack-help-bot/idam-slack-help-bot.yaml
+++ b/apps/slack-help-bot/idam-slack-help-bot/idam-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: idam-slack-help-bot

--- a/apps/slack-help-bot/rd-slack-help-bot/rd-slack-help-bot.yaml
+++ b/apps/slack-help-bot/rd-slack-help-bot/rd-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: rd-slack-help-bot

--- a/apps/slack-help-bot/slack-help-bot/slack-help-bot.yaml
+++ b/apps/slack-help-bot/slack-help-bot/slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: slack-help-bot

--- a/apps/slack-help-bot/wa-slack-help-bot/wa-slack-help-bot.yaml
+++ b/apps/slack-help-bot/wa-slack-help-bot/wa-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-slack-help-bot

--- a/apps/slack-help-bot/xui-slack-help-bot/xui-slack-help-bot.yaml
+++ b/apps/slack-help-bot/xui-slack-help-bot/xui-slack-help-bot.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-slack-help-bot

--- a/apps/sptribs/sptribs-case-api/aat.yaml
+++ b/apps/sptribs/sptribs-case-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-case-api/demo.yaml
+++ b/apps/sptribs/sptribs-case-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-case-api/ithc.yaml
+++ b/apps/sptribs/sptribs-case-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-case-api/perftest.yaml
+++ b/apps/sptribs/sptribs-case-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-case-api/prod.yaml
+++ b/apps/sptribs/sptribs-case-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-case-api/sptribs-case-api.yaml
+++ b/apps/sptribs/sptribs-case-api/sptribs-case-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/aat/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/aat/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/demo/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/demo/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/perftest/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/perftest/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/prod/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/prod/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/sptribs-cron-migrate-case-flags.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/sptribs-cron-migrate-case-flags.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-links/aat/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/aat/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/demo/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/demo/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/perftest/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/perftest/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/prod/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/prod/01.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-cron-migrate-case-links/sptribs-cron-migrate-case-links.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/sptribs-cron-migrate-case-links.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-frontend/aat.yaml
+++ b/apps/sptribs/sptribs-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-frontend

--- a/apps/sptribs/sptribs-frontend/demo.yaml
+++ b/apps/sptribs/sptribs-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-frontend

--- a/apps/sptribs/sptribs-frontend/ithc.yaml
+++ b/apps/sptribs/sptribs-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-frontend

--- a/apps/sptribs/sptribs-frontend/perftest.yaml
+++ b/apps/sptribs/sptribs-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-frontend

--- a/apps/sptribs/sptribs-frontend/prod.yaml
+++ b/apps/sptribs/sptribs-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-frontend

--- a/apps/sptribs/sptribs-frontend/sptribs-frontend.yaml
+++ b/apps/sptribs/sptribs-frontend/sptribs-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sptribs-frontend

--- a/apps/sscs/sscs-bulk-scan/aat.yaml
+++ b/apps/sscs/sscs-bulk-scan/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-bulk-scan

--- a/apps/sscs/sscs-bulk-scan/demo.yaml
+++ b/apps/sscs/sscs-bulk-scan/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-bulk-scan

--- a/apps/sscs/sscs-bulk-scan/perftest.yaml
+++ b/apps/sscs/sscs-bulk-scan/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-bulk-scan

--- a/apps/sscs/sscs-bulk-scan/prod.yaml
+++ b/apps/sscs/sscs-bulk-scan/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-bulk-scan

--- a/apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
+++ b/apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-bulk-scan

--- a/apps/sscs/sscs-case-loader/aat-00.yaml
+++ b/apps/sscs/sscs-case-loader/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/apps/sscs/sscs-case-loader/aat-01.yaml
+++ b/apps/sscs/sscs-case-loader/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/apps/sscs/sscs-case-loader/prod-00.yaml
+++ b/apps/sscs/sscs-case-loader/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/apps/sscs/sscs-case-loader/prod-01.yaml
+++ b/apps/sscs/sscs-case-loader/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/apps/sscs/sscs-case-loader/sscs-case-loader.yaml
+++ b/apps/sscs/sscs-case-loader/sscs-case-loader.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-case-loader

--- a/apps/sscs/sscs-case-migration/sscs-case-migration.yaml
+++ b/apps/sscs/sscs-case-migration/sscs-case-migration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-case-migration

--- a/apps/sscs/sscs-ccd-callback-orchestrator/aat.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-ccd-callback-orchestrator/demo.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-ccd-callback-orchestrator/ithc.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-ccd-callback-orchestrator/perftest.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-ccd-callback-orchestrator/prod.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-ccd-callback-orchestrator/sscs-ccd-callback-orchestrator.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/sscs-ccd-callback-orchestrator.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-cor-frontend/aat.yaml
+++ b/apps/sscs/sscs-cor-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-cor-frontend/demo.yaml
+++ b/apps/sscs/sscs-cor-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-cor-frontend/ithc.yaml
+++ b/apps/sscs/sscs-cor-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-cor-frontend/perftest.yaml
+++ b/apps/sscs/sscs-cor-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-cor-frontend/prod.yaml
+++ b/apps/sscs/sscs-cor-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
+++ b/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-evidence-share/aat.yaml
+++ b/apps/sscs/sscs-evidence-share/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-evidence-share/demo.yaml
+++ b/apps/sscs/sscs-evidence-share/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-evidence-share/ithc.yaml
+++ b/apps/sscs/sscs-evidence-share/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-evidence-share/perftest.yaml
+++ b/apps/sscs/sscs-evidence-share/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-evidence-share/prod.yaml
+++ b/apps/sscs/sscs-evidence-share/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-evidence-share/sscs-evidence-share.yaml
+++ b/apps/sscs/sscs-evidence-share/sscs-evidence-share.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-hearings-api/aat.yaml
+++ b/apps/sscs/sscs-hearings-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hearings-api/demo.yaml
+++ b/apps/sscs/sscs-hearings-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hearings-api/ithc.yaml
+++ b/apps/sscs/sscs-hearings-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hearings-api/perftest.yaml
+++ b/apps/sscs/sscs-hearings-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hearings-api/prod.yaml
+++ b/apps/sscs/sscs-hearings-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
+++ b/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hmc-stub/sscs-hmc-stub.yaml
+++ b/apps/sscs/sscs-hmc-stub/sscs-hmc-stub.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-hmc-stub

--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-api/demo.yaml
+++ b/apps/sscs/sscs-tribunals-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-api/ithc.yaml
+++ b/apps/sscs/sscs-tribunals-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-api/perftest.yaml
+++ b/apps/sscs/sscs-tribunals-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-api/prod.yaml
+++ b/apps/sscs/sscs-tribunals-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+++ b/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-frontend/aat.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tribunals-frontend/demo.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tribunals-frontend/ithc.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tribunals-frontend/perftest.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tribunals-frontend/prod.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tya-notif/aat.yaml
+++ b/apps/sscs/sscs-tya-notif/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/apps/sscs/sscs-tya-notif/demo.yaml
+++ b/apps/sscs/sscs-tya-notif/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/apps/sscs/sscs-tya-notif/ithc.yaml
+++ b/apps/sscs/sscs-tya-notif/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/apps/sscs/sscs-tya-notif/perftest.yaml
+++ b/apps/sscs/sscs-tya-notif/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/apps/sscs/sscs-tya-notif/prod.yaml
+++ b/apps/sscs/sscs-tya-notif/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/apps/sscs/sscs-tya-notif/sscs-tya-notif.yaml
+++ b/apps/sscs/sscs-tya-notif/sscs-tya-notif.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: sscs-tya-notif

--- a/apps/tax-tribunals/tax-tribunals-application/aat.yaml
+++ b/apps/tax-tribunals/tax-tribunals-application/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: tax-tribunals-application

--- a/apps/tax-tribunals/tax-tribunals-application/demo.yaml
+++ b/apps/tax-tribunals/tax-tribunals-application/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: tax-tribunals-application

--- a/apps/tax-tribunals/tax-tribunals-application/prod.yaml
+++ b/apps/tax-tribunals/tax-tribunals-application/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: tax-tribunals-application

--- a/apps/tax-tribunals/tax-tribunals-application/tax-tribunals-application.yaml
+++ b/apps/tax-tribunals/tax-tribunals-application/tax-tribunals-application.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: tax-tribunals-application

--- a/apps/ts/ts-translation-service-int/demo.yaml
+++ b/apps/ts/ts-translation-service-int/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service-int

--- a/apps/ts/ts-translation-service-int/ts-translation-service-int.yaml
+++ b/apps/ts/ts-translation-service-int/ts-translation-service-int.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service-int

--- a/apps/ts/ts-translation-service/aat.yaml
+++ b/apps/ts/ts-translation-service/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service

--- a/apps/ts/ts-translation-service/demo.yaml
+++ b/apps/ts/ts-translation-service/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service

--- a/apps/ts/ts-translation-service/ithc.yaml
+++ b/apps/ts/ts-translation-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service

--- a/apps/ts/ts-translation-service/perftest.yaml
+++ b/apps/ts/ts-translation-service/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service

--- a/apps/ts/ts-translation-service/prod.yaml
+++ b/apps/ts/ts-translation-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service

--- a/apps/ts/ts-translation-service/ts-translation-service.yaml
+++ b/apps/ts/ts-translation-service/ts-translation-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ts-translation-service

--- a/apps/wa/wa-case-event-handler-clean-up-messages/aat-00.yaml
+++ b/apps/wa/wa-case-event-handler-clean-up-messages/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler-clean-up-messages

--- a/apps/wa/wa-case-event-handler-clean-up-messages/aat-01.yaml
+++ b/apps/wa/wa-case-event-handler-clean-up-messages/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler-clean-up-messages

--- a/apps/wa/wa-case-event-handler-clean-up-messages/prod-00.yaml
+++ b/apps/wa/wa-case-event-handler-clean-up-messages/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler-clean-up-messages

--- a/apps/wa/wa-case-event-handler-clean-up-messages/prod-01.yaml
+++ b/apps/wa/wa-case-event-handler-clean-up-messages/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler-clean-up-messages

--- a/apps/wa/wa-case-event-handler-clean-up-messages/wa-case-event-handler-clean-up-messages.yaml
+++ b/apps/wa/wa-case-event-handler-clean-up-messages/wa-case-event-handler-clean-up-messages.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler-clean-up-messages

--- a/apps/wa/wa-case-event-handler/aat.yaml
+++ b/apps/wa/wa-case-event-handler/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-case-event-handler/demo.yaml
+++ b/apps/wa/wa-case-event-handler/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-case-event-handler/ithc.yaml
+++ b/apps/wa/wa-case-event-handler/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-case-event-handler/perftest.yaml
+++ b/apps/wa/wa-case-event-handler/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-case-event-handler/prod.yaml
+++ b/apps/wa/wa-case-event-handler/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-case-event-handler/wa-case-event-handler.yaml
+++ b/apps/wa/wa-case-event-handler/wa-case-event-handler.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-messages-find-problem-messages/aat-00.yaml
+++ b/apps/wa/wa-messages-find-problem-messages/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-find-problem-messages

--- a/apps/wa/wa-messages-find-problem-messages/aat-01.yaml
+++ b/apps/wa/wa-messages-find-problem-messages/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-find-problem-messages

--- a/apps/wa/wa-messages-find-problem-messages/prod-00.yaml
+++ b/apps/wa/wa-messages-find-problem-messages/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-find-problem-messages

--- a/apps/wa/wa-messages-find-problem-messages/prod-01.yaml
+++ b/apps/wa/wa-messages-find-problem-messages/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-find-problem-messages

--- a/apps/wa/wa-messages-find-problem-messages/wa-messages-find-problem-messages.yaml
+++ b/apps/wa/wa-messages-find-problem-messages/wa-messages-find-problem-messages.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-find-problem-messages

--- a/apps/wa/wa-messages-reset-problem-messages/aat-00.yaml
+++ b/apps/wa/wa-messages-reset-problem-messages/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-problem-messages

--- a/apps/wa/wa-messages-reset-problem-messages/aat-01.yaml
+++ b/apps/wa/wa-messages-reset-problem-messages/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-problem-messages

--- a/apps/wa/wa-messages-reset-problem-messages/prod-00.yaml
+++ b/apps/wa/wa-messages-reset-problem-messages/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-problem-messages

--- a/apps/wa/wa-messages-reset-problem-messages/wa-messages-reset-problem-messages.yaml
+++ b/apps/wa/wa-messages-reset-problem-messages/wa-messages-reset-problem-messages.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-problem-messages

--- a/apps/wa/wa-messages-reset-timestamp-problem-messages/aat/00.yaml
+++ b/apps/wa/wa-messages-reset-timestamp-problem-messages/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-timestamp-problem-messages

--- a/apps/wa/wa-messages-reset-timestamp-problem-messages/aat/01.yaml
+++ b/apps/wa/wa-messages-reset-timestamp-problem-messages/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-timestamp-problem-messages

--- a/apps/wa/wa-messages-reset-timestamp-problem-messages/prod/00.yaml
+++ b/apps/wa/wa-messages-reset-timestamp-problem-messages/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-timestamp-problem-messages

--- a/apps/wa/wa-messages-reset-timestamp-problem-messages/prod/01.yaml
+++ b/apps/wa/wa-messages-reset-timestamp-problem-messages/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-timestamp-problem-messages

--- a/apps/wa/wa-messages-reset-timestamp-problem-messages/wa-messages-reset-timestamp-problem-messages.yaml
+++ b/apps/wa/wa-messages-reset-timestamp-problem-messages/wa-messages-reset-timestamp-problem-messages.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-reset-timestamp-problem-messages

--- a/apps/wa/wa-messages-set-processed-state-messages/aat/00.yaml
+++ b/apps/wa/wa-messages-set-processed-state-messages/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-set-processed-state-messages

--- a/apps/wa/wa-messages-set-processed-state-messages/aat/01.yaml
+++ b/apps/wa/wa-messages-set-processed-state-messages/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-set-processed-state-messages

--- a/apps/wa/wa-messages-set-processed-state-messages/prod/00.yaml
+++ b/apps/wa/wa-messages-set-processed-state-messages/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-set-processed-state-messages

--- a/apps/wa/wa-messages-set-processed-state-messages/prod/01.yaml
+++ b/apps/wa/wa-messages-set-processed-state-messages/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-set-processed-state-messages

--- a/apps/wa/wa-messages-set-processed-state-messages/wa-messages-set-processed-state-messages.yaml
+++ b/apps/wa/wa-messages-set-processed-state-messages/wa-messages-set-processed-state-messages.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-messages-set-processed-state-messages

--- a/apps/wa/wa-task-batch-ad-hoc-create-tasks/aat-00.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-create-tasks/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-create-tasks

--- a/apps/wa/wa-task-batch-ad-hoc-create-tasks/prod-00.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-create-tasks/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-create-tasks

--- a/apps/wa/wa-task-batch-ad-hoc-create-tasks/wa-task-batch-ad-hoc-create-tasks.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-create-tasks/wa-task-batch-ad-hoc-create-tasks.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-create-tasks

--- a/apps/wa/wa-task-batch-ad-hoc-delete-process-instances/prod-00.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-delete-process-instances/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-delete-process-instances

--- a/apps/wa/wa-task-batch-ad-hoc-delete-process-instances/wa-task-batch-ad-hoc-delete-process-instances.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-delete-process-instances/wa-task-batch-ad-hoc-delete-process-instances.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-delete-process-instances

--- a/apps/wa/wa-task-batch-ad-hoc-pending-termination/aat-00.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-pending-termination/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-pending-termination

--- a/apps/wa/wa-task-batch-ad-hoc-pending-termination/aat-01.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-pending-termination/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-pending-termination

--- a/apps/wa/wa-task-batch-ad-hoc-pending-termination/prod-00.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-pending-termination/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-pending-termination

--- a/apps/wa/wa-task-batch-ad-hoc-pending-termination/prod-01.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-pending-termination/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-pending-termination

--- a/apps/wa/wa-task-batch-ad-hoc-pending-termination/wa-task-batch-ad-hoc-pending-termination.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-pending-termination/wa-task-batch-ad-hoc-pending-termination.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-ad-hoc-pending-termination

--- a/apps/wa/wa-task-batch-initiation-failure/aat-00.yaml
+++ b/apps/wa/wa-task-batch-initiation-failure/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation-failure

--- a/apps/wa/wa-task-batch-initiation-failure/aat-01.yaml
+++ b/apps/wa/wa-task-batch-initiation-failure/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation-failure

--- a/apps/wa/wa-task-batch-initiation-failure/prod-00.yaml
+++ b/apps/wa/wa-task-batch-initiation-failure/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation-failure

--- a/apps/wa/wa-task-batch-initiation-failure/prod-01.yaml
+++ b/apps/wa/wa-task-batch-initiation-failure/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation-failure

--- a/apps/wa/wa-task-batch-initiation-failure/wa-task-batch-initiation-failure.yaml
+++ b/apps/wa/wa-task-batch-initiation-failure/wa-task-batch-initiation-failure.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation-failure

--- a/apps/wa/wa-task-batch-initiation/aat-00.yaml
+++ b/apps/wa/wa-task-batch-initiation/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/aat-01.yaml
+++ b/apps/wa/wa-task-batch-initiation/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/demo-00.yaml
+++ b/apps/wa/wa-task-batch-initiation/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/demo-01.yaml
+++ b/apps/wa/wa-task-batch-initiation/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/ithc-00.yaml
+++ b/apps/wa/wa-task-batch-initiation/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/ithc-01.yaml
+++ b/apps/wa/wa-task-batch-initiation/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/perftest-00.yaml
+++ b/apps/wa/wa-task-batch-initiation/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/perftest-01.yaml
+++ b/apps/wa/wa-task-batch-initiation/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/prod-00.yaml
+++ b/apps/wa/wa-task-batch-initiation/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/prod-01.yaml
+++ b/apps/wa/wa-task-batch-initiation/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-initiation/wa-task-batch-initiation.yaml
+++ b/apps/wa/wa-task-batch-initiation/wa-task-batch-initiation.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/aat-00.yaml
+++ b/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-maintenance-camunda-task-clean-up

--- a/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/aat-01.yaml
+++ b/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-maintenance-camunda-task-clean-up

--- a/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/wa-task-batch-maintenance-camunda-task-clean-up.yaml
+++ b/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/wa-task-batch-maintenance-camunda-task-clean-up.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-maintenance-camunda-task-clean-up

--- a/apps/wa/wa-task-batch-reconfiguration-failure/aat/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/aat/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/demo/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/demo/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/ithc/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/ithc/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/perftest/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/perftest/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/prod/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/prod/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration-failure/wa-task-batch-reconfiguration-failure.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/wa-task-batch-reconfiguration-failure.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration/aat/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/aat/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/aat/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/aat/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/demo/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/demo/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/ithc/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/ithc/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/ithc/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/ithc/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/perftest/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/perftest/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/perftest/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/perftest/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/prod/00.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/prod/01.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-reconfiguration/wa-task-batch-reconfiguration.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/wa-task-batch-reconfiguration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-replication-check/aat-00.yaml
+++ b/apps/wa/wa-task-batch-replication-check/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/aat-01.yaml
+++ b/apps/wa/wa-task-batch-replication-check/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/demo-00.yaml
+++ b/apps/wa/wa-task-batch-replication-check/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/ithc-00.yaml
+++ b/apps/wa/wa-task-batch-replication-check/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/perftest-00.yaml
+++ b/apps/wa/wa-task-batch-replication-check/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/prod-00.yaml
+++ b/apps/wa/wa-task-batch-replication-check/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/prod-01.yaml
+++ b/apps/wa/wa-task-batch-replication-check/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-replication-check/wa-task-batch-replication-check.yaml
+++ b/apps/wa/wa-task-batch-replication-check/wa-task-batch-replication-check.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-termination-failure/aat-00.yaml
+++ b/apps/wa/wa-task-batch-termination-failure/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination-failure

--- a/apps/wa/wa-task-batch-termination-failure/aat-01.yaml
+++ b/apps/wa/wa-task-batch-termination-failure/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination-failure

--- a/apps/wa/wa-task-batch-termination-failure/prod-00.yaml
+++ b/apps/wa/wa-task-batch-termination-failure/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination-failure

--- a/apps/wa/wa-task-batch-termination-failure/prod-01.yaml
+++ b/apps/wa/wa-task-batch-termination-failure/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination-failure

--- a/apps/wa/wa-task-batch-termination-failure/wa-task-batch-termination-failure.yaml
+++ b/apps/wa/wa-task-batch-termination-failure/wa-task-batch-termination-failure.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination-failure

--- a/apps/wa/wa-task-batch-termination/aat-00.yaml
+++ b/apps/wa/wa-task-batch-termination/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/aat-01.yaml
+++ b/apps/wa/wa-task-batch-termination/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/demo-00.yaml
+++ b/apps/wa/wa-task-batch-termination/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/demo-01.yaml
+++ b/apps/wa/wa-task-batch-termination/demo-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/ithc-00.yaml
+++ b/apps/wa/wa-task-batch-termination/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/ithc-01.yaml
+++ b/apps/wa/wa-task-batch-termination/ithc-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/perftest-00.yaml
+++ b/apps/wa/wa-task-batch-termination/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/perftest-01.yaml
+++ b/apps/wa/wa-task-batch-termination/perftest-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/prod-00.yaml
+++ b/apps/wa/wa-task-batch-termination/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/prod-01.yaml
+++ b/apps/wa/wa-task-batch-termination/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-termination/wa-task-batch-termination.yaml
+++ b/apps/wa/wa-task-batch-termination/wa-task-batch-termination.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-update-search-index/aat-00.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/aat-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/aat-01.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/aat-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/demo-00.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/demo-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/ithc-00.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/ithc-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/perftest-00.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/perftest-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/prod-00.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/prod-00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/prod-01.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/prod-01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-batch-update-search-index/wa-task-batch-update-search-index.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/wa-task-batch-update-search-index.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-management-api/aat.yaml
+++ b/apps/wa/wa-task-management-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-management-api/demo.yaml
+++ b/apps/wa/wa-task-management-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-management-api/ithc.yaml
+++ b/apps/wa/wa-task-management-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-management-api/perftest.yaml
+++ b/apps/wa/wa-task-management-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-management-api/prod.yaml
+++ b/apps/wa/wa-task-management-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-management-api/wa-task-management-api.yaml
+++ b/apps/wa/wa-task-management-api/wa-task-management-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-monitor/aat.yaml
+++ b/apps/wa/wa-task-monitor/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-task-monitor/demo.yaml
+++ b/apps/wa/wa-task-monitor/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-task-monitor/ithc.yaml
+++ b/apps/wa/wa-task-monitor/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-task-monitor/perftest.yaml
+++ b/apps/wa/wa-task-monitor/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-task-monitor/prod.yaml
+++ b/apps/wa/wa-task-monitor/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-task-monitor/wa-task-monitor.yaml
+++ b/apps/wa/wa-task-monitor/wa-task-monitor.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-workflow-api/aat.yaml
+++ b/apps/wa/wa-workflow-api/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-workflow-api

--- a/apps/wa/wa-workflow-api/demo.yaml
+++ b/apps/wa/wa-workflow-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-workflow-api

--- a/apps/wa/wa-workflow-api/ithc.yaml
+++ b/apps/wa/wa-workflow-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-workflow-api

--- a/apps/wa/wa-workflow-api/perftest.yaml
+++ b/apps/wa/wa-workflow-api/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-workflow-api

--- a/apps/wa/wa-workflow-api/prod.yaml
+++ b/apps/wa/wa-workflow-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-workflow-api

--- a/apps/wa/wa-workflow-api/wa-workflow-api.yaml
+++ b/apps/wa/wa-workflow-api/wa-workflow-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: wa-workflow-api

--- a/apps/xui/xui-activity-tracker-api/demo.yaml
+++ b/apps/xui/xui-activity-tracker-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-activity-tracker-api

--- a/apps/xui/xui-activity-tracker-api/xui-activity-tracker-api.yaml
+++ b/apps/xui/xui-activity-tracker-api/xui-activity-tracker-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-activity-tracker-api

--- a/apps/xui/xui-ao-webapp/aat.yaml
+++ b/apps/xui/xui-ao-webapp/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-ao-webapp/demo.yaml
+++ b/apps/xui/xui-ao-webapp/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-ao-webapp/ithc.yaml
+++ b/apps/xui/xui-ao-webapp/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-ao-webapp/perftest.yaml
+++ b/apps/xui/xui-ao-webapp/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-ao-webapp/prod.yaml
+++ b/apps/xui/xui-ao-webapp/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-ao-webapp/xui-ao-webapp.yaml
+++ b/apps/xui/xui-ao-webapp/xui-ao-webapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-mo-webapp/aat.yaml
+++ b/apps/xui/xui-mo-webapp/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-mo-webapp/demo.yaml
+++ b/apps/xui/xui-mo-webapp/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-mo-webapp/ithc.yaml
+++ b/apps/xui/xui-mo-webapp/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-mo-webapp/perftest.yaml
+++ b/apps/xui/xui-mo-webapp/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-mo-webapp/prod.yaml
+++ b/apps/xui/xui-mo-webapp/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-mo-webapp/xui-mo-webapp.yaml
+++ b/apps/xui/xui-mo-webapp/xui-mo-webapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-webapp-ac-integration/demo.yaml
+++ b/apps/xui/xui-webapp-ac-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-ac-integration

--- a/apps/xui/xui-webapp-ac-integration/xui-webapp-ac-integration.yaml
+++ b/apps/xui/xui-webapp-ac-integration/xui-webapp-ac-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-ac-integration

--- a/apps/xui/xui-webapp-caa-assigned-case-view/demo.yaml
+++ b/apps/xui/xui-webapp-caa-assigned-case-view/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-caa-assigned-case-view

--- a/apps/xui/xui-webapp-caa-assigned-case-view/xui-webapp-caa-assigned-case-view.yaml
+++ b/apps/xui/xui-webapp-caa-assigned-case-view/xui-webapp-caa-assigned-case-view.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-caa-assigned-case-view

--- a/apps/xui/xui-webapp-hearings-integration/demo.yaml
+++ b/apps/xui/xui-webapp-hearings-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-hearings-integration

--- a/apps/xui/xui-webapp-hearings-integration/xui-webapp-hearings-integration.yaml
+++ b/apps/xui/xui-webapp-hearings-integration/xui-webapp-hearings-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-hearings-integration

--- a/apps/xui/xui-webapp-integration/demo.yaml
+++ b/apps/xui/xui-webapp-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-integration

--- a/apps/xui/xui-webapp-integration/xui-webapp-integration.yaml
+++ b/apps/xui/xui-webapp-integration/xui-webapp-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-integration

--- a/apps/xui/xui-webapp-integration1/demo.yaml
+++ b/apps/xui/xui-webapp-integration1/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-integration1

--- a/apps/xui/xui-webapp-integration1/xui-webapp-integration1.yaml
+++ b/apps/xui/xui-webapp-integration1/xui-webapp-integration1.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-integration1

--- a/apps/xui/xui-webapp-integration2/demo.yaml
+++ b/apps/xui/xui-webapp-integration2/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-integration2

--- a/apps/xui/xui-webapp-integration2/xui-webapp-integration2.yaml
+++ b/apps/xui/xui-webapp-integration2/xui-webapp-integration2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-integration2

--- a/apps/xui/xui-webapp-wa-integration/demo.yaml
+++ b/apps/xui/xui-webapp-wa-integration/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-wa-integration

--- a/apps/xui/xui-webapp-wa-integration/xui-webapp-wa-integration.yaml
+++ b/apps/xui/xui-webapp-wa-integration/xui-webapp-wa-integration.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp-wa-integration

--- a/apps/xui/xui-webapp/aat.yaml
+++ b/apps/xui/xui-webapp/aat.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp

--- a/apps/xui/xui-webapp/demo.yaml
+++ b/apps/xui/xui-webapp/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp

--- a/apps/xui/xui-webapp/ithc.yaml
+++ b/apps/xui/xui-webapp/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp

--- a/apps/xui/xui-webapp/perftest.yaml
+++ b/apps/xui/xui-webapp/perftest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp

--- a/apps/xui/xui-webapp/prod.yaml
+++ b/apps/xui/xui-webapp/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp

--- a/apps/xui/xui-webapp/xui-webapp.yaml
+++ b/apps/xui/xui-webapp/xui-webapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: xui-webapp

--- a/bin/v2/add-helm-release.sh
+++ b/bin/v2/add-helm-release.sh
@@ -37,7 +37,7 @@ fi
 (
 cat <<EOF
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ${PRODUCT}-${COMPONENT}

--- a/docs/app-deployment-v2.md
+++ b/docs/app-deployment-v2.md
@@ -68,7 +68,7 @@ All application deployments are managed with `HelmRelease`.
    ```
 - Add a comment next to `image` section in HelmRelease with ImagePolicy name as shown below.
     ```yaml
-    apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    apiVersion: helm.toolkit.fluxcd.io/v2beta2
     kind: HelmRelease
     metadata:
       name: <component-name>
@@ -106,7 +106,7 @@ If you want to add a new app only to a one environment, see [Add application to 
 - If you wish to override this default behaviour in a specific environment, create a environment patch as described in the previous section and override image automation comment like below: 
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: <component-name>


### PR DESCRIPTION
### Change description ###

* Flux upgrade to v2.2.0 has seen apiversion for _helmRelease_ increase from _helm.toolkit.fluxcd.io/v2beta1_ to _helm.toolkit.fluxcd.io/v2beta2_
* New apiversion has been tested through environments using our test application Plum and working as expected.
* v2beta2 API is backwards compatible with v2beta1 - for info on deprecation and new fields see the [release notes](https://github.com/fluxcd/flux2/releases/tag/v2.2.0). All current config will be valid

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
