### PR TITLE
Enable sscs-cron-trigger in prod

### DIFF
--- a/apps/sscs/sscs-cron-trigger/prod.yaml
+++ b/apps/sscs/sscs-cron-trigger/prod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     job:
-      suspend: true
+      suspend: false
       schedule: "0 1 * * *"
       image: hmctspublic.azurecr.io/sscs/cron-trigger:prod-ef94d80-20240508134955 #{"$imagepolicy": "flux-system:sscs-cron-trigger"}
       aadIdentityName: sscs


### PR DESCRIPTION
### Change description ###
Change Request CHG5016234
Enable sscs-cron-trigger in prod



## 🤖AEP PR SUMMARY🤖


- The `prod.yaml` file in `apps/sscs/sscs-cron-trigger` has been updated to change the value of `suspend` from `true` to `false` for the job schedule.
- Additionally, the schedule time has been updated to \"0 1 * * *\".