### PR TITLE
upgrade ImageRepository apiVersion to v2beta2 introudced in flux 2.2.0

### DIFF
--- a/apps/aac/aac-ac-int-manage-case-assignment/image-repo.yaml
+++ b/apps/aac/aac-ac-int-manage-case-assignment/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: aac-ac-int-manage-case-assignment

--- a/apps/aac/manage-case-assignment/image-repo.yaml
+++ b/apps/aac/manage-case-assignment/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: manage-case-assignment

--- a/apps/adoption/adoption-cos-api/image-repo.yaml
+++ b/apps/adoption/adoption-cos-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: adoption-cos-api

--- a/apps/adoption/adoption-web/image-repo.yaml
+++ b/apps/adoption/adoption-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: adoption-web

--- a/apps/am/am-judicial-booking-service/image-repo.yaml
+++ b/apps/am/am-judicial-booking-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: am-judicial-booking-service

--- a/apps/am/am-org-role-mapping-service/image-repo.yaml
+++ b/apps/am/am-org-role-mapping-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: am-org-role-mapping-service

--- a/apps/am/am-role-assignment-batch-service/image-repo.yaml
+++ b/apps/am/am-role-assignment-batch-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: am-role-assignment-batch-service

--- a/apps/am/am-role-assignment-refresh-batch/image-repo.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: am-role-assignment-refresh-batch

--- a/apps/am/am-role-assignment-service/image-repo.yaml
+++ b/apps/am/am-role-assignment-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: am-role-assignment-service

--- a/apps/azure-devops/azure-devops-agent/image-repo.yaml
+++ b/apps/azure-devops/azure-devops-agent/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: azure-devops-agent

--- a/apps/backstage/backstage/backend-image-repo.yaml
+++ b/apps/backstage/backstage/backend-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: backstage-backend

--- a/apps/bar/bar-api/image-repo.yaml
+++ b/apps/bar/bar-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bar-api

--- a/apps/bar/bar-web/image-repo.yaml
+++ b/apps/bar/bar-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bar-web

--- a/apps/bsp/bulk-scan-orchestrator/image-repo.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-orchestrator

--- a/apps/bsp/bulk-scan-orchestrator/orchestrator-test-image-repo.yaml
+++ b/apps/bsp/bulk-scan-orchestrator/orchestrator-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-orchestrator-orchestrator-test

--- a/apps/bsp/bulk-scan-payment-processor/image-repo.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-payment-processor

--- a/apps/bsp/bulk-scan-payment-processor/payment-processor-test-image-repo.yaml
+++ b/apps/bsp/bulk-scan-payment-processor/payment-processor-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-payment-processor-payment-processor-test

--- a/apps/bsp/bulk-scan-processor/image-repo.yaml
+++ b/apps/bsp/bulk-scan-processor/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-processor

--- a/apps/bsp/bulk-scan-processor/processor-test-image-repo.yaml
+++ b/apps/bsp/bulk-scan-processor/processor-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-processor-processor-test

--- a/apps/bsp/bulk-scan-sample-app/image-repo.yaml
+++ b/apps/bsp/bulk-scan-sample-app/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-sample-app

--- a/apps/bsp/bulk-scan-sample-app/sample-app-test-image-repo.yaml
+++ b/apps/bsp/bulk-scan-sample-app/sample-app-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bulk-scan-sample-app-sample-app-test

--- a/apps/camunda/camunda-optimize/image-repo.yaml
+++ b/apps/camunda/camunda-optimize/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: camunda-optimize

--- a/apps/camunda/camunda/image-repo.yaml
+++ b/apps/camunda/camunda/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: camunda

--- a/apps/ccd/ccd-ac-int-api-gateway-web/image-repo.yaml
+++ b/apps/ccd/ccd-ac-int-api-gateway-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-ac-int-api-gateway-web

--- a/apps/ccd/ccd-ac-int-data-store-api/image-repo.yaml
+++ b/apps/ccd/ccd-ac-int-data-store-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-ac-int-data-store-api

--- a/apps/ccd/ccd-ac-int-definition-store-api/image-repo.yaml
+++ b/apps/ccd/ccd-ac-int-definition-store-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-ac-int-definition-store-api

--- a/apps/ccd/ccd-admin-web/image-repo.yaml
+++ b/apps/ccd/ccd-admin-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-admin-web

--- a/apps/ccd/ccd-api-gateway-web/image-repo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-api-gateway-web

--- a/apps/ccd/ccd-case-activity-api/image-repo.yaml
+++ b/apps/ccd/ccd-case-activity-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-case-activity-api

--- a/apps/ccd/ccd-case-disposer/image-repo.yaml
+++ b/apps/ccd/ccd-case-disposer/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-case-disposer

--- a/apps/ccd/ccd-case-document-am-api/image-repo.yaml
+++ b/apps/ccd/ccd-case-document-am-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-case-document-am-api

--- a/apps/ccd/ccd-case-print-service/image-repo.yaml
+++ b/apps/ccd/ccd-case-print-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-case-print-service

--- a/apps/ccd/ccd-data-store-api/image-repo.yaml
+++ b/apps/ccd/ccd-data-store-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-data-store-api

--- a/apps/ccd/ccd-definition-store-api/image-repo.yaml
+++ b/apps/ccd/ccd-definition-store-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-definition-store-api

