### PR TITLE
Remove spot in demo for sptribs

### DIFF
--- a/apps/sptribs/sptribs-case-api/demo.yaml
+++ b/apps/sptribs/sptribs-case-api/demo.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   values:
     java:
+      spotInstances:
+        enabled: false
       image: hmctspublic.azurecr.io/sptribs/case-api:prod-2cd9ee3-20240326103643 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
       environment:
         S2S_AUTHORISED_SERVICES: ccd_definition,ccd_data,xui_webapp,sptribs_case_api,ccd_gw,sptribs_frontend,sptribs_dss_update_case_web

--- a/apps/sptribs/sptribs-dss-update-case-web/demo.yaml
+++ b/apps/sptribs/sptribs-dss-update-case-web/demo.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   values:
     nodejs:
+      spotInstances:
+        enabled: false
       ingressSessionAffinity:
         enabled: true
         sessionCookieName: sticky


### PR DESCRIPTION
Currently spot enabled in demo via env-injector for most apps

When we set this ourselves, as sptribs have in their application repo, env-injector gets very sad and throws this error:
```
 Error creating: Internal error occurred: failed calling webhook "env-injector.hmcts.net": failed to call webhook: Post "https://env-injector-webhook-svc.admin.svc:443/mutate?timeout=10s": EOF
```

Will add this as a temporary fix while i look into the root cause

