### PR TITLE
Demo: disable spot instances because of env injector error

### DIFF
--- a/apps/rd/rd-commondata-api/demo.yaml
+++ b/apps/rd/rd-commondata-api/demo.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   values:
     java:
+      spotInstances:
+        enabled: false
       keyVaults:
         rd:
           secrets:


### PR DESCRIPTION
DTSPO-17327.

Disabling here as is giving an error in env-injector, clashing.
Ticket for proper fix will be created separately but this will unblock

4m1s        Warning   FailedCreate                   replicaset/rd-commondata-api-java-64597d8644                     Error creating: Internal error occurred: failed calling webhook "env-injector.hmcts.net": failed to call webhook: Post "https://env-injector-webhook-svc.admin.svc:443/mutate?timeout=10s": EOF
