### PR TITLE
Revert "Update hmctspublic.azurecr.io/jenkins/jenkins Docker tag to v2.447-624 in jenkins"

### DIFF
--- a/apps/jenkins/jenkins/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/jenkins-controller-version.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.447-624
+      tag: 2.447-623


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#29541