### PR TITLE
DTSPO-16593 - turn off idam from sbox

### DIFF
--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 - ../../../apps/crumble/base/kustomize.yaml
 - ../../../apps/rpe/base/kustomize.yaml
 - ../../../apps/docmosis/base/kustomize.yaml
-- ../../../apps/idam/base/kustomize.yaml
+# - ../../../apps/idam/base/kustomize.yaml
 - ../../../apps/labs/base/kustomize.yaml
 - ../../../apps/neuvector/base/kustomize.yaml
 - ../../../apps/azureserviceoperator-system/base/kustomize.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16593

### Change description ###

idam-api and idam-web-public containers is not in running state for some reason on sbox, did try to fix but didn't work so turning it off to perform the Custer upgrade.

