### PR TITLE
Increasing CCD data store memory in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -13,7 +13,7 @@ spec:
         minReplicas: 2
         maxReplicas: 15
       memoryRequests: '4096Mi'
-      memoryLimits: '5120Mi'
+      memoryLimits: '6144Mi'
       cpuRequests: '1000m'
       cpuLimits: '3000m'
       environment:


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Increasing CCD data store memory in perftest for testing HPA during performance testing



## 🤖AEP PR SUMMARY🤖


- The file `perftest.yaml` in `apps/ccd/ccd-data-store-api` had its `memoryLimits` value updated from `5120Mi` to `6144Mi`.