--- a/apps/ccd/ccd-next-hearing-date-updater/image-repo.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-next-hearing-date-updater

--- a/apps/ccd/ccd-test-stubs-service/image-repo.yaml
+++ b/apps/ccd/ccd-test-stubs-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-test-stubs-service

--- a/apps/ccd/ccd-user-profile-api/image-repo.yaml
+++ b/apps/ccd/ccd-user-profile-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-user-profile-api

--- a/apps/ccd/message-publisher/image-repo.yaml
+++ b/apps/ccd/message-publisher/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: message-publisher

--- a/apps/civil/civil-citizen-ui/image-repo.yaml
+++ b/apps/civil/civil-citizen-ui/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-citizen-ui

--- a/apps/civil/civil-general-applications/image-repo.yaml
+++ b/apps/civil/civil-general-applications/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-general-applications

--- a/apps/civil/civil-orchestrator-service/image-repo.yaml
+++ b/apps/civil/civil-orchestrator-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-orchestrator-service

--- a/apps/civil/civil-sdt-commissioning/image-repo.yaml
+++ b/apps/civil/civil-sdt-commissioning/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-sdt-commissioning

--- a/apps/civil/civil-sdt-gateway/image-repo.yaml
+++ b/apps/civil/civil-sdt-gateway/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-sdt-gateway

--- a/apps/civil/civil-sdt/image-repo.yaml
+++ b/apps/civil/civil-sdt/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-sdt

--- a/apps/civil/civil-service/image-repo.yaml
+++ b/apps/civil/civil-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: civil-service

--- a/apps/clamav-mirror/clamav/image-repo.yaml
+++ b/apps/clamav-mirror/clamav/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: clamav-mirror

--- a/apps/cnp/plum-recipe-receiver/image-repo.yaml
+++ b/apps/cnp/plum-recipe-receiver/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: plum-recipe-receiver

--- a/apps/cpo/case-payment-orders-api/image-repo.yaml
+++ b/apps/cpo/case-payment-orders-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: case-payment-orders-api

--- a/apps/cui/cui-ra/image-repo.yaml
+++ b/apps/cui/cui-ra/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cui-ra

--- a/apps/dg/dg-docassembly/image-repo.yaml
+++ b/apps/dg/dg-docassembly/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dg-docassembly

--- a/apps/disposer/disposer-idam-user/image-repo.yaml
+++ b/apps/disposer/disposer-idam-user/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: disposer-idam-user

--- a/apps/divorce/div-cfs/image-repo.yaml
+++ b/apps/divorce/div-cfs/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-cfs

--- a/apps/divorce/div-cms/image-repo.yaml
+++ b/apps/divorce/div-cms/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-cms

--- a/apps/divorce/div-cos/image-repo.yaml
+++ b/apps/divorce/div-cos/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-cos

--- a/apps/divorce/div-da/image-repo.yaml
+++ b/apps/divorce/div-da/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-da

--- a/apps/divorce/div-dgs/image-repo.yaml
+++ b/apps/divorce/div-dgs/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-dgs

--- a/apps/divorce/div-dn/image-repo.yaml
+++ b/apps/divorce/div-dn/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-dn

--- a/apps/divorce/div-emca/image-repo.yaml
+++ b/apps/divorce/div-emca/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-emca

--- a/apps/divorce/div-fps/image-repo.yaml
+++ b/apps/divorce/div-fps/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-fps

--- a/apps/divorce/div-pfe/image-repo.yaml
+++ b/apps/divorce/div-pfe/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-pfe

--- a/apps/divorce/div-rfe/image-repo.yaml
+++ b/apps/divorce/div-rfe/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: div-rfe

--- a/apps/dm-store/dm-store/image-repo.yaml
+++ b/apps/dm-store/dm-store/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dm-store

--- a/apps/dm-store/dm-store/store-test-image-repo.yaml
+++ b/apps/dm-store/dm-store/store-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dm-store-store-test

--- a/apps/docmosis/docmosis/image-repo.yaml
+++ b/apps/docmosis/docmosis/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: docmosis

--- a/apps/dtsse/dtsse-ardoq-adapter/image-repo.yaml
+++ b/apps/dtsse/dtsse-ardoq-adapter/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dtsse-ardoq-adapter

--- a/apps/dtsse/dtsse-dashboard-ingestion/image-repo.yaml
+++ b/apps/dtsse/dtsse-dashboard-ingestion/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dtsse-dashboard-ingestion

--- a/apps/em/em-anno/image-repo.yaml
+++ b/apps/em/em-anno/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-anno

--- a/apps/em/em-ccd-orchestrator/image-repo.yaml
+++ b/apps/em/em-ccd-orchestrator/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-ccd-orchestrator

--- a/apps/em/em-hrs-api/image-repo.yaml
+++ b/apps/em/em-hrs-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-hrs-api

--- a/apps/em/em-hrs-ingestor/image-repo.yaml
+++ b/apps/em/em-hrs-ingestor/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-hrs-ingestor

--- a/apps/em/em-icp/image-repo.yaml
+++ b/apps/em/em-icp/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-icp

--- a/apps/em/em-media-viewer/image-repo.yaml
+++ b/apps/em/em-media-viewer/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-media-viewer

