### PR TITLE
Reinstate the resource group for RD namespace

### DIFF
--- a/apps/rd/preview/base/kustomization.yaml
+++ b/apps/rd/preview/base/kustomization.yaml
@@ -4,8 +4,8 @@ resources:
   - ../../../base
   - ../../../base/workload-identity
   - ../../identity/identity.yaml
-  # - ../../../azureserviceoperator-system/resources/resource-group.yaml
-  # - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
   - ../../rd-commondata-api/rd-commondata-api.yaml
   - ../../rd-professional-api/rd-professional-api.yaml
@@ -16,7 +16,7 @@ resources:
 namespace: rd
 patches:
   - path: ../../identity/aat.yaml
-  # - path: ../aso/rd-servicebus.yaml
+  - path: ../aso/rd-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../../rd-commondata-api/preview.yaml
   - path: ../../rd-professional-api/preview.yaml


### PR DESCRIPTION
Reinstate the resource group for RD namespace
Reverts hmcts/cnp-flux-config#30744

## 🤖GIPPI PR SUMMARY🤖


The pull request modifies the `kustomization.yaml` file in the `rd/preview/base` directory. 
- Adds `servicebus-namespace.yaml` from `azureserviceoperator-system/resources` as a resource. 
- Adds a patch to include `rd-servicebus.yaml` in the resources.