### PR TITLE
DTSPO-17517 bulk scan processor Jenkins builds hang

### DIFF
--- a/apps/bsp/preview/aso/resource-group-old.yaml
+++ b/apps/bsp/preview/aso/resource-group-old.yaml
@@ -8,3 +8,9 @@ metadata:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   location: uksouth
+  tags:
+    builtFrom: https://github.com/hmcts/cnp-flux-config
+    businessArea: CFT
+    environment: development
+    exemptFromAutoLock: "true"
+    application: "${APPLICATION_TAG:-not-set-yet}"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17517

### Change description ###

The problem: the resource group 'bulk-scan-aks-rg' being automatically assigned with a resource lock. The rg belongs to a dev subscription 'dcd-cnp-dev'. 

The fix involves applying the exemption tag `exemptFromAutoLock` to the file `resource-group-old.yaml` belongs to 'bsp' namespace for the `preview` environment


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines