### PR TITLE
revert ccd/am cleanup for adoption

### DIFF
--- a/apps/adoption/preview/base/kustomization.yaml
+++ b/apps/adoption/preview/base/kustomization.yaml
@@ -3,8 +3,14 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../ccd/identity/identity.yaml
+  - ../../../xui/identity/identity.yaml
+  - ../../../am/identity/identity.yaml
 namespace: adoption
 patches:
+  - path: ../../../ccd/identity/aat.yaml
+  - path: ../../../xui/identity/aat.yaml
+  - path: ../../../am/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo


### PR DESCRIPTION
Same reason as https://github.com/hmcts/cnp-flux-config/pull/28767

### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