--- a/apps/em/em-npa/image-repo.yaml
+++ b/apps/em/em-npa/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-npa

--- a/apps/em/em-showcase/image-repo.yaml
+++ b/apps/em/em-showcase/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-showcase

--- a/apps/em/em-stitching/image-repo.yaml
+++ b/apps/em/em-stitching/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-stitching

--- a/apps/et-pet/et-pet-admin/image-repo.yaml
+++ b/apps/et-pet/et-pet-admin/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-pet-admin

--- a/apps/et-pet/et-pet-api/image-repo.yaml
+++ b/apps/et-pet/et-pet-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-pet-api

--- a/apps/et-pet/et-pet-ccd-export/image-repo.yaml
+++ b/apps/et-pet/et-pet-ccd-export/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-pet-ccd-export

--- a/apps/et-pet/et-pet-et1/image-repo.yaml
+++ b/apps/et-pet/et-pet-et1/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-pet-et1

--- a/apps/et-pet/et-pet-et3/image-repo.yaml
+++ b/apps/et-pet/et-pet-et3/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-pet-et3

--- a/apps/et/et-ccd-case-migration/image-repo.yaml
+++ b/apps/et/et-ccd-case-migration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-ccd-case-migration

--- a/apps/et/et-cos/image-repo.yaml
+++ b/apps/et/et-cos/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-cos

--- a/apps/et/et-hearings-api/image-repo.yaml
+++ b/apps/et/et-hearings-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-hearings-api

--- a/apps/et/et-msg-handler/image-repo.yaml
+++ b/apps/et/et-msg-handler/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-msg-handler

--- a/apps/et/et-sya-api/image-repo.yaml
+++ b/apps/et/et-sya-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-sya-api

--- a/apps/et/et-sya/image-repo.yaml
+++ b/apps/et/et-sya/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: et-sya

--- a/apps/ethos/ecm-consumer/image-repo.yaml
+++ b/apps/ethos/ecm-consumer/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ecm-consumer

--- a/apps/ethos/repl-docmosis-service/image-repo.yaml
+++ b/apps/ethos/repl-docmosis-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: repl-docmosis-service

--- a/apps/fact/fact-admin/image-repo.yaml
+++ b/apps/fact/fact-admin/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fact-admin

--- a/apps/fact/fact-api/image-repo.yaml
+++ b/apps/fact/fact-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fact-api

--- a/apps/fact/fact-frontend/image-repo.yaml
+++ b/apps/fact/fact-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fact-frontend

--- a/apps/family-public-law/fpl-case-service/image-repo.yaml
+++ b/apps/family-public-law/fpl-case-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fpl-case-service

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/image-repo.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fpl-cron-ccd-data-migration-tool

--- a/apps/fees-pay/bar-csv-report/image-repo.yaml
+++ b/apps/fees-pay/bar-csv-report/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: bar-csv-report

--- a/apps/fees-pay/card-csv-report/image-repo.yaml
+++ b/apps/fees-pay/card-csv-report/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: card-csv-report

--- a/apps/fees-pay/ccpay-bubble-frontend/image-repo.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-bubble-frontend

--- a/apps/fees-pay/ccpay-bulkscanning-api/image-repo.yaml
+++ b/apps/fees-pay/ccpay-bulkscanning-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-bulkscanning-api

--- a/apps/fees-pay/ccpay-callback-function/image-repo.yaml
+++ b/apps/fees-pay/ccpay-callback-function/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-callback-function

--- a/apps/fees-pay/ccpay-cpo-callback-function/image-repo.yaml
+++ b/apps/fees-pay/ccpay-cpo-callback-function/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-cpo-callback-function

--- a/apps/fees-pay/ccpay-cpo-update-service/image-repo.yaml
+++ b/apps/fees-pay/ccpay-cpo-update-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-cpo-update-service

--- a/apps/fees-pay/ccpay-notifications-service/image-repo.yaml
+++ b/apps/fees-pay/ccpay-notifications-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-notifications-service

--- a/apps/fees-pay/ccpay-payment-api/image-repo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-payment-app

--- a/apps/fees-pay/ccpay-paymentoutcome-web/image-repo.yaml
+++ b/apps/fees-pay/ccpay-paymentoutcome-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-paymentoutcome-web

--- a/apps/fees-pay/ccpay-refunds-api/image-repo.yaml
+++ b/apps/fees-pay/ccpay-refunds-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-refunds-api

--- a/apps/fees-pay/dead-letter-queue-process/image-repo.yaml
+++ b/apps/fees-pay/dead-letter-queue-process/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dead-letter-queue-process

--- a/apps/fees-pay/duplicate-payment-process/image-repo.yaml
+++ b/apps/fees-pay/duplicate-payment-process/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: duplicate-payment-process

--- a/apps/fees-pay/fees-register-api/image-repo.yaml
+++ b/apps/fees-pay/fees-register-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fees-register-api

--- a/apps/fees-pay/fees-register-frontend/image-repo.yaml
+++ b/apps/fees-pay/fees-register-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fees-register-frontend

--- a/apps/fees-pay/pba-csv-report/image-repo.yaml
+++ b/apps/fees-pay/pba-csv-report/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pba-csv-report

