### PR TITLE
LAU test if spot instances failing to spin pods

### DIFF
--- a/apps/lau/lau-case-backend/aat.yaml
+++ b/apps/lau/lau-case-backend/aat.yaml
@@ -6,5 +6,7 @@ spec:
   releaseName: lau-case-backend
   values:
     java:
+      spotInstances:
+        enabled: false
       environment:
         DUMMY_RESTART_VAR: 1

--- a/apps/lau/lau-frontend/aat.yaml
+++ b/apps/lau/lau-frontend/aat.yaml
@@ -1,12 +1,9 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: lau-idam-backend
+  name: lau-frontend
 spec:
-  releaseName: lau-idam-backend
   values:
-    java:
+    nodejs:
       spotInstances:
         enabled: false
-      environment:
-        DUMMY_RESTART_VAR: 1


### PR DESCRIPTION
### Change description ###
Disable spot instances on aat for lau apps


## 🤖GIPPI PR SUMMARY🤖


- Updated `aat.yaml` in `lau-case-backend`, added a new configuration to disable spot instances for the Java service.
- Added a new file `aat.yaml` in `lau-frontend` with configurations to disable spot instances for the Node.js service.
- Updated `aat.yaml` in `lau-idam-backend`, added a new configuration to disable spot instances for the Java service.