### PR TITLE
AM_3038 Connect to v15 JBS Prod - Host and User hardcoded in prod yaml

### DIFF
--- a/apps/am/am-judicial-booking-service/prod.yaml
+++ b/apps/am/am-judicial-booking-service/prod.yaml
@@ -10,3 +10,5 @@ spec:
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
         IDAM_USER_URL: https://idam-api.platform.hmcts.net
         APPLICATION_LOGGING_LEVEL: INFO
+        JUDICIAL_BOOKING_SERVICE_POSTGRES_HOST: am-judicial-booking-service-postgres-db-v15-prod.postgres.database.azure.com
+        JUDICIAL_BOOKING_SERVICE_POSTGRES_USER: pgadmin


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3038
Connect to v15 JBS Prod - Host and User hardcoded in prod yaml

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


### apps/am/am-judicial-booking-service/prod.yaml
- Added environment variables `JUDICIAL_BOOKING_SERVICE_POSTGRES_HOST` and `JUDICIAL_BOOKING_SERVICE_POSTGRES_USER` for connecting to a PostgreSQL database in the production environment.