--- a/apps/fees-pay/pba-finrem-weekly-csv-report/image-repo.yaml
+++ b/apps/fees-pay/pba-finrem-weekly-csv-report/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pba-finrem-weekly-csv-report

--- a/apps/fees-pay/refund-notifications-job/image-repo.yaml
+++ b/apps/fees-pay/refund-notifications-job/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: refund-notifications-job

--- a/apps/fees-pay/status-update/image-repo.yaml
+++ b/apps/fees-pay/status-update/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: status-update

--- a/apps/fees-pay/unprocessed-payment-update-int/image-repo.yaml
+++ b/apps/fees-pay/unprocessed-payment-update-int/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: unprocessed-payment-update

--- a/apps/fees-pay/unprocessed-payment-update/image-repo.yaml
+++ b/apps/fees-pay/unprocessed-payment-update/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: unprocessed-payment-update

--- a/apps/financial-remedy/finrem-cos/image-repo.yaml
+++ b/apps/financial-remedy/finrem-cos/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: finrem-cos

--- a/apps/fis/fis-bulk-scan-api/image-repo.yaml
+++ b/apps/fis/fis-bulk-scan-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fis-bulk-scan-api

--- a/apps/fis/fis-cos-api/image-repo.yaml
+++ b/apps/fis/fis-cos-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fis-cos-api

--- a/apps/fis/fis-ds-update-web/image-repo.yaml
+++ b/apps/fis/fis-ds-update-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fis-ds-update-web

--- a/apps/fis/fis-ds-web/image-repo.yaml
+++ b/apps/fis/fis-ds-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fis-ds-web

--- a/apps/fis/fis-hmc-api/image-repo.yaml
+++ b/apps/fis/fis-hmc-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fis-hmc-api

--- a/apps/flux-system/automation/hmctsprivate-image-repo.yaml
+++ b/apps/flux-system/automation/hmctsprivate-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/flux-system/automation/hmctspublic-image-repo.yaml
+++ b/apps/flux-system/automation/hmctspublic-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/flux-system/automation/hmctssandbox-image-repo.yaml
+++ b/apps/flux-system/automation/hmctssandbox-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/help-with-fees/help-with-fees-benefit-checker-api/image-repo.yaml
+++ b/apps/help-with-fees/help-with-fees-benefit-checker-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: help-with-fees-benefit-checker-api

--- a/apps/help-with-fees/help-with-fees-publicapp/image-repo.yaml
+++ b/apps/help-with-fees/help-with-fees-publicapp/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: help-with-fees-publicapp

--- a/apps/help-with-fees/help-with-fees-staffapp/image-repo.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: help-with-fees-staffapp

--- a/apps/hmc/hmc-cft-hearing-service/image-repo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: hmc-cft-hearing-service

--- a/apps/hmc/hmc-hmi-inbound-adapter/image-repo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/image-repo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-operational-reports-runner/image-repo.yaml
+++ b/apps/hmc/hmc-operational-reports-runner/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: hmc-operational-reports-runner

--- a/apps/ia/ia-aip-frontend/image-repo.yaml
+++ b/apps/ia/ia-aip-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-aip-frontend

--- a/apps/ia/ia-bail-case-api/image-repo.yaml
+++ b/apps/ia/ia-bail-case-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-bail-case-api

--- a/apps/ia/ia-case-access-api/image-repo.yaml
+++ b/apps/ia/ia-case-access-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-case-access-api

--- a/apps/ia/ia-case-api/image-repo.yaml
+++ b/apps/ia/ia-case-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-case-api

--- a/apps/ia/ia-case-documents-api/image-repo.yaml
+++ b/apps/ia/ia-case-documents-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-case-documents-api

--- a/apps/ia/ia-case-notifications-api/image-repo.yaml
+++ b/apps/ia/ia-case-notifications-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-case-notifications-api

--- a/apps/ia/ia-case-payments-api/image-repo.yaml
+++ b/apps/ia/ia-case-payments-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-case-payments-api

--- a/apps/ia/ia-cron-ccd-migration-tool/image-repo.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-unnotified-hearings-processor/image-repo.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-cron-unnotified-hearings-processor

--- a/apps/ia/ia-hearings-api/image-repo.yaml
+++ b/apps/ia/ia-hearings-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-hearings-api

--- a/apps/ia/ia-home-office-integration-api/image-repo.yaml
+++ b/apps/ia/ia-home-office-integration-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-home-office-integration-api

--- a/apps/ia/ia-home-office-mock-api/image-repo.yaml
+++ b/apps/ia/ia-home-office-mock-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-home-office-mock-api

--- a/apps/ia/ia-timed-event-service/image-repo.yaml
+++ b/apps/ia/ia-timed-event-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ia-timed-event-service

--- a/apps/idam/idam-api/image-repo.yaml
+++ b/apps/idam/idam-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-api

--- a/apps/idam/idam-hmcts-access/image-repo.yaml
+++ b/apps/idam/idam-hmcts-access/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-hmcts-access

--- a/apps/idam/idam-testing-support-api/image-repo.yaml
+++ b/apps/idam/idam-testing-support-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-testing-support-api

--- a/apps/idam/idam-user-dashboard/image-repo.yaml
+++ b/apps/idam/idam-user-dashboard/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-user-dashboard

