### PR TITLE
run caseloader cron job every 30mins to speed up interpreter data migration release

### DIFF
--- a/apps/sscs/sscs-case-loader/prod-00.yaml
+++ b/apps/sscs/sscs-case-loader/prod-00.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 21-23,0-7 * * *"
+      schedule: "0/30 21-23,0-7 * * *"
       startingDeadlineSeconds: 1800
       concurrencyPolicy: Forbid
       memoryRequests: "768Mi"


### PR DESCRIPTION
### Jira link (if applicable)
- https://tools.hmcts.net/jira/browse/SSCSCI-488

### Change description ###
- run caseloader cron job every 30mins to speed up interpreter data migration release
