### PR TITLE
Revert sptribs demo images back to prod images

### DIFF
--- a/apps/sptribs/sptribs-dss-update-case-web/demo-image-policy.yaml
+++ b/apps/sptribs/sptribs-dss-update-case-web/demo-image-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: demo-sptribs-dss-update-case-web
 spec:
   filterTags:
-    pattern: '^pr-213-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/sptribs/sptribs-frontend/demo-image-policy.yaml
+++ b/apps/sptribs/sptribs-frontend/demo-image-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: demo-sptribs-frontend
 spec:
   filterTags:
-    pattern: '^pr-637-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/sptribs/sptribs-frontend/demo.yaml
+++ b/apps/sptribs/sptribs-frontend/demo.yaml
@@ -9,4 +9,4 @@ spec:
         enabled: false
       environment:
         PCQ_ENABLED: false
-      image: hmctspublic.azurecr.io/sptribs/frontend:pr-637-4735113-20240429151723 #{"$imagepolicy": "flux-system:demo-sptribs-frontend"}
+      image: hmctspublic.azurecr.io/sptribs/frontend:prod-4c83e08-20240429113504 #{"$imagepolicy": "flux-system:demo-sptribs-frontend"}


### PR DESCRIPTION


## 🤖GIPPI PR SUMMARY🤖


- demo-image-policy.yaml (sptribs-dss-update-case-web):
  - Changed the filter pattern from '^pr-213-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'.

- demo-image-policy.yaml (sptribs-frontend):
  - Changed the filter pattern from '^pr-637-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'.

- demo.yaml (sptribs-frontend):
  - Updated the image from 'hmctspublic.azurecr.io/sptribs/frontend:pr-637-4735113-20240429151723' to 'hmctspublic.azurecr.io/sptribs/frontend:prod-4c83e08-20240429113504'.