### PR TITLE
deploy dtspb-4138 to demo for testing

### DIFF
--- a/apps/probate/probate-back-office/demo-image-policy.yaml
+++ b/apps/probate/probate-back-office/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2568-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2556-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link (if applicable)
resolves https://tools.hmcts.net/jira/browse/DTSPB-4138



## 🤖GIPPI PR SUMMARY🤖


### apps/probate/probate-back-office/demo-image-policy.yaml
- Changed the `filterTags` pattern from '^pr-2568-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-2556-[a-f0-9]+-(?P<ts>[0-9]+)' for the automated demo image policy.