### PR TITLE
DTSPB-4168 Pointing Demo Probate CVE to PR_709

### DIFF
--- a/apps/probate/probate-caveats-fe/demo-image-policy.yaml
+++ b/apps/probate/probate-caveats-fe/demo-image-policy.yaml
@@ -3,5 +3,8 @@ kind: ImagePolicy
 metadata:
   name: demo-probate-caveats-fe
 spec:
+  filterTags:
+    pattern: '^pr-709-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
   imageRepositoryRef:
     name: probate-caveats-fe

--- a/apps/probate/probate-caveats-fe/demo.yaml
+++ b/apps/probate/probate-caveats-fe/demo.yaml
@@ -7,5 +7,5 @@ spec:
   values:
     nodejs:
       enableOAuth: true
-      image: hmctspublic.azurecr.io/probate/caveats-fe:prod-d9d7036-20240424111830 #{"$imagepolicy": "flux-system:probate-caveats-fe"}
+      image: hmctspublic.azurecr.io/probate/caveats-fe:pr-709-3d222f0-20240510153457 #{"$imagepolicy": "flux-system:demo-probate-caveats-fe"}
       VAR_FV2_DEMO: demo-1


### PR DESCRIPTION
### Jira link (if applicable)

DTSPB-4168

### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated `demo-image-policy.yaml`: Added a new filterTags section with a pattern and extract fields to extract an alphanumeric string based on a pattern from image tags.
- Updated `demo.yaml`: Updated the image field to `hmctspublic.azurecr.io/probate/caveats-fe:pr-709-3d222f0-20240510153457`.