### PR TITLE
DTSPO-15526 - Re-enable dynatrace monitoring of neuvector ns on prod

### DIFF
--- a/apps/dynatrace/prod/base/dynakube.yaml
+++ b/apps/dynatrace/prod/base/dynakube.yaml
@@ -9,9 +9,3 @@ spec:
     cloudNativeFullStack:
       args:
         - --set-host-group=PROD_CFT
-  namespaceSelector:
-    matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: NotIn
-        values:
-          - neuvector


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15526

### Change description ###
Removing namespace selector annotation so dynatrace monitors the neuvector namespace again. Andrew Thomson from Dynatrace confirmed they weren't seeing any spike in logs since it was [re-enabled on AAT](https://github.com/hmcts/cnp-flux-config/pull/28517).

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
