### PR TITLE
AM_3040 Connect to v15 ORM Prod - Host and User hardcoded in prod yaml

### DIFF
--- a/apps/am/am-org-role-mapping-service/prod.yaml
+++ b/apps/am/am-org-role-mapping-service/prod.yaml
@@ -11,3 +11,5 @@ spec:
         IDAM_USER_URL: https://idam-api.platform.hmcts.net
         APPLICATION_LOGGING_LEVEL: INFO
         DUMMY_VAL: dummyval
+        ORG_ROLE_MAPPING_DB_HOST: am-org-role-mapping-service-postgres-db-v15-prod.postgres.database.azure.com
+        ORG_ROLE_MAPPING_DB_USERNAME: pgadmin


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3040
Connect to v15 ORM Prod - Host and User hardcoded in prod yaml

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


### apps/am/am-org-role-mapping-service/prod.yaml
- Added environment variables for ORG_ROLE_MAPPING_DB_HOST and ORG_ROLE_MAPPING_DB_USERNAME.
- Set ORG_ROLE_MAPPING_DB_HOST to am-org-role-mapping-service-postgres-db-v15-prod.postgres.database.azure.com.
- Set ORG_ROLE_MAPPING_DB_USERNAME to pgadmin.