### PR TITLE
DTSPO-17534: fix HelmRelease yaml for traefik upgrade to v27.0.2 in sbox

### DIFF
--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -4,16 +4,16 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 27.0.2
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
-    chart:
-      spec:
-        chart: traefik
-        # update the crd version in traefik-crds when updating this
-        version: 27.0.2
-        sourceRef:
-          kind: HelmRepository
-          name: traefik
-          namespace: admin
     deployment:
       additionalVolumes:
         - name: traefik-default-cert

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,16 +4,16 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 27.0.2
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
-    chart:
-      spec:
-        chart: traefik
-        # update the crd version in traefik-crds when updating this
-        version: 27.0.2
-        sourceRef:
-          kind: HelmRepository
-          name: traefik
-          namespace: admin
     service:
       spec:
         loadBalancerIP: "10.2.11.250"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17534


### Change description ###

- fix HelmRelease yaml for traefik upgrade to v27.0.2 in sbox


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
