### PR TITLE
Update div-emca image on demo

### DIFF
--- a/apps/divorce/div-emca/demo-image-policy.yaml
+++ b/apps/divorce/div-emca/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-div-emca
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-424-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: div-emca


### PR DESCRIPTION
### Change description ###
Update div-emca image on demo to latest prod



## 🤖AEP PR SUMMARY🤖


### apps/divorce/div-emca/demo-image-policy.yaml
- Removed annotations and filterTags from the ImagePolicy metadata.
- Updated the policy from alphabetical with ascending order to using the imageRepositoryRef with the name div-emca.