### PR TITLE
[ADOP-2450] Restarting pods after merging flexserver changes

### DIFF
--- a/apps/adoption/adoption-cos-api/prod.yaml
+++ b/apps/adoption/adoption-cos-api/prod.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       environment:
-        RELEASE: AGAIN
+        RELEASE: NOW
         APP_INSIGHTS_KEY: 'e792bfea-7fdb-492a-92f6-5501c29b2fe3'
         NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/
         IDAM_API_REDIRECT_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/receiver


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/ADOP-2450

### Change description ###
Restarting pods after merging flexserver changes (https://github.com/hmcts/cnp-flux-config/pull/31457)



## 🤖AEP PR SUMMARY🤖


### File changed: prod.yaml
- Changed the value of the `RELEASE` environment variable from \"AGAIN\" to \"NOW\" 🔄