### PR TITLE
Revert "CHG5014943: CFT IDAM 9.5.0"

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-460738d-20240129112804
+      image: hmctspublic.azurecr.io/idam/api:prod-6625886-20231207104800
       replicas: 4
       ingressHost: idam-api.platform.hmcts.net
       aadIdentityName: idam
@@ -54,8 +54,8 @@ spec:
         IDAM_QUERIES_CHANGED-USERS-WITH-ROLES_QUERY-ID: query-lastChanged-with-roles-user-value
         IDAM_QUERIES_CHANGED-USERS-WITH-SINGLE-ROLE_ENABLED: false
         IDAM_QUERIES_TIMEFILTERTEMPLATE: createTimestamp gt "%s"
-        IDAM_REGISTRATION_APPOINTDOMAINREGEX_0: idam\.appointment\.domains.\disabled
         SPRING_REDIS_TIMEOUT: 300
+        trigger_deploy: INC5539698
   chart:
     spec:
       chart: idam-api

--- a/apps/idam/idam-web-public/idam-web-public.yaml
+++ b/apps/idam/idam-web-public/idam-web-public.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-web-public
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-f959983-20240130111640
+      image: hmctspublic.azurecr.io/idam/web-public:prod-34be9e1-20231211094927
       ingressHost: hmcts-access.service.gov.uk
       aadIdentityName: idam
       useInterpodAntiAffinity: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#28984

We are seeing unusual HTTP 400s on calls to `/o/authorize` which we do not currently understand.
To be on the safe side, we are reverting back the release.