### PR TITLE
PAY-2787: Pass Language flag to GovPay

### DIFF
--- a/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ccpay-payment-app
+  annotations:
+    hmcts.github.com/prod-automated: disabled  
 spec:
+  filterTags:
+    pattern: '^pr-1572-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: ccpay-payment-app

--- a/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
@@ -3,7 +3,7 @@ kind: ImagePolicy
 metadata:
   name: demo-ccpay-payment-app
   annotations:
-    hmcts.github.com/prod-automated: disabled  
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
     pattern: '^pr-1572-[a-f0-9]+-(?P<ts>[0-9]+)'


### PR DESCRIPTION
Passing the language flag to GovPay. 

This will always be 'en' (english) unless 'cy' (welsh) is explicitly reqested from the Manage Case or Paybubble applications or any Citizen services. 

Currently Paybubble does not support welsh the Manage Case EXUI team neet to release the Welsh language update. Potentially making card payments could pass a welsh language attribute with this update. 


### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-2787


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
