### PR TITLE
fix: revert ccd-data-store-api to previous image tag

### DIFF
--- a/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
+++ b/apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
@@ -8,7 +8,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-2c19752-20240509132628 #{"$imagepolicy": "flux-system:ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-7ba80a3-20240417115000
       environment:
         CCD_MULTIPARTY_FIX_ENABLED: true
         CCD_MULTIPARTY_CASE_TYPES: "*"


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/ccd/ccd-data-store-api/ccd-data-store-api.yaml
- Updated the image tag for the `ccd/data-store-api` to `prod-7ba80a3-20240417115000` 📦