### PR TITLE
DTSPO-17582 upgrade ImageRepository API to v1 for app Plum

### DIFF
--- a/apps/cnp/plum-frontend/image-repo.yaml
+++ b/apps/cnp/plum-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: plum-frontend

--- a/apps/cnp/plum-recipe-backend/image-repo.yaml
+++ b/apps/cnp/plum-recipe-backend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: plum-recipe-backend

--- a/apps/cnp/plum-recipe-backend/recipe-backend-test-image-repo.yaml
+++ b/apps/cnp/plum-recipe-backend/recipe-backend-test-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: plum-recipe-backend-recipe-backend-test

--- a/apps/cnp/plum-recipe-receiver/image-repo.yaml
+++ b/apps/cnp/plum-recipe-receiver/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: plum-recipe-receiver


### PR DESCRIPTION
### Jira link (if applicable)

DTSPO-17582 / DTSPO-17587

### Change description ###
upgrade ImageRepository API to v1 for app Plum

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines




## 🤖AEP PR SUMMARY🤖


- Updated `image-repo.yaml` for `plum-frontend`, `plum-recipe-backend`, and `plum-recipe-receiver` to change the `apiVersion` from `v1beta2` to `v1`. 🔄