### PR TITLE
DTSPO-16593 - remove failed helm releases

### DIFF
--- a/apps/labs/sbox/base/kustomization.yaml
+++ b/apps/labs/sbox/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../labs-rhodrif/labs-rhodrif.yaml
-  - ../../labs-darrenbayliss-dev/labs-darrenbayliss-dev.yaml
-  - ../../labs-darrenbayliss-dev2/labs-darrenbayliss-dev2.yaml
+  # - ../../labs-darrenbayliss-dev/labs-darrenbayliss-dev.yaml
+  # - ../../labs-darrenbayliss-dev2/labs-darrenbayliss-dev2.yaml
   - ../../labs-apps-njs/labs-apps-njs.yaml
 namespace: labs


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16593


### Change description ###

Removing failed Helmreleases


