### PR TITLE
CFT IDAM 9.6.2: Index on staleusers

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/api:prod-adf1e51-20240410122103
+      image: hmctspublic.azurecr.io/idam/api:prod-fc2582b-20240510102650
       replicas: 2
       cpuRequests: '160m'
       cpuLimits: '1500m'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SIDM-9201


### Change description ###
The change is in flyway migrations:
* crete or replace an index on staleusers.creationDate.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/idam/idam-api/idam-api.yaml
- Updated the image tag for the `idam/api` container to `prod-fc2582b-20240510102650` from `prod-adf1e51-20240410122103`. The number of replicas has remained at 2, with updated resource requests and limits. 🐳