### PR TITLE
Trying to see if removing helm release will pick correct version

### DIFF
--- a/apps/nfdiv/demo/base/kustomization.yaml
+++ b/apps/nfdiv/demo/base/kustomization.yaml
@@ -16,7 +16,7 @@ resources:
   - ../../nfdiv-cron-applicant-can-sts-after-intention-fo/nfdiv-cron-applicant-can-sts-after-intention-fo.yaml
   - ../../nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
   - ../../nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
-  - ../../nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
+  # - ../../nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
   - ../../nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
   - ../../nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
   - ../../nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
@@ -53,7 +53,7 @@ patches:
   - path: ../../nfdiv-cron-eligible-for-switch-to-sole/demo.yaml
   - path: ../../nfdiv-cron-js-disputed-answer-overdue/demo.yaml
   - path: ../../nfdiv-cron-partner-not-applied-for-final-order/demo.yaml
-  - path: ../../nfdiv-cron-bulk-list-create/demo/demo.yaml
+  # - path: ../../nfdiv-cron-bulk-list-create/demo/demo.yaml
   - path: ../../nfdiv-cron-migrate-bulk-cases/demo/demo.yaml
   - path: ../../nfdiv-cron-migrate-cases/demo/demo.yaml
   - path: ../../nfdiv-cron-remind-awaiting-joint-final-order/demo/demo.yaml


### PR DESCRIPTION
CronJob seems to be picking up wrong chart version and deprecated API, trying to see if removing and re-adding would fix that.