--- a/apps/idam/idam-user-profile-bridge/image-repo.yaml
+++ b/apps/idam/idam-user-profile-bridge/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-user-profile-bridge

--- a/apps/idam/idam-web-admin/image-repo.yaml
+++ b/apps/idam/idam-web-admin/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-web-admin

--- a/apps/idam/idam-web-public/image-repo.yaml
+++ b/apps/idam/idam-web-public/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-web-public

--- a/apps/jenkins/jenkins-webhook-relay/image-repo.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jps/jps-judicial-payment-frontend/image-repo.yaml
+++ b/apps/jps/jps-judicial-payment-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: jps-judicial-payment-frontend

--- a/apps/jps/jps-judicial-payment-service/image-repo.yaml
+++ b/apps/jps/jps-judicial-payment-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: jps-judicial-payment-service

--- a/apps/labs/labs-darrenbayliss-dev/image-repo.yaml
+++ b/apps/labs/labs-darrenbayliss-dev/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: labs-darrenbayliss-dev

--- a/apps/labs/labs-darrenbayliss-dev2/image-repo.yaml
+++ b/apps/labs/labs-darrenbayliss-dev2/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: labs-darrenbayliss-dev2

--- a/apps/labs/labs-hub-ngfw-poc/image-repo.yaml
+++ b/apps/labs/labs-hub-ngfw-poc/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: labs-hub-ngfw-poc

--- a/apps/labs/labs-rhodrif/image-repo.yaml
+++ b/apps/labs/labs-rhodrif/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: labs-rhodrif

--- a/apps/lau/lau-case-backend/image-repo.yaml
+++ b/apps/lau/lau-case-backend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: lau-case-backend

--- a/apps/lau/lau-frontend/image-repo.yaml
+++ b/apps/lau/lau-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: lau-frontend

--- a/apps/lau/lau-idam-backend/image-repo.yaml
+++ b/apps/lau/lau-idam-backend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: lau-idam-backend

--- a/apps/money-claims/cmc-ccd/image-repo.yaml
+++ b/apps/money-claims/cmc-ccd/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cmc-ccd

--- a/apps/money-claims/cmc-citizen-frontend/image-repo.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cmc-citizen-frontend

--- a/apps/money-claims/cmc-claim-store/image-repo.yaml
+++ b/apps/money-claims/cmc-claim-store/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cmc-claim-store

--- a/apps/money-claims/cmc-draft-store/image-repo.yaml
+++ b/apps/money-claims/cmc-draft-store/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cmc-draft-store

--- a/apps/money-claims/cmc-s2s/image-repo.yaml
+++ b/apps/money-claims/cmc-s2s/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cmc-s2s

--- a/apps/monitoring/helm-base-versions/image-repo.yaml
+++ b/apps/monitoring/helm-base-versions/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: helm-base-versions

--- a/apps/nfdiv/nfdiv-case-api/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-case-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-case-api

--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-alert-application-not-reviewed

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-applicant-can-sts-after-intention-fo

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-bulk-list-create

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-eligible-for-switch-to-sole

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-js-disputed-answer-overdue

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-migrate-bulk-cases

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-migrate-cases

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-partner-not-applied-for-final-order

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-remind-awaiting-joint-final-order

--- a/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-cron-resend-co-pronounced-cover-letters/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-cron-resend-co-pronounced-cover-letters

--- a/apps/nfdiv/nfdiv-frontend/image-repo.yaml
+++ b/apps/nfdiv/nfdiv-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: nfdiv-frontend

--- a/apps/pcq/pcq-backend/image-repo.yaml
+++ b/apps/pcq/pcq-backend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pcq-backend

--- a/apps/pcq/pcq-consolidation-service/image-repo.yaml
+++ b/apps/pcq/pcq-consolidation-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pcq-consolidation-service

--- a/apps/pcq/pcq-frontend/image-repo.yaml
+++ b/apps/pcq/pcq-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pcq-frontend

--- a/apps/pcq/pcq-loader/image-repo.yaml
+++ b/apps/pcq/pcq-loader/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pcq-loader

--- a/apps/private-law/prl-ccd-case-migration/image-repo.yaml
+++ b/apps/private-law/prl-ccd-case-migration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: prl-ccd-case-migration

--- a/apps/private-law/prl-citizen-frontend/image-repo.yaml
+++ b/apps/private-law/prl-citizen-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: prl-citizen-frontend

--- a/apps/private-law/prl-cos/image-repo.yaml
+++ b/apps/private-law/prl-cos/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: prl-cos

--- a/apps/private-law/prl-dgs/image-repo.yaml
+++ b/apps/private-law/prl-dgs/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: prl-dgs

--- a/apps/probate/probate-back-office/image-repo.yaml
+++ b/apps/probate/probate-back-office/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-back-office

--- a/apps/probate/probate-business-service/image-repo.yaml
+++ b/apps/probate/probate-business-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-business-service

--- a/apps/probate/probate-caveats-fe/image-repo.yaml
+++ b/apps/probate/probate-caveats-fe/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-caveats-fe

--- a/apps/probate/probate-cron-ccd-data-migration-tool/image-repo.yaml
+++ b/apps/probate/probate-cron-ccd-data-migration-tool/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-cron-ccd-data-migration-tool

