### PR TITLE
Increased blob router memory

### DIFF
--- a/apps/reform-scan/reform-scan-blob-router/demo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/demo.yaml
@@ -6,7 +6,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/reform-scan/blob-router:pr-2182 # Lock demo to PR until change is merged so both suppliers work
-      memoryLimits: "3072Mi"
       environment:
         TASK_SCAN_DELAY: 300000
         CREATE_RECONCILIATION_SUMMARY_REPORT_ENABLED: "false"

--- a/apps/reform-scan/reform-scan-blob-router/demo.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/demo.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/reform-scan/blob-router:pr-2182 # Lock demo to PR until change is merged so both suppliers work
-      memoryLimits: "1024Mi"
+      memoryLimits: "3072Mi"
       environment:
         TASK_SCAN_DELAY: 300000
         CREATE_RECONCILIATION_SUMMARY_REPORT_ENABLED: "false"


### PR DESCRIPTION
### Change description ###

use default blob router memory (4gb) to fix outOfMemoryError with new supplier files.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
