### PR TITLE
SIDM-9196: Set default replicas for idam-api and idam-web-public

### DIFF
--- a/apps/idam/idam-api/aat.yaml
+++ b/apps/idam/idam-api/aat.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-adf1e51-20240410122103
+      replicas: 2
       ingressHost: idam-api.aat.platform.hmcts.net
       environment:
         SERVER_MAX_HTTP_REQUEST_HEADER_SIZE: 20KB

--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-adf1e51-20240410122103
-      replicas: 2
+      replicas: 1
       ingressHost: idam-api.demo.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-adf1e51-20240410122103
+      replicas: 2
       ingressHost: idam-api.demo.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-api/perftest.yaml
+++ b/apps/idam/idam-api/perftest.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/api:prod-adf1e51-20240410122103
+      replicas: 2
       ingressHost: idam-api.perftest.platform.hmcts.net
       environment:
         TESTING_SUPPORT_ENABLED: true

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -10,7 +10,7 @@ spec:
       image: hmctspublic.azurecr.io/idam/api:preview-0006f88-20240415165821 #{"$imagepolicy": "flux-system:preview-idam-api"}
       ingressHost: idam-api.sandbox.platform.hmcts.net
       disableTraefikTls: true
-      replicas: 4
+      replicas: 1
       environment:
         LOG_AND_AUDIT_IDAM_ENABLED: false
         MANAGEMENT_HEALTH_IDAMSERVICEAUTH_ENABLED: false

--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-public:prod-36694ff-20240408171044
+      replicas: 2
       ingressHost: idam-web-public.aat.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-public:prod-36694ff-20240408171044
-      replicas: 2
+      replicas: 1
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.demo.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-public:prod-36694ff-20240408171044
+      replicas: 2
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.demo.platform.hmcts.net

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/idam/web-public:prod-36694ff-20240408171044
+      replicas: 2
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.perftest.platform.hmcts.net

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -9,7 +9,7 @@ spec:
       image: hmctspublic.azurecr.io/idam/web-public:preview-72fff42-20240418215146 #{"$imagepolicy": "flux-system:preview-idam-web-public"}
       ingressHost: idam-web-public.sandbox.platform.hmcts.net
       disableTraefikTls: true
-      replicas: 2
+      replicas: 1
       environment:
         STRATEGIC_SERVICE_URL: http://idam-api
         TRIGGER: false


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SIDM-9196


### Change description ###
With HPA enabled, both idam-api and idam-web-public can have 2 min replicas.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