--- a/apps/probate/probate-cron-hmrc-extract/image-repo.yaml
+++ b/apps/probate/probate-cron-hmrc-extract/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-cron-hmrc-extract

--- a/apps/probate/probate-cron-make-dormant-cases/image-repo.yaml
+++ b/apps/probate/probate-cron-make-dormant-cases/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-cron-make-dormant-cases

--- a/apps/probate/probate-cron-reactivate-dormant-cases/image-repo.yaml
+++ b/apps/probate/probate-cron-reactivate-dormant-cases/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-cron-reactivate-dormant-cases

--- a/apps/probate/probate-frontend/image-repo.yaml
+++ b/apps/probate/probate-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-frontend

--- a/apps/probate/probate-orchestrator-service/image-repo.yaml
+++ b/apps/probate/probate-orchestrator-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-orchestrator-service

--- a/apps/probate/probate-submit-service/image-repo.yaml
+++ b/apps/probate/probate-submit-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: probate-submit-service

--- a/apps/rd/rd-caseworker-ref-api-integration/image-repo.yaml
+++ b/apps/rd/rd-caseworker-ref-api-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-caseworker-ref-api-integration

--- a/apps/rd/rd-caseworker-ref-api/image-repo.yaml
+++ b/apps/rd/rd-caseworker-ref-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-caseworker-ref-api

--- a/apps/rd/rd-commondata-api/image-repo.yaml
+++ b/apps/rd/rd-commondata-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-commondata-api

--- a/apps/rd/rd-commondata-dataload/image-repo.yaml
+++ b/apps/rd/rd-commondata-dataload/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-commondata-dataload

--- a/apps/rd/rd-judicial-api-integration/image-repo.yaml
+++ b/apps/rd/rd-judicial-api-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-judicial-api-integration

--- a/apps/rd/rd-judicial-api/image-repo.yaml
+++ b/apps/rd/rd-judicial-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-judicial-api

--- a/apps/rd/rd-judicial-data-load-integration/image-repo.yaml
+++ b/apps/rd/rd-judicial-data-load-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-judicial-data-load-integration

--- a/apps/rd/rd-judicial-data-load/image-repo.yaml
+++ b/apps/rd/rd-judicial-data-load/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-judicial-data-load

--- a/apps/rd/rd-location-ref-api-integration/image-repo.yaml
+++ b/apps/rd/rd-location-ref-api-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-location-ref-api-integration

--- a/apps/rd/rd-location-ref-api/image-repo.yaml
+++ b/apps/rd/rd-location-ref-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-location-ref-api

--- a/apps/rd/rd-location-ref-data-load-integration/image-repo.yaml
+++ b/apps/rd/rd-location-ref-data-load-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-location-ref-data-load-integration

--- a/apps/rd/rd-location-ref-data-load/image-repo.yaml
+++ b/apps/rd/rd-location-ref-data-load/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-location-ref-data-load

--- a/apps/rd/rd-professional-api-integration/image-repo.yaml
+++ b/apps/rd/rd-professional-api-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-professional-api-integration

--- a/apps/rd/rd-professional-api/image-repo.yaml
+++ b/apps/rd/rd-professional-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-professional-api

--- a/apps/rd/rd-profile-sync-integration/image-repo.yaml
+++ b/apps/rd/rd-profile-sync-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-profile-sync-integration

--- a/apps/rd/rd-profile-sync/image-repo.yaml
+++ b/apps/rd/rd-profile-sync/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-profile-sync

--- a/apps/rd/rd-user-profile-api-integration/image-repo.yaml
+++ b/apps/rd/rd-user-profile-api-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-user-profile-api-integration

--- a/apps/rd/rd-user-profile-api/image-repo.yaml
+++ b/apps/rd/rd-user-profile-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-user-profile-api

--- a/apps/reform-scan/reform-scan-blob-router/blob-router-test-image-repo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/blob-router-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: reform-scan-blob-router-blob-router-test

--- a/apps/reform-scan/reform-scan-blob-router/image-repo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: reform-scan-blob-router

--- a/apps/reform-scan/reform-scan-notification-service/image-repo.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: reform-scan-notification-service

--- a/apps/reform-scan/reform-scan-notification-service/notification-service-test-image-repo.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/notification-service-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: reform-scan-notification-service-notification-service-test

--- a/apps/response/api/image-repo.yaml
+++ b/apps/response/api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: response-api

--- a/apps/response/frontend/image-repo.yaml
+++ b/apps/response/frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: response-frontend

--- a/apps/rpe/draft-store-service/image-repo.yaml
+++ b/apps/rpe/draft-store-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: draft-store-service

--- a/apps/rpe/draft-store-service/service-test-image-repo.yaml
+++ b/apps/rpe/draft-store-service/service-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: draft-store-service-service-test

--- a/apps/rpe/pdf-service/image-repo.yaml
+++ b/apps/rpe/pdf-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pdf-service

--- a/apps/rpe/pdf-service/pdf-service-test-image-repo.yaml
+++ b/apps/rpe/pdf-service/pdf-service-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pdf-service-pdf-service-test

--- a/apps/rpe/rpe-send-letter-service-container-new/image-repo.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-new/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpe-send-letter-service-container-new

--- a/apps/rpe/rpe-send-letter-service-container-proc/image-repo.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-proc/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpe-send-letter-service-container-proc

