### PR TITLE
LAU enable spot instances on demo

### DIFF
--- a/apps/lau/lau-frontend/demo.yaml
+++ b/apps/lau/lau-frontend/demo.yaml
@@ -6,3 +6,5 @@ spec:
   values:
     nodejs:
       image: hmctspublic.azurecr.io/lau/frontend:prod-799793e-20240506144833 #{"$imagepolicy": "flux-system:demo-lau-frontend"}
+      spotInstances:
+        enabled: true


### PR DESCRIPTION
### Change description ###
enable spot instances on demo, as it should work fine


## 🤖GIPPI PR SUMMARY🤖


- **demo.yaml**:
  - Added a new configuration for enabling spot instances.