### PR TITLE
DFPL: Set perftest image to be inline in prod

### DIFF
--- a/apps/family-public-law/fpl-case-service/perftest-image-policy.yaml
+++ b/apps/family-public-law/fpl-case-service/perftest-image-policy.yaml
@@ -2,8 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: perftest-fpl-case-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
     pattern: '^pr-5178-[a-f0-9]+-(?P<ts>[0-9]+)'

--- a/apps/family-public-law/fpl-case-service/perftest.yaml
+++ b/apps/family-public-law/fpl-case-service/perftest.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     java:
       ingressHost: fpl-case-service-perftest.service.core-compute-perftest.internal
-      image: hmctspublic.azurecr.io/fpl/case-service:pr-5178-6940421-20240315114701 #{"$imagepolicy": "flux-system:perftest-fpl-case-service"}
+      image: hmctspublic.azurecr.io/fpl/case-service:prod-3b2fc38-20240408133349 #{"$imagepolicy": "flux-system:perftest-fpl-case-service"}
       environment:
         SCHEDULER_ENABLED: false
         GATEWAY_URL: https://gateway-ccd.perftest.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
- Reset perftest pod to be inline with production

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [NO] Does this PR introduce a breaking change
