### PR TITLE
Upgrade HelmRepository API to v1 for app Plum

### DIFF
--- a/apps/cnp/sbox/base/descheduler-helmrepo.yaml
+++ b/apps/cnp/sbox/base/descheduler-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: descheduler


### PR DESCRIPTION
### Jira link (if applicable)

DTSPO-17582

### Change description ###

HelmRepository API upgraded to v1

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

## 🤖AEP PR SUMMARY🤖


### apps/cnp/sbox/base/descheduler-helmrepo.yaml
- Updated the `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`

