### PR TITLE
[NFDIV-3873] Production hpa configuration for nfdiv case-api and frontend

### DIFF
--- a/apps/nfdiv/nfdiv-case-api/aat.yaml
+++ b/apps/nfdiv/nfdiv-case-api/aat.yaml
@@ -5,14 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 2
-      autoscaling:
-        enabled: true
-        maxReplicas: 9
-      memoryRequests: '1536Mi'
-      memoryLimits: '2048Mi'
-      cpuRequests: '250m'
-      cpuLimits: '1500m'
       environment:
         CASE_HOLDING_WEEKS: 20
         BULK_ACTION_BATCH_SIZE_MIN: 3

--- a/apps/nfdiv/nfdiv-case-api/nfdiv-case-api.yaml
+++ b/apps/nfdiv/nfdiv-case-api/nfdiv-case-api.yaml
@@ -7,6 +7,13 @@ spec:
   values:
     java:
       replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 9
+      memoryRequests: '1536Mi'
+      memoryLimits: '2048Mi'
+      cpuRequests: '250m'
+      cpuLimits: '1500m'
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/nfdiv/case-api:prod-25a18b3-20240228075059 #{"$imagepolicy": "flux-system:nfdiv-case-api"}
       environment:

--- a/apps/nfdiv/nfdiv-frontend/aat.yaml
+++ b/apps/nfdiv/nfdiv-frontend/aat.yaml
@@ -5,14 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      replicas: 2
-      autoscaling:
-        enabled: true
-        maxReplicas: 8
-      memoryRequests: '512Mi'
-      cpuRequests: '200m'
-      memoryLimits: '512Mi'
-      cpuLimits: '1000m'
       environment:
         IGNORE_LINKED_INVITES: ENABLED
         IDAM_TOKEN_CACHE: true

--- a/apps/nfdiv/nfdiv-frontend/nfdiv-frontend.yaml
+++ b/apps/nfdiv/nfdiv-frontend/nfdiv-frontend.yaml
@@ -7,6 +7,13 @@ spec:
   values:
     nodejs:
       replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 8
+      memoryRequests: '512Mi'
+      cpuRequests: '200m'
+      memoryLimits: '512Mi'
+      cpuLimits: '1000m'
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/nfdiv/frontend:prod-0744324-20240228072404 #{"$imagepolicy": "flux-system:nfdiv-frontend"}
       environment:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/NFDIV-3873

### Change description ###
The HPA configuration has been moved from individual service repos to flux as per the recommendation in the [HPA guidance doc](https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1753681181). After monitoring autoscaling performance and discussing it with the performance testing team, we've also increased memory requests slightly, from 1024 Mb to 1536 Mb (nfdiv-case-api) and 256 Mb to 512 Mb (nfdiv frontend). The config has already been tested on AAT ([PR 29500](https://github.com/hmcts/cnp-flux-config/pull/29500)).