### PR TITLE
Test java and appinsights upgrade in sbox

### DIFF
--- a/apps/rpe/pdf-service/sbox.yaml
+++ b/apps/rpe/pdf-service/sbox.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/rpe/pdf-service:pr-753-2bbbf05-20240502084301
+      image: hmctspublic.azurecr.io/rpe/pdf-service:pr-753-db2bcd7-20240502093307


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17366


### Change description ###
- Testing app insights agent upgrade due to error in pod: 
`2024-05-02 08:29:01.086Z ERROR c.m.applicationinsights.agent Application Insights Java Agent 3.4.10 startup failed (PID 1)`
- https://github.com/hmcts/rpe-pdf-service/pull/753
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


- Updated `sbox.yaml`: Updated the Docker image version for the pdf-service to `hmctspublic.azurecr.io/rpe/pdf-service:pr-753-db2bcd7-20240502093307`.