### PR TITLE
1777 on demo

### DIFF
--- a/apps/xui/xui-ao-webapp/demo.yaml
+++ b/apps/xui/xui-ao-webapp/demo.yaml
@@ -13,5 +13,6 @@ spec:
         DEBUG: xuiNode:*,-xuiNode:auth:s2s
         ISS_SERVICE: https://forgerock-am.service.core-compute-idam-demo.internal:8443/openam/oauth2/realms/root/realms/hmcts
         FEATURE_SECURE_COOKIE_ENABLED: false
+        FEE_AND_PAY_API: http://payment-api-int-demo.service.core-compute-demo.internal
         DUMMY_VAR: false
       image: hmctspublic.azurecr.io/xui/ao-webapp:prod-8416ede-20240318115128 #{"$imagepolicy": "flux-system:demo-xui-ao-webapp"}

--- a/apps/xui/xui-mo-webapp/demo.yaml
+++ b/apps/xui/xui-mo-webapp/demo.yaml
@@ -21,4 +21,5 @@ spec:
         SERVICES_ROLE_ASSIGNMENT_API: http://am-role-assignment-service-demo.service.core-compute-demo.internal
         SERVICES_PRD_COMMONDATA_API: http://rd-commondata-api-demo.service.core-compute-demo.internal
         SERVICES_CCD_COMPONENT_API_PATH: https://gateway-ccd.demo.platform.hmcts.net
+        FEE_AND_PAY_API: http://payment-api-int-demo.service.core-compute-demo.internal
       image: hmctspublic.azurecr.io/xui/mo-webapp:prod-b240850-20240404121023 #{"$imagepolicy": "flux-system:demo-xui-mo-webapp"}

--- a/apps/xui/xui-webapp/demo.yaml
+++ b/apps/xui/xui-webapp/demo.yaml
@@ -49,4 +49,5 @@ spec:
         SERVICES_REFUNDS_API_URL: http://ccpay-refunds-api-demo.service.core-compute-demo.internal
         SERVICES_NOTIFICATIONS_API_URL: http://ccpay-notifications-service-demo.service.core-compute-demo.internal
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
+        FEE_AND_PAY_API: http://payment-api-int-demo.service.core-compute-demo.internal
       image: hmctspublic.azurecr.io/xui/webapp:prod-be69d2c-20240411121222 #{"$imagepolicy": "flux-system:xui-webapp"}


### PR DESCRIPTION
Test the Fix for 1777 / PAY-6933 on demo - 

Update the FEE_AND_PAY_API url  to point to the FeePay URL as below. This need to be done for both MO and AO on demo environment.

FEE_AND_PAY_API: http://payment-api-int-demo.service.core-compute-demo.internal . This entry will be reversed once testing is complete for https://tools.hmcts.net/jira/browse/PAY-6933.