### PR TITLE
Updating minReplicas for CCD Data Store Perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -10,6 +10,7 @@ spec:
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-2c19752-20240509132628 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
         enabled: true
+        minReplicas: 2
         maxReplicas: 15
       memoryRequests: '4096Mi'
       memoryLimits: '5120Mi'


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Updating minReplicas for CCD Data Store Perftest for performance testing. Currently being set by app code config to 6