### PR TITLE
upgrde traefik version to 27.0.2

### DIFF
--- a/apps/admin/traefik2/prod/00.yaml
+++ b/apps/admin/traefik2/prod/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 27.0.2
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/prod/01.yaml
+++ b/apps/admin/traefik2/prod/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 27.0.2
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -62,3 +62,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/prod/base/kustomize.yaml
   - path: ../../../apps/admin/prod/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml


### PR DESCRIPTION
### Jira link (https://tools.hmcts.net/jira/browse/DTSPO-17572)

upgrade traefik to version 27.0.2 in prod env

### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


- `apps/admin/traefik2/prod/00.yaml` 📦
  - Added new chart for Traefik with version 27.0.2.
  
- `apps/admin/traefik2/prod/01.yaml` 📦
  - Added new chart for Traefik with version 27.0.2.
  
- `clusters/prod/base/kustomization.yaml` 🔄
  - Updated paths for kustomization, added a new path for Traefik CRDs upgrade.