### PR TITLE
AM_3039 Connect to v15 RAS Prod - Host and User hardcoded in prod yaml

### DIFF
--- a/apps/am/am-role-assignment-service/prod.yaml
+++ b/apps/am/am-role-assignment-service/prod.yaml
@@ -18,3 +18,5 @@ spec:
         APPLICATION_LOGGING_LEVEL: INFO
         BYPASS_ORG_DROOL_RULE: false
         MAX_POOL_SIZE: 20
+        ROLE_ASSIGNMENT_DB_HOST: am-role-assignment-service-postgres-db-v15-prod.postgres.database.azure.com
+        ROLE_ASSIGNMENT_DB_USERNAME: pgadmin


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3039
Connect to v15 RAS Prod - Host and User hardcoded in prod yaml

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


### apps/am/am-role-assignment-service/prod.yaml
- Added new environment variables `ROLE_ASSIGNMENT_DB_HOST` and `ROLE_ASSIGNMENT_DB_USERNAME`. 
- `ROLE_ASSIGNMENT_DB_HOST` is set to `am-role-assignment-service-postgres-db-v15-prod.postgres.database.azure.com` and `ROLE_ASSIGNMENT_DB_USERNAME` is set to `pgadmin`.