### PR TITLE
SSCSCI-816

### DIFF
--- a/apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
+++ b/apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
@@ -7,6 +7,11 @@ spec:
   releaseName: sscs-bulk-scan
   values:
     java:
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: '1536Mi'
+      memoryLimits: "2048Mi"
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-f9cbd07-20240402105956 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}

--- a/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
+++ b/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
@@ -7,6 +7,11 @@ spec:
   releaseName: sscs-cor-frontend
   values:
     nodejs:
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: '512Mi'
+      memoryLimits: "1024Mi"
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs-cor/frontend:prod-9b60723-20240416151108 #{"$imagepolicy": "flux-system:sscs-cor-frontend"}

--- a/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
+++ b/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
@@ -12,6 +12,8 @@ spec:
         maxReplicas: 4
       memoryRequests: '512Mi'
       memoryLimits: "1024Mi"
+      cpuRequests: 200m
+      cpuLimits: 1000m
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs-cor/frontend:prod-9b60723-20240416151108 #{"$imagepolicy": "flux-system:sscs-cor-frontend"}

--- a/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
+++ b/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
@@ -6,6 +6,11 @@ spec:
   releaseName: sscs-hearings-api
   values:
     java:
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: '1536Mi'
+      memoryLimits: "2048Mi"
       replicas: 2
       image: hmctspublic.azurecr.io/sscs/hearings-api:prod-bf51f45-20240411112326 #{"$imagepolicy": "flux-system:sscs-hearings-api"}
       useInterpodAntiAffinity: true

--- a/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
+++ b/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
@@ -9,8 +9,8 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      memoryRequests: '1536Mi'
-      memoryLimits: "2048Mi"
+      memoryRequests: '2048Mi'
+      memoryLimits: "3072Mi"
       replicas: 2
       image: hmctspublic.azurecr.io/sscs/hearings-api:prod-bf51f45-20240411112326 #{"$imagepolicy": "flux-system:sscs-hearings-api"}
       useInterpodAntiAffinity: true

--- a/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+++ b/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
@@ -12,8 +12,6 @@ spec:
         maxReplicas: 4
       memoryRequests: '2048Mi'
       memoryLimits: "3072Mi"
-      cpuRequests: '250m'
-      cpuLimits: '1500m'
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-19a1c06-20240429193306 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}

--- a/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+++ b/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
@@ -7,6 +7,13 @@ spec:
   releaseName: sscs-tribunals-api
   values:
     java:
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: '2048Mi'
+      memoryLimits: "3072Mi"
+      cpuRequests: '250m'
+      cpuLimits: '1500m'
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-19a1c06-20240429193306 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}

--- a/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+++ b/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
@@ -10,8 +10,8 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      memoryRequests: '2048Mi'
-      memoryLimits: "3072Mi"
+      memoryRequests: '3072Mi'
+      memoryLimits: "4096Mi"
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-19a1c06-20240429193306 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}

--- a/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
@@ -7,6 +7,11 @@ spec:
   releaseName: sscs-tribunals-frontend
   values:
     nodejs:
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: '512Mi'
+      memoryLimits: "1024Mi"
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-frontend:prod-37dfa86-20240424145043 #{"$imagepolicy": "flux-system:sscs-tribunals-frontend"}

--- a/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
@@ -12,6 +12,8 @@ spec:
         maxReplicas: 4
       memoryRequests: '512Mi'
       memoryLimits: "1024Mi"
+      cpuRequests: 100m
+      cpuLimits: 500m
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-frontend:prod-37dfa86-20240424145043 #{"$imagepolicy": "flux-system:sscs-tribunals-frontend"}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SSCSCI-816


### Change description ###
Enable autoscaling for sscs applications

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖GIPPI PR SUMMARY🤖


### apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
- Autoscaling enabled with a maximum of 4 replicas.
- Updated memory requests to '1536Mi'.
- Updated memory limits to '2048Mi'.

### apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
- Autoscaling enabled with a maximum of 4 replicas.
- Updated memory requests to '512Mi'.
- Updated memory limits to '1024Mi'.

### apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
- Autoscaling enabled with a maximum of 4 replicas.
- Updated memory requests to '1536Mi'.
- Updated memory limits to '2048Mi'.

### apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
- Autoscaling enabled with a maximum of 4 replicas.
- Updated memory requests to '2048Mi'.
- Updated memory limits to '3072Mi'.

### apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
- Autoscaling enabled with a maximum of 4 replicas.
- Updated memory requests to '512Mi'.
- Updated memory limits to '1024Mi'.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
- Enabled autoscaling with a maximum of 4 replicas
- Increased memoryRequests to '1536Mi' and memoryLimits to '2048Mi'

### apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
- Introduced autoscaling with a maximum of 4 replicas
- Adjusted memoryRequests to '512Mi' and memoryLimits to '1024Mi'
- Specified cpuRequests as 200m and cpuLimits as 1000m

### apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
- Implemented autoscaling with a maximum of 4 replicas
- Raised memoryRequests to '2048Mi' and memoryLimits to '3072Mi'

### apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
- Enabled autoscaling with a maximum of 4 replicas
- Set memoryRequests to '3072Mi' and memoryLimits to '4096Mi'

### apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
- Added autoscaling with a maximum of 4 replicas
- Adjusted memoryRequests to '512Mi' and memoryLimits to '1024Mi'
- Specified cpuRequests as 100m and cpuLimits as 500m