### PR TITLE
DTSPO-17365-Testing Camunda upgrade

### DIFF
--- a/apps/camunda/camunda-api/ithc.yaml
+++ b/apps/camunda/camunda-api/ithc.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivate.azurecr.io/camunda/bpm:pr-814-6ada93f-20240501171715
       environment:
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         DUMMY_REDEPLOY_VAR: false

--- a/apps/camunda/camunda-ui/ithc.yaml
+++ b/apps/camunda/camunda-ui/ithc.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivate.azurecr.io/camunda/bpm:pr-814-6ada93f-20240501171715
       ingressClass: traefik


### PR DESCRIPTION
### Jira link (if applicable)

[DTSPO-17365](https://tools.hmcts.net/jira/browse/DTSPO-17365)

### Change description ###

Testing Camunda upgrade version 21.0 on ithc 
https://github.com/hmcts/camunda-bpm/pull/814


## 🤖GIPPI PR SUMMARY🤖


### apps/camunda/camunda-api/ithc.yaml
- Added a new `java` image with the specified version: `hmctsprivate.azurecr.io/camunda/bpm:pr-814-6ada93f-20240501171715`

### apps/camunda/camunda-ui/ithc.yaml
- Added a new `java` image with the specified version: `hmctsprivate.azurecr.io/camunda/bpm:pr-814-6ada93f-20240501171715`
- Updated the `ingressClass` to `traefik`