### PR TITLE
Adding tags to chart-tests-aso resource group including a lock exempt…

### DIFF
--- a/apps/chart-tests/azure-service-operator/aso.yaml
+++ b/apps/chart-tests/azure-service-operator/aso.yaml
@@ -17,6 +17,12 @@ metadata:
 spec:
   location: uksouth
   azureName: chart-tests-aso-${ENVIRONMENT}-rg
+  tags:
+    application: core
+    builtFrom: https://github.com/hmcts/cnp-flux-config
+    businessArea: CFT
+    environment: development
+    exemptFromAutoLock: "true"
 ---
 apiVersion: servicebus.azure.com/v1beta20210101preview
 kind: Namespace


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17358

### Change description ###
Adding tags to chart-tests-aso resource group including a lock exemption to allow charts to clean up when removed, affects Databases, Servicebus and storage accounts for charts deployed to this resource group



## 🤖GIPPI PR SUMMARY🤖


- Changed `aso.yaml` in `azure-service-operator` directory
- Added tags for application, builtFrom, businessArea, environment, and exemptFromAutoLock
- Updated spec location to uksouth and azureName to include chart-tests-aso-${ENVIRONMENT}-rg