### PR TITLE
DTSPB-4078 pointing Probate FE demo to PR1999

### DIFF
--- a/apps/probate/probate-frontend/demo-image-policy.yaml
+++ b/apps/probate/probate-frontend/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2005-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1999-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-frontend/demo.yaml
+++ b/apps/probate/probate-frontend/demo.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     nodejs:
       ingressHost: probate.demo.platform.hmcts.net
-      image: hmctspublic.azurecr.io/probate/frontend:pr-2005-751eb87-20240507143707 #{"$imagepolicy": "flux-system:demo-probate-frontend"}
+      image: hmctspublic.azurecr.io/probate/frontend:pr-1999-bec7fa9-20240509122004 #{"$imagepolicy": "flux-system:demo-probate-frontend"}
       environment:
         VAR_FV2: demo-2
         EXCEPTED_ESTATE_DATE_OF_DEATH: "2021-11-01"

--- a/apps/probate/probate-orchestrator-service/demo-image-policy.yaml
+++ b/apps/probate/probate-orchestrator-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-896-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-orchestrator-service/demo.yaml
+++ b/apps/probate/probate-orchestrator-service/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/probate/orchestrator-service:prod-ff84c13-20240509090141 #{"$imagepolicy": "flux-system:demo-probate-orchestrator-service"}
+      image: hmctspublic.azurecr.io/probate/orchestrator-service:pr-896-4c2980e-20240503104526 #{"$imagepolicy": "flux-system:demo-probate-orchestrator-service"}
       ingressHost: probate-orchestrator-service-demo.service.core-compute-demo.internal
       environment:
         VAR_FV2: demo-trig2


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `apps/probate/probate-frontend/demo-image-policy.yaml`:
  - Changed the pattern to match a different format for filterTags.

- `apps/probate/probate-frontend/demo.yaml`:
  - Updated the image version for the frontend.

- `apps/probate/probate-orchestrator-service/demo-image-policy.yaml`:
  - Updated the pattern for filterTags.

- `apps/probate/probate-orchestrator-service/demo.yaml`:
  - Changed the image version for the orchestrator service.