### PR TITLE
Revert "AM-3111 Stop AM in Prod 2 Postgres Migration"

### DIFF
--- a/apps/am/am-judicial-booking-service/prod.yaml
+++ b/apps/am/am-judicial-booking-service/prod.yaml
@@ -10,4 +10,3 @@ spec:
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
         IDAM_USER_URL: https://idam-api.platform.hmcts.net
         APPLICATION_LOGGING_LEVEL: INFO
-      replicas: 0

--- a/apps/am/am-org-role-mapping-service/prod.yaml
+++ b/apps/am/am-org-role-mapping-service/prod.yaml
@@ -11,4 +11,3 @@ spec:
         IDAM_USER_URL: https://idam-api.platform.hmcts.net
         APPLICATION_LOGGING_LEVEL: INFO
         DUMMY_VAL: dummyval
-      replicas: 0

--- a/apps/am/am-role-assignment-batch-service/prod.yaml
+++ b/apps/am/am-role-assignment-batch-service/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 05 * * *"
+      schedule: "00 22 * * *"
       environment:
         DELETE_ORG: true
         CCD_AM_MIGRATION_MASTER_FLAG: false

--- a/apps/am/am-role-assignment-refresh-batch/prod.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "00 05 * * *"
+      schedule: "00 22 * * *"
       environment:
         DELETE_ORG: true
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o

--- a/apps/am/am-role-assignment-service/prod.yaml
+++ b/apps/am/am-role-assignment-service/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      replicas: 0
+      replicas: 5
       memoryRequests: "1024Mi"
       memoryLimits: "2048Mi"
       cpuRequests: "1000m"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#30581

## 🤖GIPPI PR SUMMARY🤖


- `am-judicial-booking-service/prod.yaml`:
  - Removed the setting for `replicas`.

- `am-org-role-mapping-service/prod.yaml`:
  - Removed the setting for `replicas`.

- `am-role-assignment-batch-service/prod.yaml`:
  - Updated the job schedule from \"0 05 * * *\" to \"00 22 * * *\".

- `am-role-assignment-refresh-batch/prod.yaml`:
  - Updated the job schedule from \"00 05 * * *\" to \"00 22 * * *\".

- `am-role-assignment-service/prod.yaml`:
  - Updated the setting for `replicas` to 5 and adjusted the memory and CPU configurations.