### PR TITLE
DTSPO-17252: Updating jenkins version - limiting update to ptl

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -104,7 +104,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu"
-                          galleryImageVersion: "1.4.128"
+                          galleryImageVersion: "1.4.134"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
@@ -120,7 +120,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu"
-                          galleryImageVersion: "1.4.128"
+                          galleryImageVersion: "1.4.134"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-builders-arm"
                         templateDesc: "Jenkins build agents running on ARM64 CPUs"
@@ -136,7 +136,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.128"
+                          galleryImageVersion: "1.4.134"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-builders-arm-daily"
                         templateDesc: "Jenkins build agents running on ARM64 CPUs"
@@ -152,5 +152,5 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.128"
+                          galleryImageVersion: "1.4.134"
                         <<: *vm_template_values_anchor


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17252



### Change description ###
Second pr to update the ptl jenkins to new release version added in [190](https://github.com/hmcts/jenkins-packer/pull/190) pr. sbox version was updated first in #30139. 

*NOTE* the ptl version was lower than the sbox version at the time of this update, this pr brings then to same version