--- a/apps/rpe/rpe-send-letter-service-container-zip/image-repo.yaml
+++ b/apps/rpe/rpe-send-letter-service-container-zip/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpe-send-letter-service-container-zip

--- a/apps/rpe/rpe-send-letter-service/image-repo.yaml
+++ b/apps/rpe/rpe-send-letter-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpe-send-letter-service

--- a/apps/rpe/rpe-service-auth-provider/image-repo.yaml
+++ b/apps/rpe/rpe-service-auth-provider/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpe-service-auth-provider

--- a/apps/rpts/rpts-api/image-repo.yaml
+++ b/apps/rpts/rpts-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpts-api

--- a/apps/rpts/rpts-frontend/image-repo.yaml
+++ b/apps/rpts/rpts-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpts-frontend

--- a/apps/slack-help-bot/ccd-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/ccd-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccd-slack-help-bot

--- a/apps/slack-help-bot/ccpay-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/ccpay-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ccpay-slack-help-bot

--- a/apps/slack-help-bot/cs-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/cs-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: cs-slack-help-bot

--- a/apps/slack-help-bot/em-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/em-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: em-slack-help-bot

--- a/apps/slack-help-bot/fact-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/fact-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: fact-slack-help-bot

--- a/apps/slack-help-bot/idam-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/idam-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: idam-slack-help-bot

--- a/apps/slack-help-bot/rd-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/rd-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rd-slack-help-bot

--- a/apps/slack-help-bot/slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: slack-help-bot

--- a/apps/slack-help-bot/wa-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/wa-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-slack-help-bot

--- a/apps/slack-help-bot/xui-slack-help-bot/image-repo.yaml
+++ b/apps/slack-help-bot/xui-slack-help-bot/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-slack-help-bot

--- a/apps/sptribs/sptribs-case-api/image-repo.yaml
+++ b/apps/sptribs/sptribs-case-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sptribs-case-api

--- a/apps/sptribs/sptribs-cron-migrate-case-flags/image-repo.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sptribs-cron-migrate-case-flags

--- a/apps/sptribs/sptribs-cron-migrate-case-links/image-repo.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sptribs-cron-migrate-case-links

--- a/apps/sptribs/sptribs-frontend/image-repo.yaml
+++ b/apps/sptribs/sptribs-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sptribs-frontend

--- a/apps/sscs/sscs-bulk-scan/image-repo.yaml
+++ b/apps/sscs/sscs-bulk-scan/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-bulk-scan

--- a/apps/sscs/sscs-case-loader/image-repo.yaml
+++ b/apps/sscs/sscs-case-loader/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-case-loader

--- a/apps/sscs/sscs-case-migration/image-repo.yaml
+++ b/apps/sscs/sscs-case-migration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-case-migration

--- a/apps/sscs/sscs-ccd-callback-orchestrator/image-repo.yaml
+++ b/apps/sscs/sscs-ccd-callback-orchestrator/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-ccd-callback-orchestrator

--- a/apps/sscs/sscs-cor-frontend/image-repo.yaml
+++ b/apps/sscs/sscs-cor-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-cor-frontend

--- a/apps/sscs/sscs-evidence-share/image-repo.yaml
+++ b/apps/sscs/sscs-evidence-share/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-evidence-share

--- a/apps/sscs/sscs-hearings-api/image-repo.yaml
+++ b/apps/sscs/sscs-hearings-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-hearings-api

--- a/apps/sscs/sscs-hmc-stub/image-repo.yaml
+++ b/apps/sscs/sscs-hmc-stub/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-hmc-stub

--- a/apps/sscs/sscs-tribunals-api/image-repo.yaml
+++ b/apps/sscs/sscs-tribunals-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-frontend/image-repo.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-tribunals-frontend

--- a/apps/sscs/sscs-tya-notif/image-repo.yaml
+++ b/apps/sscs/sscs-tya-notif/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: sscs-tya-notif

--- a/apps/tax-tribunals/tax-tribunals-application/image-repo.yaml
+++ b/apps/tax-tribunals/tax-tribunals-application/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: tax-tribunals-application

--- a/apps/ts/ts-translation-service/image-repo.yaml
+++ b/apps/ts/ts-translation-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ts-translation-service

--- a/apps/wa/wa-case-event-handler-clean-up-messages/image-repo.yaml
+++ b/apps/wa/wa-case-event-handler-clean-up-messages/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-case-event-handler-clean-up-messages

--- a/apps/wa/wa-case-event-handler/image-repo.yaml
+++ b/apps/wa/wa-case-event-handler/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-case-event-handler

--- a/apps/wa/wa-messages-find-problem-messages/image-repo.yaml
+++ b/apps/wa/wa-messages-find-problem-messages/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-messages-find-problem-messages

--- a/apps/wa/wa-messages-reset-problem-messages/image-repo.yaml
+++ b/apps/wa/wa-messages-reset-problem-messages/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-messages-reset-problem-messages

--- a/apps/wa/wa-messages-reset-timestamp-problem-messages/image-repo.yaml
+++ b/apps/wa/wa-messages-reset-timestamp-problem-messages/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-messages-reset-timestamp-problem-messages

