### PR TITLE
Update div-emca image on demo

### DIFF
--- a/apps/divorce/div-emca/demo.yaml
+++ b/apps/divorce/div-emca/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/div/emca:prod-4370fd1-20230206144806 #{"$imagepolicy": "flux-system:demo-div-emca"}
+      image: hmctspublic.azurecr.io/div/emca:prod-8295596-20240517113834 #{"$imagepolicy": "flux-system:demo-div-emca"}
       environment:
         IDAM_API_HEALTH_URI: https://idam-api.demo.platform.hmcts.net/health
         IDAM_API_URL: https://idam-api.demo.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
Manual update of div-emca image on demo as flux doesn't seem to be triggering update to latest



## 🤖AEP PR SUMMARY🤖


### apps/divorce/div-emca/demo.yaml
- Updated the `java` image from `hmctspublic.azurecr.io/div/emca:prod-4370fd1-20230206144806` to `hmctspublic.azurecr.io/div/emca:prod-8295596-20240517113834` 🔄