### PR TITLE
DTSPO-16658 Updating ptl traefik v26.0.0

### DIFF
--- a/apps/admin/traefik2/ptl-intsvc/00.yaml
+++ b/apps/admin/traefik2/ptl-intsvc/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 26.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/ptl-intsvc/base/kustomization.yaml
+++ b/clusters/ptl-intsvc/base/kustomization.yaml
@@ -19,8 +19,9 @@ resources:
 - ../../../apps/clamav-mirror/base/kustomize.yaml
 
 patches:
-- path: ../../../apps/base/kustomize.yaml
-  target:
-    kind: Kustomization
-    annotationSelector: hmcts.github.com/kustomize-defaults != disabled
-- path: ../../../apps/admin/ptl-intsvc/base/kustomize.yaml
+ - path: ../../../apps/base/kustomize.yaml
+    target:
+     kind: Kustomization
+     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+ - path: ../../../apps/admin/ptl-intsvc/base/kustomize.yaml
+ - path: ../../../apps/admin/traefik-crds-upgrade-v26/kustomize.yaml

--- a/clusters/ptl-intsvc/base/kustomization.yaml
+++ b/clusters/ptl-intsvc/base/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 
 patches:
 - path: ../../../apps/base/kustomize.yaml
-target:
+  target:
     kind: Kustomization
     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
 - path: ../../../apps/admin/ptl-intsvc/base/kustomize.yaml

--- a/clusters/ptl-intsvc/base/kustomization.yaml
+++ b/clusters/ptl-intsvc/base/kustomization.yaml
@@ -19,9 +19,9 @@ resources:
 - ../../../apps/clamav-mirror/base/kustomize.yaml
 
 patches:
- - path: ../../../apps/base/kustomize.yaml
-    target:
-     kind: Kustomization
-     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
- - path: ../../../apps/admin/ptl-intsvc/base/kustomize.yaml
- - path: ../../../apps/admin/traefik-crds-upgrade-v26/kustomize.yaml
+- path: ../../../apps/base/kustomize.yaml
+target:
+    kind: Kustomization
+    annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+- path: ../../../apps/admin/ptl-intsvc/base/kustomize.yaml
+- path: ../../../apps/admin/traefik-crds-upgrade-v26/kustomize.yaml


### PR DESCRIPTION
Jira link (if applicable)
[DTSPO-16658](https://tools.hmcts.net/jira/browse/DTSPO-16658)

Change description
Upgraded traefik to v26, followed what has been done on the non-prod environment https://github.com/hmcts/sds-flux-config/pull/4156
