### PR TITLE
[NFDIV-3873] HPA configuration for nfdiv frontend and case-api (AAT test)

### DIFF
--- a/apps/nfdiv/nfdiv-case-api/aat.yaml
+++ b/apps/nfdiv/nfdiv-case-api/aat.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   values:
     java:
+      replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 9
+      memoryRequests: '1536Mi'
+      memoryLimits: '2048Mi'
+      cpuRequests: '250m'
+      cpuLimits: '1500m'
       environment:
         CASE_HOLDING_WEEKS: 20
         BULK_ACTION_BATCH_SIZE_MIN: 3

--- a/apps/nfdiv/nfdiv-frontend/aat.yaml
+++ b/apps/nfdiv/nfdiv-frontend/aat.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   values:
     nodejs:
+      replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 8
+      memoryRequests: '512Mi'
+      cpuRequests: '200m'
+      memoryLimits: '512Mi'
+      cpuLimits: '1000m'
       environment:
         IGNORE_LINKED_INVITES: ENABLED
         IDAM_TOKEN_CACHE: true


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/NFDIV-3873


### Change description ###
The HPA configuration has been moved from individual service repos to flux as per the recommendation in the [HPA guidance doc](https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1753681181). After monitoring autoscaling performance and discussing it with the performance testing team, we've also increased memory requests slightly, from 1024 Mb to 1536 Mb (nfdiv-case-api) and 256 Mb to 512 Mb (nfdiv frontend), to reduce scaling under normal conditions. This is a test for the new configuration (non-production environment) and if performance is okay, we would hope to open another PR to apply the changes in production.
