### PR TITLE
Revert  Flux Config FEE_AND_PAY_API in AO and MO . For MC point to payment-api-demo.

### DIFF
--- a/apps/xui/xui-ao-webapp/demo.yaml
+++ b/apps/xui/xui-ao-webapp/demo.yaml
@@ -13,6 +13,5 @@ spec:
         DEBUG: xuiNode:*,-xuiNode:auth:s2s
         ISS_SERVICE: https://forgerock-am.service.core-compute-idam-demo.internal:8443/openam/oauth2/realms/root/realms/hmcts
         FEATURE_SECURE_COOKIE_ENABLED: false
-        FEE_AND_PAY_API: http://payment-api-int-demo.service.core-compute-demo.internal
         DUMMY_VAR: false
       image: hmctspublic.azurecr.io/xui/ao-webapp:prod-8416ede-20240318115128 #{"$imagepolicy": "flux-system:demo-xui-ao-webapp"}

--- a/apps/xui/xui-mo-webapp/demo.yaml
+++ b/apps/xui/xui-mo-webapp/demo.yaml
@@ -21,5 +21,4 @@ spec:
         SERVICES_ROLE_ASSIGNMENT_API: http://am-role-assignment-service-demo.service.core-compute-demo.internal
         SERVICES_PRD_COMMONDATA_API: http://rd-commondata-api-demo.service.core-compute-demo.internal
         SERVICES_CCD_COMPONENT_API_PATH: https://gateway-ccd.demo.platform.hmcts.net
-        FEE_AND_PAY_API: http://payment-api-int-demo.service.core-compute-demo.internal
       image: hmctspublic.azurecr.io/xui/mo-webapp:prod-b0d2587-20240415153133 #{"$imagepolicy": "flux-system:demo-xui-mo-webapp"}

--- a/apps/xui/xui-webapp/demo.yaml
+++ b/apps/xui/xui-webapp/demo.yaml
@@ -48,5 +48,5 @@ spec:
         SERVICES_TRANSLATION_API_URL: http://ts-translation-service-demo.service.core-compute-demo.internal
         SERVICES_REFUNDS_API_URL: http://ccpay-refunds-api-demo.service.core-compute-demo.internal
         SERVICES_NOTIFICATIONS_API_URL: http://ccpay-notifications-service-demo.service.core-compute-demo.internal
-        SERVICES_PAYMENTS_URL: http://payment-api-int-demo.service.core-compute-demo.internal
+        SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
       image: hmctspublic.azurecr.io/xui/webapp:prod-91d1de4-20240415180826 #{"$imagepolicy": "flux-system:xui-webapp"}


### PR DESCRIPTION
For AO  - revert entry FEE_AND_PAY_API in Flux 
For MO - revert entry FEE_AND_PAY_API in Flux 
For MC - Ensure the SERVICES_PAYMENTS_URL points to payment-api-demo.service... in Flux 

These were the exact Flux entries that were present before the  fix for https://tools.hmcts.net/jira/browse/PAY-6933 /  https://tools.hmcts.net/jira/browse/EXUI-1777  was deployed in demo to Test. 

Hence , reverting these to bring it back in line with the original.  
