### PR TITLE
Revert civil-service and cui to prod image

### DIFF
--- a/apps/civil/civil-citizen-ui/demo-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-civil-citizen-ui
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-3667-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/demo.yaml
+++ b/apps/civil/civil-citizen-ui/demo.yaml
@@ -12,7 +12,7 @@ spec:
       readinessPeriod: 15
       useInterpodAntiAffinity: true
       ingressHost: moneyclaims.demo.platform.hmcts.net
-      image: hmctspublic.azurecr.io/civil/citizen-ui:pr-3667-6b80de1-20240513092351 #{"$imagepolicy": "flux-system:demo-civil-citizen-ui"}
+      image: hmctspublic.azurecr.io/civil/citizen-ui:prod-cb0fd55-20240513144855 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       keyVaults:
         civil-cui:
           resourceGroup: civil-citizen-ui

--- a/apps/civil/civil-service/demo-image-policy.yaml
+++ b/apps/civil/civil-service/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-civil-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-4608-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-4608-6ecbc29-20240513135102 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-01988f8-20240513135322 #{"$imagepolicy": "flux-system:civil-service"}
       environment:
         TESTING_SUPPORT_ENABLED: true
         EM_CCD_ORCHESTRATOR_URL: http://em-ccd-orchestrator-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Changed in *demo-image-policy.yaml* for *civil-citizen-ui* and *civil-service*: removed annotations for *prod-automated* and updated the *filterTags* and *policy* section.
- Updated *demo.yaml* for *civil-citizen-ui* and *civil-service*: changed the image name to a *prod* image with a new timestamp.