### PR TITLE
[ADOP-2462] Added new social worker domain

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -60,6 +60,7 @@ spec:
           - pactcharity.org
           - adoptionteesvalley.org.uk
           - adoptersforadoption.com
+          - diagrama.org
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/ADOP-2462

### Change description ###
Added new adoption social worker domain to whitelist.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [N/A] README and other documentation has been updated / added (if needed)
- [N/A] tests have been updated / new tests has been added (if needed)
- [N] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/adoption/adoption-web/adoption-web.yaml
- Added `diagrama.org` to the list of domains under `spec` section.
- Updated the values for `COR_VAL`, `WOL_VAL`, and `SMC_VAL`.