### PR TITLE
RET-5035

### DIFF
--- a/apps/et/et-cos/ithc-image-policy.yaml
+++ b/apps/et/et-cos/ithc-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1801-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/et/et-cos/ithc.yaml
+++ b/apps/et/et-cos/ithc.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: et-cos
   values:
     java:
-      image: hmctspublic.azurecr.io/et/cos:pr-1801-c1469e3-20240416102457 #{"$imagepolicy": "flux-system:ithc-et-cos"}
+      image: hmctspublic.azurecr.io/et/cos:prod-9a48933-20240501130316 #{"$imagepolicy": "flux-system:ithc-et-cos"}
       environment:
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-ithc.service.core-compute-ithc.internal
         AAC_URL: http://aac-manage-case-assignment-ithc.service.core-compute-ithc.internal

--- a/apps/et/et-msg-handler/ithc-image-policy.yaml
+++ b/apps/et/et-msg-handler/ithc-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-392-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/et/et-msg-handler/ithc.yaml
+++ b/apps/et/et-msg-handler/ithc.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: et-msg-handler
   values:
     java:
-      image: hmctspublic.azurecr.io/et/msg-handler:pr-392-c8a8e40-20240415125322 #{"$imagepolicy": "flux-system:ithc-et-msg-handler"}
+      image: hmctspublic.azurecr.io/et/msg-handler:prod-46f2218-20240430072750 #{"$imagepolicy": "flux-system:ithc-et-msg-handler"}
       environment:
         CCD_GATEWAY_BASE_URL: https://manage-case.ithc.platform.hmcts.net
         ET_MSG_HANDLER_POSTGRES_DATABASE: et_cos

--- a/apps/et/et-sya/ithc-image-policy.yaml
+++ b/apps/et/et-sya/ithc-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1266-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/et/et-sya/ithc.yaml
+++ b/apps/et/et-sya/ithc.yaml
@@ -7,5 +7,5 @@ spec:
   releaseName: et-sya
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/et/sya:pr-1266-b646729-20240415142036 #{"$imagepolicy": "flux-system:ithc-et-sya"}
+      image: hmctspublic.azurecr.io/et/sya:prod-c7a4c36-20240501080259 #{"$imagepolicy": "flux-system:ithc-et-sya"}
       ingressHost: et-sya.ithc.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RET-5035

-----

### Change description ###

Update for having RET-5035 deployed on ITHC

-----

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖GIPPI PR SUMMARY🤖


- et-cos/ithc-image-policy.yaml
  - Changed the pattern from '^pr-1801-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' and updated the extract and policy.

- et-cos/ithc.yaml
  - Updated the image from 'hmctspublic.azurecr.io/et/cos:pr-1801-c1469e3-20240416102457' to 'hmctspublic.azurecr.io/et/cos:prod-9a48933-20240501130316' and environment variables.

- et-msg-handler/ithc-image-policy.yaml
  - Changed the pattern from '^pr-392-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' and updated the extract and policy.

- et-msg-handler/ithc.yaml
  - Updated the image from 'hmctspublic.azurecr.io/et/msg-handler:pr-392-c8a8e40-20240415125322' to 'hmctspublic.azurecr.io/et/msg-handler:prod-46f2218-20240430072750' and environment variables.

- et-sya/ithc-image-policy.yaml
  - Changed the pattern from '^pr-1266-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' and updated the extract and policy.

- et-sya/ithc.yaml
  - Updated the image from 'hmctspublic.azurecr.io/et/sya:pr-1266-b646729-20240415142036' to 'hmctspublic.azurecr.io/et/sya:prod-c7a4c36-20240501080259' and ingressHost.