### PR TITLE
DTSPO-16593 - turn off idam on sbox to carry on upgrade'

### DIFF
--- a/apps/idam/sbox/base/kustomization.yaml
+++ b/apps/idam/sbox/base/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
   - ../../idam-user-profile-bridge/idam-user-profile-bridge.yaml
 namespace: idam
 patches:
-  - path: ../../idam-api/sbox.yaml
-  - path: ../../idam-web-public/sbox.yaml
+  # - path: ../../idam-api/sbox.yaml
+  # - path: ../../idam-web-public/sbox.yaml
   - path: ../../idam-web-admin/sbox.yaml
   - path: ../../idam-testing-support-api/sbox.yaml
   - path: ../../idam-user-dashboard/sbox.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16593

### Change description ###

idam-api and idam-web-public containers is not in running state for some reason on sbox, did try to fix but didn't work so turning it off to perform the Custer upgrade.

