### PR TITLE
Botkube upgrade

### DIFF
--- a/apps/monitoring/botkube/botkube.yaml
+++ b/apps/monitoring/botkube/botkube.yaml
@@ -19,7 +19,7 @@ spec:
       name: "botkube-values"
   values:
     image:
-      tag: v1.5.0
+      tag: v1.10.0
     settings:
       clusterName: cft-${CLUSTER_FULL_NAME}-aks
       upgradeNotifier: false


### PR DESCRIPTION

Were some changes in 1.9.0 that I checked but they don't seem to affect any of the plugins we are using https://github.com/kubeshop/botkube/releases.

Botkube is currently showing issues "Incompatible API version with plugin" on some clusters, want to try this upgrade.