### PR TITLE
Removing aso resource group for RD namespace to test deployment issues

### DIFF
--- a/apps/rd/preview/base/kustomization.yaml
+++ b/apps/rd/preview/base/kustomization.yaml
@@ -4,8 +4,8 @@ resources:
   - ../../../base
   - ../../../base/workload-identity
   - ../../identity/identity.yaml
-  - ../../../azureserviceoperator-system/resources/resource-group.yaml
-  - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
+  # - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  # - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
   - ../../rd-commondata-api/rd-commondata-api.yaml
   - ../../rd-professional-api/rd-professional-api.yaml
@@ -16,7 +16,7 @@ resources:
 namespace: rd
 patches:
   - path: ../../identity/aat.yaml
-  - path: ../aso/rd-servicebus.yaml
+  # - path: ../aso/rd-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../../rd-commondata-api/preview.yaml
   - path: ../../rd-professional-api/preview.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17358

### Change description ###
Removing aso resource group for RD namespace to test deployment issues

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


The changes in this pull request are:

- Removed references to `azureserviceoperator-system` resources
- Added a new reference to `sops-secrets` resource
- Updated the path for the `serviceaccount/aat.yaml` file