### PR TITLE
traefik 90s timeout on preview 00

### DIFF
--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -13,3 +13,10 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
+    additionalArguments:
+      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
+      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
+      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
+      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"
+      - "--entryPoints.web.forwardedHeaders.insecure=true"
+      - "--entryPoints.websecure.forwardedHeaders.insecure=true"


### PR DESCRIPTION
### Change description ###
traefik 90s timeout on preview 00
- Currently Functional tests are > 30s and causing potential error. 

Adding temporary to test theory

## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process