### PR TITLE
DTSPO-16593 - turn off draft-store from sbox

### DIFF
--- a/apps/rpe/sbox/base/kustomization.yaml
+++ b/apps/rpe/sbox/base/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
   - ../../rpe-service-auth-provider/rpe-service-auth-provider.yaml
 namespace: rpe
 patches:
-  - path: ../../draft-store-service/sbox.yaml
+  # - path: ../../draft-store-service/sbox.yaml # temporary remove this to allow AKS upgrade
   - path: ../../serviceaccount/sbox.yaml

--- a/apps/rpe/sbox/base/kustomization.yaml
+++ b/apps/rpe/sbox/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../draft-store-service/draft-store-service.yaml
+  # - ../../draft-store-service/draft-store-service.yaml   # temporary remove this to allow AKS upgrade
   - ../../rpe-service-auth-provider/rpe-service-auth-provider.yaml
 namespace: rpe
 patches:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16593

### Change description ###

Turning off Draf-Store HR because of the draft-store DB creation errors for sbox
https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/rpe-draft-store-v14-data-sandbox/eventlogs


