### PR TITLE
CIV-11520 Add missing Isle of Wight court to JDDO and LADO

### DIFF
--- a/apps/money-claims/cmc-citizen-frontend/demo-image-policy.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-3647-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-3656-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/money-claims/cmc-citizen-frontend/demo.yaml
+++ b/apps/money-claims/cmc-citizen-frontend/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-3647-c45a145-20240219132211 #{"$imagepolicy": "flux-system:demo-cmc-citizen-frontend"}
+      image: hmctspublic.azurecr.io/cmc/citizen-frontend:pr-3656-4a3adc2-20240312133905 #{"$imagepolicy": "flux-system:demo-cmc-citizen-frontend"}
       ingressHost: moneyclaims1.demo.platform.hmcts.net
       environment:
         GA_TRACKING_ID: UA-97111056-1


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/CIV-11520

### Change description ###

Add missing Isle of Wight court to LADO/JDDO.

This branch is dedicated to testing demo. This fixes citizen-frontend not matching claim-store.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
