### PR TITLE
reverting civil service demo to use latest image

### DIFF
--- a/apps/civil/civil-service/demo-image-policy.yaml
+++ b/apps/civil/civil-service/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-civil-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-4592-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-4592-86ce266-20240430105345 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-b86f411-20240430153326 #{"$imagepolicy": "flux-system:demo-civil-service"}
       environment:
         TESTING_SUPPORT_ENABLED: true
         EM_CCD_ORCHESTRATOR_URL: http://em-ccd-orchestrator-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


### apps/civil/civil-service/demo-image-policy.yaml
- Removed annotation `hmcts.github.com/prod-automated: disabled`
- Removed `filterTags` and `policy` sections

### apps/civil/civil-service/demo.yaml
- Updated the `java` image tag from `pr-4592-86ce266-20240430105345` to `prod-b86f411-20240430153326`