### PR TITLE
[ADOP-2457] Added social worker domain

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -59,6 +59,7 @@ spec:
           - barnardos.org.uk
           - pactcharity.org
           - adoptionteesvalley.org.uk
+          - adoptersforadoption.com
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/ADOP-2457

### Change description ###
Adding new social worker domain.


## 🤖AEP PR SUMMARY🤖


### apps/adoption/adoption-web/adoption-web.yaml
- Added adoptersforadoption.com``` to the list of adoption websites 🌐.