### PR TITLE
ADOP-2323-ITHC-preview-image: Removing ITHC fee override to AAT

### DIFF
--- a/apps/adoption/adoption-web/ithc.yaml
+++ b/apps/adoption/adoption-web/ithc.yaml
@@ -14,4 +14,4 @@ spec:
         APPINSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
         SECURE_COOKIE: 'true'
         REDIS_PORT: 6380
-        FEE_LOOKUP_URL: 'http://fees-register-api-aat.service.core-compute-aat.internal/fees-register/fees/lookup'
+

--- a/apps/adoption/adoption-web/ithc.yaml
+++ b/apps/adoption/adoption-web/ithc.yaml
@@ -14,4 +14,3 @@ spec:
         APPINSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
         SECURE_COOKIE: 'true'
         REDIS_PORT: 6380
-


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/ADOP-2323

### Change description ###

Reverting fee to ITHC version of service for the ITHC env.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change




## 🤖GIPPI PR SUMMARY🤖


### apps/adoption/adoption-web/ithc.yaml
- Removed the `FEE_LOOKUP_URL` environment variable.