### PR TITLE
traefik timeout to 90s to test case-document-am-api

### DIFF
--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -13,3 +13,8 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
+    additionalArguments:
+      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
+      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
+      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
+      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -13,3 +13,8 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
+    additionalArguments:
+      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
+      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
+      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
+      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"


### PR DESCRIPTION
### Change description ###
traefik timeout to 90s to test case-document-am-api
- will be reverted, only a brief high-level test. 
