### PR TITLE
Update Divorce HPA AAT 

### DIFF
--- a/apps/divorce/div-dgs/aat.yaml
+++ b/apps/divorce/div-dgs/aat.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   values:
     java:
-      memoryRequests: "768Mi"
+      memoryRequests: "2.7Gi"
+      memoryLimits: "3Gi"
       cpuRequests: "1000m"
       memoryLimits: "3072Mi"
       cpuLimits: "2500m"

--- a/apps/divorce/div-emca/aat.yaml
+++ b/apps/divorce/div-emca/aat.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   values:
     java:
+      memoryRequests: "2.2Gi"
       environment:
         IDAM_API_HEALTH_URI: https://idam-api.aat.platform.hmcts.net/health
         IDAM_API_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/divorce/div-pfe/aat.yaml
+++ b/apps/divorce/div-pfe/aat.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   values:
     nodejs:
-      memoryRequests: "512Mi"
+      memoryRequests: "3.5Gi"
+      memoryLimits: "4Gi"
       cpuRequests: "500m"
       memoryLimits: "2048Mi"
       cpuLimits: "1000m"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DFR-3001

### Change description ###

Fine tune HPA for Divorce aat services running redundant pods.  

Number of pods for entire divorce application before tuning (per cluster): 23

Anticipated number of pods per cluster post tuning: 19 



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
