### PR TITLE
CUI disable spot instances as they dont work

### DIFF
--- a/apps/cui/cui-ra/aat.yaml
+++ b/apps/cui/cui-ra/aat.yaml
@@ -5,5 +5,7 @@ metadata:
 spec:
   values:
     nodejs:
+      spotInstances:
+        enabled: false
       environment:
         DEMO_ENABLED: 'true'


### PR DESCRIPTION
### Change description ###
Disable spot instances as they don't work on AAT01


## 🤖GIPPI PR SUMMARY🤖


### apps/cui/cui-ra/aat.yaml
- Added a new configuration for `spotInstances` with `enabled` set to `false` under `nodejs` section in the `spec` values.