### PR TITLE
DTSPO-17524: traefik upgrade to v27.0.2 for sbox

### DIFF
--- a/apps/admin/traefik-crds-upgrade-v27.0.2/kustomization.yaml
+++ b/apps/admin/traefik-crds-upgrade-v27.0.2/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.io_traefikservices.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v27.0.2/traefik/crds/traefik.containo.us_traefikservices.yaml

--- a/apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+++ b/apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/admin/traefik-crds-upgrade-v27.0.2

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -5,6 +5,15 @@ metadata:
   namespace: admin
 spec:
   values:
+    chart:
+      spec:
+        chart: traefik
+        # update the crd version in traefik-crds when updating this
+        version: 27.0.2
+        sourceRef:
+          kind: HelmRepository
+          name: traefik
+          namespace: admin
     deployment:
       additionalVolumes:
         - name: traefik-default-cert

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+      spec:
+        chart: traefik
+        # update the crd version in traefik-crds when updating this
+        version: 27.0.2
+        sourceRef:
+          kind: HelmRepository
+          name: traefik
+          namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -5,15 +5,15 @@ metadata:
   namespace: admin
 spec:
   values:
-  chart:
-    spec:
-      chart: traefik
-      # update the crd version in traefik-crds when updating this
-      version: 27.0.2
-      sourceRef:
-        kind: HelmRepository
-        name: traefik
-        namespace: admin
+    chart:
+      spec:
+        chart: traefik
+        # update the crd version in traefik-crds when updating this
+        version: 27.0.2
+        sourceRef:
+          kind: HelmRepository
+          name: traefik
+          namespace: admin
     service:
       spec:
         loadBalancerIP: "10.2.11.250"

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,16 +4,16 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
-  chart:
-      spec:
-        chart: traefik
-        # update the crd version in traefik-crds when updating this
-        version: 27.0.2
-        sourceRef:
-          kind: HelmRepository
-          name: traefik
-          namespace: admin
   values:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 27.0.2
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
     service:
       spec:
         loadBalancerIP: "10.2.11.250"

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -22,4 +22,4 @@ patches:
     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
     kind: Kustomization
 - path: ../../../apps/admin/sbox/base/kustomize.yaml
-- path: ../../../apps/admin/traefik-crds-upgrade-v26/kustomize.yaml
+- path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
     kind: Kustomization
 - path: ../../../apps/admin/sbox/base/kustomize.yaml
+- path: ../../../apps/admin/traefik-crds-upgrade-v26/kustomize.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17534


### Change description ###

- Upgrade Traefik in sbox to v27.0.2


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖GIPPI PR SUMMARY🤖


### apps/admin/traefik-crds-upgrade-v27.0.2/kustomization.yaml
- A new file with Kustomization resources for Traefik CRDs upgrade v27.0.2 has been added.

### apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
- A new file with Kustomization for the Traefik CRDs upgrade v27.0.2 has been added, specifying the interval and path.

### apps/admin/traefik2/sbox/00.yaml
- Added configuration for using Traefik chart v27.0.2 from the HelmRepository.

### apps/admin/traefik2/sbox/01.yaml
- Updated Traefik chart to version 27.0.2 and specified the HelmRepository for the chart.

### clusters/sbox/base/kustomization.yaml
- Updated the path to include the new Kustomization for Traefik CRDs upgrade v27.0.2.