### PR TITLE
ADOP-2443-flip-aat-ithc-perftest-prod-cos-pods: yamls changed to RELEASE: AGAIN

### DIFF
--- a/apps/adoption/adoption-cos-api/aat.yaml
+++ b/apps/adoption/adoption-cos-api/aat.yaml
@@ -8,4 +8,5 @@ spec:
   values:
     java:
       environment:
+        RELEASE: AGAIN
         APP_INSIGHTS_KEY: '273cc8cd-c511-49ae-9988-9debe01d54d5'

--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -9,6 +9,7 @@ spec:
     java:
       image: hmctspublic.azurecr.io/adoption/cos-api:prod-7f6568e-20240501060337 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
+        RELEASE: AGAIN
         APP_INSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
       keyVaults:
         adoption:

--- a/apps/adoption/adoption-cos-api/perftest.yaml
+++ b/apps/adoption/adoption-cos-api/perftest.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     java:
       environment:
+        RELEASE: AGAIN
         APP_INSIGHTS_KEY: '8007ea1d-b655-4399-9d4c-b6bc0a4728fb'
       keyVaults:
         adoption:

--- a/apps/adoption/adoption-cos-api/prod.yaml
+++ b/apps/adoption/adoption-cos-api/prod.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     java:
       environment:
+        RELEASE: AGAIN
         APP_INSIGHTS_KEY: 'e792bfea-7fdb-492a-92f6-5501c29b2fe3'
         NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/
         IDAM_API_REDIRECT_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/receiver


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/ADOP-2443

### Change description ###

The secrets have been changed with the rotated GOV.UK Notify key in AAT, ITHC, perftest and Prod.  This is the Flux change to flip the pods to pick up the change.

### Checklist

- [ ] Does this PR introduce a breaking change


## 🤖GIPPI PR SUMMARY🤖


### apps/adoption/adoption-cos-api/aat.yaml
- Added a new environment variable `RELEASE` with the value 'AGAIN'.
- Updated the value of the `APP_INSIGHTS_KEY`.

### apps/adoption/adoption-cos-api/ithc.yaml
- Added a new environment variable `RELEASE` with the value 'AGAIN'.
- Updated the value of the `APP_INSIGHTS_KEY`.

### apps/adoption/adoption-cos-api/perftest.yaml
- Added a new environment variable `RELEASE` with the value 'AGAIN'.
- Updated the value of the `APP_INSIGHTS_KEY`.

### apps/adoption/adoption-cos-api/prod.yaml
- Added a new environment variable `RELEASE` with the value 'AGAIN'.
- Updated the value of the `APP_INSIGHTS_KEY`.
- Updated the value of `NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL` and `IDAM_API_REDIRECT_URL`.