### PR TITLE
DTSPO-16594 - Disable PDB for failed demo pods

### DIFF
--- a/apps/em/em-hrs-api/demo.yaml
+++ b/apps/em/em-hrs-api/demo.yaml
@@ -10,4 +10,3 @@ spec:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_EM_HRS: DEBUG
       pdb:
         enabled: false
-      

--- a/apps/em/em-hrs-api/demo.yaml
+++ b/apps/em/em-hrs-api/demo.yaml
@@ -8,3 +8,6 @@ spec:
       image: hmctspublic.azurecr.io/em/hrs-api:pr-1696-39d6dea-20240408095935 #{"$imagepolicy": "flux-system:demo-em-hrs-api"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_EM_HRS: DEBUG
+      pdb:
+        enabled: false
+      

--- a/apps/et-pet/et-pet-et1/demo.yaml
+++ b/apps/et-pet/et-pet-et1/demo.yaml
@@ -6,5 +6,9 @@ spec:
   values:
     base:
       image: hmctspublic.azurecr.io/et-pet/et1:prod-48a7c0b-20230914174139 #{"$imagepolicy": "demo-flux-system:et-pet-et1"}
+      pdb:
+        enabled: false
     sidekiq:
       image: hmctspublic.azurecr.io/et-pet/et1:prod-48a7c0b-20230914174139 #{"$imagepolicy": "demo-flux-system:et-pet-et1"}
+      pdb:
+        enabled: false

--- a/apps/ethos/ecm-consumer/demo.yaml
+++ b/apps/ethos/ecm-consumer/demo.yaml
@@ -10,3 +10,5 @@ spec:
       image: hmctspublic.azurecr.io/ethos/ecm-consumer:pr-778-b65f20c-20240403101632 #{"$imagepolicy": "flux-system:demo-ecm-consumer"}
       environment:
         TRIGGER_RESTART: 2
+      pdb:
+        enabled: false

--- a/apps/fis/fis-cos-api/demo.yaml
+++ b/apps/fis/fis-cos-api/demo.yaml
@@ -27,6 +27,8 @@ spec:
         CASE_DATA_STORE_BASEURL: http://ccd-data-store-api-demo.service.core-compute-demo.internal
         CCD_CASE_DOCS_AM_API: http://ccd-case-document-am-api-demo.service.core-compute-demo.internal
         DUMMY_VAR_TO_REDEPLOY: 2
+      pdb:
+        enabled: false
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/apps/help-with-fees/help-with-fees-staffapp/demo.yaml
+++ b/apps/help-with-fees/help-with-fees-staffapp/demo.yaml
@@ -13,3 +13,5 @@ spec:
         NOTIFY_RAW_DATA_READY_TEMPLATE_ID: "9025a651-90ac-4d31-8448-0b295f02a81a"
         URL_HELPER_DOMAIN: 'hwf-staffapp.demo.platform.hmcts.net'
       image: hmctspublic.azurecr.io/help-with-fees/staffapp:pr-1692-c516f89-20240415163613 #{"$imagepolicy": "flux-system:demo-help-with-fees-staffapp"}
+      pdb:
+        enabled: false

--- a/apps/jps/jps-judicial-payment-frontend/demo.yaml
+++ b/apps/jps/jps-judicial-payment-frontend/demo.yaml
@@ -43,3 +43,5 @@ spec:
             - jps-idam-client-secret
             - idam-jps-system-username
             - idam-jps-system-password
+      pdb:
+        enabled: false

--- a/apps/pcq/pcq-backend-int/demo.yaml
+++ b/apps/pcq/pcq-backend-int/demo.yaml
@@ -34,3 +34,5 @@ spec:
               alias: STORAGE_ACCOUNT_CONNECTION_STRING
             - name: s2s-secret-pcq-consolidation-service
               alias: S2S_CS_SECRET
+      pdb:
+        enabled: false

--- a/apps/sscs/sscs-bulk-scan/demo.yaml
+++ b/apps/sscs/sscs-bulk-scan/demo.yaml
@@ -27,3 +27,5 @@ spec:
         WORK_ALLOCATION_FEATURE: true
         RD_LOCATION_REF_API_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         CASE_ACCESS_MANAGEMENT_FEATURE: true
+      pdb:
+        enabled: false

--- a/apps/sscs/sscs-evidence-share/demo.yaml
+++ b/apps/sscs/sscs-evidence-share/demo.yaml
@@ -22,3 +22,5 @@ spec:
         GAPS_SWITCHOVER_FEATURE: true
         CASE_ACCESS_MANAGEMENT_FEATURE: true
         BYPASS_EVIDENCE_SHARE_SERVICE: true
+      pdb:
+        enabled: false


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16594

### Change description ###

Disabling PDB temporarily for failed pods on Demo clusters, this will allow us to upgrade the cluster.

