### PR TITLE
Deploy test service to sbox

### DIFF
--- a/apps/rpe/automation/kustomization.yaml
+++ b/apps/rpe/automation/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - ../pdf-service/pdf-service-test-image-policy.yaml
   - ../rpe-service-auth-provider/image-repo.yaml
   - ../rpe-service-auth-provider/image-policy.yaml
+  - ../rpe-test-spring-java-upgrade/image-repo.yaml
+  - ../rpe-test-spring-java-upgrade/image-policy.yaml

--- a/apps/rpe/rpe-test-spring-java-upgrade/image-policy.yaml
+++ b/apps/rpe/rpe-test-spring-java-upgrade/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: rpe-test-spring-java-upgrade
+spec:
+  imageRepositoryRef:
+    name: rpe-test-spring-java-upgrade

--- a/apps/rpe/rpe-test-spring-java-upgrade/image-repo.yaml
+++ b/apps/rpe/rpe-test-spring-java-upgrade/image-repo.yaml
@@ -2,7 +2,5 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: rpe-test-spring-java-upgrade
-  annotations:
-    hmcts.github.com/image-registry: hmctssandbox
 spec:
-  image: hmctssandbox.azurecr.io/rpe/test-spring-java-upgrade
+  image: hmctspublic.azurecr.io/rpe/test-spring-java-upgrade

--- a/apps/rpe/rpe-test-spring-java-upgrade/image-repo.yaml
+++ b/apps/rpe/rpe-test-spring-java-upgrade/image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: rpe-test-spring-java-upgrade
+  annotations:
+    hmcts.github.com/image-registry: hmctssandbox
+spec:
+  image: hmctssandbox.azurecr.io/rpe/test-spring-java-upgrade

--- a/apps/rpe/rpe-test-spring-java-upgrade/rpe-test-spring-java-upgrade.yaml
+++ b/apps/rpe/rpe-test-spring-java-upgrade/rpe-test-spring-java-upgrade.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: rpe-test-spring-java-upgrade
+  namespace: rpe
+spec:
+  releaseName: rpe-test-spring-java-upgrade
+  chart:
+    spec:
+      chart: ./stable/rpe-test-spring-java-upgrade
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m
+  values:
+    java:
+      image: hmctssandbox.azurecr.io/rpe/test-spring-java-upgrade:latest # {"$imagepolicy": "flux-system:rpe-test-spring-java-upgrade"}
+      disableTraefikTls: true

--- a/apps/rpe/sbox/base/kustomization.yaml
+++ b/apps/rpe/sbox/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../../base/workload-identity
   - ../../draft-store-service/draft-store-service.yaml
   - ../../rpe-service-auth-provider/rpe-service-auth-provider.yaml
+  - ../../rpe-test-spring-java-upgrade/rpe-test-spring-java-upgrade.yaml
 namespace: rpe
 patches:
   - path: ../../draft-store-service/sbox.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17421


### Change description ###
- Deploys copy of spring-boot-template(with Java 21) to sbox
- Used to test upgrade to Java 21
- Will be reverted once confirmed upgrade was successful

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


- Updated `apps/rpe/automation/kustomization.yaml`:
  - Added references to `rpe-test-spring-java-upgrade` image repository and image policy.

- Created `apps/rpe/rpe-test-spring-java-upgrade/image-policy.yaml`:
  - Added an image policy for `rpe-test-spring-java-upgrade`.

- Created `apps/rpe/rpe-test-spring-java-upgrade/image-repo.yaml`:
  - Created an image repository for `rpe-test-spring-java-upgrade`.

- Created `apps/rpe/rpe-test-spring-java-upgrade/rpe-test-spring-java-upgrade.yaml`:
  - Added a HelmRelease configuration for `rpe-test-spring-java-upgrade`.

- Updated `apps/rpe/sbox/base/kustomization.yaml`:
  - Added a reference to `rpe-test-spring-java-upgrade/rpe-test-spring-java-upgrade.yaml`.