### PR TITLE
DTSPO-16579 - adding toleration

### DIFF
--- a/apps/azureserviceoperator-system/aso/kustomization.yaml
+++ b/apps/azureserviceoperator-system/aso/kustomization.yaml
@@ -16,3 +16,6 @@ patches:
           kubernetes.azure.com/agentpool: system
     target:
       kind: Deployment
+  - target:
+      kind: Deployment
+    path: toleration_replicas_patch.yaml

--- a/apps/azureserviceoperator-system/aso/toleration_replicas_patch.yaml
+++ b/apps/azureserviceoperator-system/aso/toleration_replicas_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: azureserviceoperator-controller-manager
+spec:
+  replicas: 2
+  template:
+    spec:
+      tolerations:
+        - effect: NoSchedule
+          key: CriticalAddonsOnly
+          operator: Equal
+          value: "true"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16579

### Change description ###

After spending number of hours on trying to fix this, some suggestion from Microsoft and Azure Service Operator team is that Helm and ASO are fighting with each other to deploy, update and eventually delete ASO resources, this resulting in slow responses from APIServer,  ASO will reconcile slowly. 

below is suggestion from MS support

```
I’ve also noticed that the ASO deployment pod isn’t running on the system nodepool, therefore it may land on a worker node that may become overcommitted due to the other workloads.
My suggestion would be to include an affinity block on the ASO deployment yaml so that it only lands on your system nodepool nodes.
Here goes a sample affinity block to use just after the containers block within the ASO deployment block:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
          - matchExpressions:
              - key: agentpool
                operator: In
                values:
                - system
```

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

