### PR TITLE
disable prod disposer

### DIFF
--- a/apps/disposer/disposer-idam-user/prod.yaml
+++ b/apps/disposer/disposer-idam-user/prod.yaml
@@ -12,7 +12,7 @@ spec:
       cpuLimits: "2000m"
       environment:
         IDAM_API_URL: "https://idam-api.platform.hmcts.net"
-        DISPOSER_IDAM_USER_ENABLED: true
+        DISPOSER_IDAM_USER_ENABLED: false
         DISPOSER_IDAM_USER_SIMULATION_MODE: true
         DISPOSER_IDAM_USER_BATCH_SIZE: 100
         DISPOSER_IDAM_USER_REQUESTS_LIMIT: 50000


### PR DESCRIPTION
### Change description ###
Disable disposer on prod


## 🤖AEP PR SUMMARY🤖


The file `prod.yaml` in `apps/disposer/disposer-idam-user` was changed:
- The environment variable `DISPOSER_IDAM_USER_ENABLED` was changed from `true` to `false`.