### PR TITLE
point perftest BO to LEV PR

### DIFF
--- a/apps/probate/probate-back-office/perftest-image-policy.yaml
+++ b/apps/probate/probate-back-office/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2568-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-back-office/perftest.yaml
+++ b/apps/probate/probate-back-office/perftest.yaml
@@ -6,12 +6,14 @@ metadata:
 spec:
   values:
     java:
+      image: hmctspublic.azurecr.io/probate/back-office:pr-2568-e8b1d04-20240517125359
       environment:
         CCD_GATEWAY_HOST: https://manage-case.perftest.platform.hmcts.net
         BLOB_STORAGE_SMEEANDFORD_FEATURE_ENABLED: true
         PROBATE_POSTGRESQL_USER: pgadmin
         PROBATE_POSTGRESQL_HOSTNAME: probatemandb-postgres-flexible-db-perftest.postgres.database.azure.com
         PROBATE_POSTGRESQL_PORT: 5432
+        VAR_FV2: perftest
       keyVaults:
         probate:
           secrets:


### PR DESCRIPTION
### Change description ###
point perftest BO to LEV PR

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


The following changes were made in the pull request:

**apps/probate/probate-back-office/perftest-image-policy.yaml**
- Changed the pattern in the filterTags section from '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-2568-[a-f0-9]+-(?P<ts>[0-9]+)'

**apps/probate/probate-back-office/perftest.yaml**
- Added a new value for the java image: hmctspublic.azurecr.io/probate/back-office:pr-2568-e8b1d04-20240517125359
- Added VAR_FV2: perftest to the environment section