### PR TITLE
LAU-876 disable hpa for lau-frontend perftest

### DIFF
--- a/apps/lau/lau-frontend/perftest.yaml
+++ b/apps/lau/lau-frontend/perftest.yaml
@@ -9,13 +9,6 @@ spec:
       memoryRequests: "768Mi"
       cpuRequests: "50m"
       autoscaling:
-        enabled: true
-        maxReplicas: 3
-        cpu:
-          enabled: true
-          averageUtilization: 90
-        memory:
-          enabled: true
-          averageUtilization: 80
+        enabled: false
       spotInstances:
         enabled: false


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/LAU-876

### Change description ###
Disabling hpa to see if app is marked live too early
