### PR TITLE
SSCSCI-641-CCD deletes redacted documents when a new Bulk Scan is added

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -28,3 +28,4 @@ spec:
         ADJOURNMENT_FEATURE: true
         ELINKS_V2_FEATURE_ENABLED: true
         ELASTIC_SEARCH_FEATURE: true
+        DELETED_REDACTED_DOC_ENABLED: false


### PR DESCRIPTION
### Change description ###
Add feature flag for fixing issue with redacted documents being deleted

