### PR TITLE
Revert "DTSPO-17252: Updating jenkins version - limiting update to ptl"

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -104,7 +104,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu"
-                          galleryImageVersion: "1.4.134"
+                          galleryImageVersion: "1.4.128"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
@@ -120,7 +120,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu"
-                          galleryImageVersion: "1.4.134"
+                          galleryImageVersion: "1.4.128"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-builders-arm"
                         templateDesc: "Jenkins build agents running on ARM64 CPUs"
@@ -136,7 +136,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.134"
+                          galleryImageVersion: "1.4.128"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-builders-arm-daily"
                         templateDesc: "Jenkins build agents running on ARM64 CPUs"
@@ -152,5 +152,5 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.134"
+                          galleryImageVersion: "1.4.128"
                         <<: *vm_template_values_anchor


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#30141

Reverting as this was not the root cause anyway of https://tools.hmcts.net/jira/browse/DTSPO-17244
Want to check if this could have caused DTSPO-17268