### PR TITLE
Test fix for dynatrace injected pods failing in perftest spot

### DIFF
--- a/apps/dynatrace/perftest/01/kustomization.yaml
+++ b/apps/dynatrace/perftest/01/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+- path: spot-test-fix.yaml

--- a/apps/dynatrace/perftest/01/kustomization.yaml
+++ b/apps/dynatrace/perftest/01/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../base
 patches:
-- path: spot-test-fix.yaml
+  - path: spot-test-fix.yaml

--- a/apps/dynatrace/perftest/01/spot-test-fix.yaml
+++ b/apps/dynatrace/perftest/01/spot-test-fix.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: dynatrace-operator
+  namespace: dynatrace
+spec:
+  releaseName: dynatrace-operator
+  values:
+    csidriver:
+      enabled: true
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.azure.com/scalesetpriority
+          operator: Equal
+          value: "spot"
+        - effect: NoSchedule
+          key: CriticalAddonsOnly
+          operator: Equal
+          value: "true"


### PR DESCRIPTION
We are seeing early adoption of spot in nonprod, leading to an issue:

When testing spot viability we used demo & sbox, neither of which are using Dynatrace.

Perftest is unable to schedule pods onto spot nodes because they fail to initialise with the following error:
```
MountVolume.SetUp failed for volume "oneagent-bin" : kubernetes.io/csi: mounter.SetUpAt failed to get CSI client: driver name csi.oneagent.dynatrace.com not found in the list of registered CSI drivers
```

Spot nodes are tainted with `kubernetes.azure.com/scalesetpriority=spot:NoSchedule` - and Dynatrace is not configured to tolerate this as it's a 3rd party chart we didn't change.


This change:
   - Adds a toleration to Dynatrace deployment to allow containers / pods onto spot nodes

Testing only in env I've seen this in so far to check it works, but it will no doubt be happening / will happen in other places.

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
