### PR TITLE
DTSCCI-000 test default feign url for RuntimeService

### DIFF
--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -22,6 +22,7 @@ spec:
         CUI_URL: https://moneyclaims.demo.platform.hmcts.net
         CUI_URL_RESPOND_TO_CLAIM: https://moneyclaims.demo.platform.hmcts.net/first-contact/start
         OCMC_CLIENT_URL: https://moneyclaims1.demo.platform.hmcts.net
+        FEIGN_CLIENT_CONFIG_DEFAULT: http://camunda-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal/engine-rest/
       keyVaults:
         civil:
           resourceGroup: civil


### PR DESCRIPTION


## 🤖GIPPI PR SUMMARY🤖


- demo.yaml - Added a new FEIGN_CLIENT_CONFIG_DEFAULT with a dynamic URL using template variables.