### PR TITLE
DTSPB-4168 Pointing Preftest Probate Frontend to PR1999

### DIFF
--- a/apps/probate/probate-frontend/perftest.yaml
+++ b/apps/probate/probate-frontend/perftest.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
+      image: hmctspublic.azurecr.io/probate/frontend:pr-1999-bec7fa9-20240509122004 #{"$imagepolicy": "flux-system:perftest-probate-frontend"}
       environment:
         EQUALITY_URL: https://pcq.perftest.platform.hmcts.net
         LAUNCHDARKLY_ENABLED: true

--- a/apps/probate/probate-orchestrator-service/perftest-image-policy.yaml
+++ b/apps/probate/probate-orchestrator-service/perftest-image-policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
-  name: perftest-probate-frontend
+  name: perftest-probate-orchestrator-service
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1999-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-896-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:
       order: asc
   imageRepositoryRef:
-    name: probate-frontend
+    name: probate-orchestrator-service

--- a/apps/probate/probate-orchestrator-service/perftest.yaml
+++ b/apps/probate/probate-orchestrator-service/perftest.yaml
@@ -7,5 +7,6 @@ spec:
   values:
     java:
       ingressHost: probate-orchestrator-service-perftest.service.core-compute-perftest.internal
+      image: hmctspublic.azurecr.io/probate/orchestrator-service:pr-896-4c2980e-20240503104526 #{"$imagepolicy": "flux-system:perftest-probate-orchestrator-service"}
       environment:
         VAR_FV2: perftest-trig1


### PR DESCRIPTION
### Jira link (if applicable)

DTSPB-4168


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated `perftest-image-policy.yaml` in `probate-frontend`: Changed the pattern to `'^pr-1999-[a-f0-9]+-(?P<ts>[0-9]+)'`.
- Updated `perftest.yaml` in `probate-frontend`: Added a new image `hmctspublic.azurecr.io/probate/frontend:pr-1999-bec7fa9-20240509122004` for `nodejs`.
- Added `perftest-image-policy.yaml` in `probate-orchestrator-service` with the image policy configuration for the perftest environment.
- Updated `perftest.yaml` in `probate-orchestrator-service`: Added a new image `hmctspublic.azurecr.io/probate/orchestrator-service:pr-896-4c2980e-20240503104526` for `java`.