### PR TITLE
update secrets for logstash fix

### DIFF
--- a/apps/ccd/demo/base/probatemandb.yaml
+++ b/apps/ccd/demo/base/probatemandb.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-    DB_PWD: ENC[AES256_GCM,data:tWhKb2WAQuaHR6bVnQeVzPQGBNH2GdYyTmMGPQ==,iv:jDtJCyXQGhsN8FGKRbDv7ijlcq+4muSWAYN8WEiUiuc=,tag:7hZRfIdZO+8F5YBVDG37Cw==,type:str]
-    DB_URL: ENC[AES256_GCM,data:Zb/i9izs1kO+XRmJGZBTvcUh3AYPZ+bWZPrNX30b9SSosed9nU4IGNMsZkWbx/OtLRibM/PVzNUObtMXrnZdfe+hbPyjhV/ziv+1Z7TkfE4VR5MQk8Hglt6n2ky86+I/BBq7INcb1XS+a1wrHPX0VML6tCY9kUd7vZQB9q+MOAQzFUxkMQ6rwrliB3c=,iv:eGYgBM+K28eNup5lKjEHAq+hDrHCdmRHOp2jU8aLYTQ=,tag:F6dIdppTaKl8xa/mBInuyA==,type:str]
-    DB_USER: ENC[AES256_GCM,data:xPgi418hjegqozQP,iv:xWUaGkd7VmGEZWOlDd/HrRoGL7GzT5FlKLnbRke3rPM=,tag:9nBZ+9/glsvRQygYzAPe6Q==,type:str]
+    DB_PWD: ENC[AES256_GCM,data:D+LqxhJneZHsGi42wjvKj8vAYXMgyd2NoY2chQ==,iv:0h0QEpYVboQ2tEEF3q3PBK22J/tFeEMnvE/5CsUIxeI=,tag:hw5c2Zup5qSIdrA9tAlFDQ==,type:str]
+    DB_URL: ENC[AES256_GCM,data:Lc9Su/sol1KZItPNkx1oC3Hl2vaW7hmQUHi5eDIe0XL9O84LNWGawD7zSTklgm9YxNZAxWyYvBMgmaziIPmYQouGL/HLLV+nSg0uoG4NZ/yRkI4Tn064Lw==,iv:0e7ppg6OoLc1ykCnX8ijOQxZN4akaoLIqts6PPNkrYY=,tag:BtLeSo8EVIAPLJVteGSWLA==,type:str]
+    DB_USER: ENC[AES256_GCM,data:3ZrP0kWXWvZkAKR/,iv:IJCoXfeaFEFNvsKmzdTcdDP2W3zPtIT4pRoWeBrrkhE=,tag:tA04PzYJussEgXKIts7DjQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -16,12 +16,12 @@ sops:
         - vault_url: https://dcdcftappsdemokv.vault.azure.net
           name: sops-key
           version: 7a5cc0c79b02466c86bc594c431e00f7
-          created_at: "2024-03-27T08:53:25Z"
-          enc: QMnXeVtChcMmvxZGpy4KwZzV3XSIH0-3dqQd8gVi8RsvAmWP6v36bGzaoVM453yjuy85kE-l7jjsnt3A1K0iC0S4BnXqzX1eNYEFQXBnZAUhPbvTAA16thiG6wQTpb2mft6oFTARStHske9IbhV2oUp7LnUooK2m8S-jNiPzMRe0DEnHyt8fNPGayt_6-23f-2ykmlsmq5IH-gm2MzfD8UkpX9-XzS_glGZlnvdQ01cslYSLTSVBQGAdq-uBsAP31_gVDOVM9-n6ueln1Ur2RSkyAmqFrJ6bqwcgmSFoGWM3OSfp_UmkRyYMd29kZz9G5qxz61fwBlH5z3gu3Dx1uA
+          created_at: "2024-05-21T08:10:35Z"
+          enc: Sq7cK3w_eUA0Qmrp47forTHEPu3C6MNVjMgc50nzCYemg2k74ElpFRmj46dok1YTwcakvJRSDbiIGCyXdTZinY_UQBCY0JGEPtonHF0uKUnV_uvg_ytuG6DKdGmyjWXb1tbGT5lI51QwLGchGwFyTf5UlvJ9u6imNerNZ4UwierbrgFuN1hLrQho8e36uy-HVq3Gel93C5m0BnhBkZyClPCH1HSCaguqqKI0sW2qmN4HKiBu7oex-ZKYTHm5jb2wvc4p93jvgzcgSKUBfC8iaCL7jTGQ-pdKsetlAttFaOgRN7ZFvHW8feMS__6QEFPSeH00vuTItiSrveS2vuqdWA
     hc_vault: []
     age: []
-    lastmodified: "2024-03-27T08:53:27Z"
-    mac: ENC[AES256_GCM,data:Y0xWRtcOYPxsgr87taBMCYVSCcmjTDy4z2Z/9ib8KrdaJCaymMi6YFoLdrcmXkx9Crrx3/t/aX2uU9g53mGNwIA0HIBXOP1rhi120RZO3kjn0F4DcyxBBLNK+pLzpWXOi/DrwJlEwRoeap230CsNo1IyBjx2i8TszXyXGMmu2XM=,iv:2XEJAWB0qAtjOBYDK6h4jpG9thSB7y5wEaQFm5qly1s=,tag:jFztddpStjh0KvpOUCLMug==,type:str]
+    lastmodified: "2024-05-21T08:10:37Z"
+    mac: ENC[AES256_GCM,data:w8XTUg5HAQn+sqy3rMrlAzjy5mhpFyNS1oEj70sFcTIkDfvHEAtcbK8lMBzI81mwzfaWKdnTnZ43EJgr4KwZ4j20Z/WDrzxsWOZjNp5voYMtzn6/v8Haxn5h5VXllNOCAmEfglsgc7mtlsDmH+rXjmbaPhjbpmIS2QwROCKZI6w=,iv:IXnrJ1skqfoEd/4d6B3tGwMyq3ziD/T5Fh4U9rgXENc=,tag:ORKG/t5LS9v9YxH5b+G+UQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
attempt to fix logstash on demo for probatemandb

## 🤖AEP PR SUMMARY🤖


### apps/ccd/demo/base/probatemandb.yaml
- Updated the DB_PWD, DB_URL, and DB_USER values in the Secret resource.
- Updated `created_at` and `enc` values.
- Updated `lastmodified` and `mac` values.