### PR TITLE
Enabling hpa in advance of chart upgrade

### DIFF
--- a/apps/wa/wa-workflow-api/wa-workflow-api.yaml
+++ b/apps/wa/wa-workflow-api/wa-workflow-api.yaml
@@ -9,6 +9,9 @@ spec:
       replicas: 2
       memoryRequests: "1.5Gi"
       useInterpodAntiAffinity: true
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
       image: hmctspublic.azurecr.io/wa/workflow-api:prod-6815957-20240402162808 #{"$imagepolicy": "flux-system:wa-workflow-api"}
   chart:
     spec:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RWA-3162

### Change description ###

Enabling HPA before we upgrade the chart version which turns it on by default.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
