### PR TITLE
ADOP-2323-fee-service-workround: Fee service down in ITHC

### DIFF
--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -10,7 +10,6 @@ spec:
       image: hmctspublic.azurecr.io/adoption/cos-api:prod-7f6568e-20240501060337 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
         APP_INSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
-        FEE_LOOKUP_URL: 'http://fees-register-api-aat.service.core-compute-aat.internal/fees-register/fees/lookup'
       keyVaults:
         adoption:
           secrets:

--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -10,6 +10,7 @@ spec:
       image: hmctspublic.azurecr.io/adoption/cos-api:prod-7f6568e-20240501060337 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
         APP_INSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
+        FEE_LOOKUP_URL: 'http://fees-register-api-ithc.service.core-compute-ithc.internal/fees-register/fees/lookup'
       keyVaults:
         adoption:
           secrets:

--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -10,7 +10,7 @@ spec:
       image: hmctspublic.azurecr.io/adoption/cos-api:prod-7f6568e-20240501060337 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
         APP_INSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
-        FEE_LOOKUP_URL: 'http://fees-register-api-ithc.service.core-compute-ithc.internal/fees-register/fees/lookup'
+        FEE_LOOKUP_URL: 'http://fees-register-api-aat.service.core-compute-aat.internal/fees-register/fees/lookup'
       keyVaults:
         adoption:
           secrets:

--- a/apps/adoption/adoption-web/ithc.yaml
+++ b/apps/adoption/adoption-web/ithc.yaml
@@ -14,3 +14,4 @@ spec:
         APPINSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
         SECURE_COOKIE: 'true'
         REDIS_PORT: 6380
+        FEE_LOOKUP_URL: 'http://fees-register-api-aat.service.core-compute-aat.internal/fees-register/fees/lookup'


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/ADOP-2323

### Change description ###

Redirecting to working fee service
- [x] Does this PR introduce a breaking change






## 🤖GIPPI PR SUMMARY🤖


### apps/adoption/adoption-web/ithc.yaml
- Added `FEE_LOOKUP_URL` with value `'http://fees-register-api-aat.service.core-compute-aat.internal/fees-register/fees/lookup'` 🔧