--- a/apps/wa/wa-messages-set-processed-state-messages/image-repo.yaml
+++ b/apps/wa/wa-messages-set-processed-state-messages/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-messages-set-processed-state-messages

--- a/apps/wa/wa-task-batch-ad-hoc-create-tasks/image-repo.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-create-tasks/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-ad-hoc-create-tasks

--- a/apps/wa/wa-task-batch-ad-hoc-delete-process-instances/image-repo.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-delete-process-instances/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-ad-hoc-delete-process-instances

--- a/apps/wa/wa-task-batch-ad-hoc-pending-termination/image-repo.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-pending-termination/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-ad-hoc-pending-termination

--- a/apps/wa/wa-task-batch-ad-hoc-update-case-data/image-repo.yaml
+++ b/apps/wa/wa-task-batch-ad-hoc-update-case-data/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-ad-hoc-update-case-data

--- a/apps/wa/wa-task-batch-initiation-failure/image-repo.yaml
+++ b/apps/wa/wa-task-batch-initiation-failure/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-initiation-failure

--- a/apps/wa/wa-task-batch-initiation/image-repo.yaml
+++ b/apps/wa/wa-task-batch-initiation/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-initiation

--- a/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/image-repo.yaml
+++ b/apps/wa/wa-task-batch-maintenance-camunda-task-clean-up/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-maintenance-camunda-task-clean-up

--- a/apps/wa/wa-task-batch-reconfiguration-failure/image-repo.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration-failure/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-reconfiguration-failure

--- a/apps/wa/wa-task-batch-reconfiguration/image-repo.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-reconfiguration

--- a/apps/wa/wa-task-batch-replication-check/image-repo.yaml
+++ b/apps/wa/wa-task-batch-replication-check/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-replication-check

--- a/apps/wa/wa-task-batch-termination-failure/image-repo.yaml
+++ b/apps/wa/wa-task-batch-termination-failure/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-termination-failure

--- a/apps/wa/wa-task-batch-termination/image-repo.yaml
+++ b/apps/wa/wa-task-batch-termination/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-termination

--- a/apps/wa/wa-task-batch-update-search-index/image-repo.yaml
+++ b/apps/wa/wa-task-batch-update-search-index/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-batch-update-search-index

--- a/apps/wa/wa-task-management-api/image-repo.yaml
+++ b/apps/wa/wa-task-management-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-management-api

--- a/apps/wa/wa-task-monitor/image-repo.yaml
+++ b/apps/wa/wa-task-monitor/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-task-monitor

--- a/apps/wa/wa-workflow-api/image-repo.yaml
+++ b/apps/wa/wa-workflow-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: wa-workflow-api

--- a/apps/xui/xui-activity-tracker-api/image-repo.yaml
+++ b/apps/xui/xui-activity-tracker-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-activity-tracker-api

--- a/apps/xui/xui-ao-webapp/image-repo.yaml
+++ b/apps/xui/xui-ao-webapp/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-ao-webapp

--- a/apps/xui/xui-mo-webapp/image-repo.yaml
+++ b/apps/xui/xui-mo-webapp/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-mo-webapp

--- a/apps/xui/xui-webapp-ac-integration/image-repo.yaml
+++ b/apps/xui/xui-webapp-ac-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-ac-integration

--- a/apps/xui/xui-webapp-caa-assigned-case-view/image-repo.yaml
+++ b/apps/xui/xui-webapp-caa-assigned-case-view/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-caa-assigned-case-view

--- a/apps/xui/xui-webapp-hearings-integration/image-repo.yaml
+++ b/apps/xui/xui-webapp-hearings-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-hearings-integration

--- a/apps/xui/xui-webapp-integration/image-repo.yaml
+++ b/apps/xui/xui-webapp-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-integration

--- a/apps/xui/xui-webapp-integration1/image-repo.yaml
+++ b/apps/xui/xui-webapp-integration1/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-integration1

--- a/apps/xui/xui-webapp-integration2/image-repo.yaml
+++ b/apps/xui/xui-webapp-integration2/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-integration2

--- a/apps/xui/xui-webapp-wa-integration/image-repo.yaml
+++ b/apps/xui/xui-webapp-wa-integration/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp-wa-integration

--- a/apps/xui/xui-webapp/image-repo.yaml
+++ b/apps/xui/xui-webapp/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: xui-webapp

--- a/bin/v2/add-image-policies.sh
+++ b/bin/v2/add-image-policies.sh
@@ -43,7 +43,7 @@ if [[ ${ACR} == "hmctspublic" ]]
 then
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ${PRODUCT}-${COMPONENT}
@@ -55,7 +55,7 @@ elif [[ ${ACR} == "hmctssandbox" ]]
 then
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ${PRODUCT}-${COMPONENT}
@@ -69,7 +69,7 @@ elif [[ ${ACR} == "hmctsprivate" ]]
 then
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ${PRODUCT}-${COMPONENT}


### PR DESCRIPTION
### Change description ###

* Flux upgrade to v2.2.0 has seen apiversion for _imageRepository_ increase from _image.toolkit.fluxcd.io/v2beta1_ to _image.toolkit.fluxcd.io/v2beta2_
* New apiversion has been tested through environments using our test application Plum and working as expected.
* v2beta2 API is backwards compatible with v2beta1. All current config will be valid

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
