### PR TITLE
Enable spot instances on demo

### DIFF
--- a/apps/cui/cui-ra/demo.yaml
+++ b/apps/cui/cui-ra/demo.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   values:
     nodejs:
+      spotInstances:
+        enabled: true


### PR DESCRIPTION
### Change description ###
Enable spot instances on demo


## 🤖GIPPI PR SUMMARY🤖


- Changed file: `apps/cui/cui-ra/demo.yaml`
- Added a new feature for `nodejs` by enabling `spotInstances` with the value of `true`.