### PR TITLE
upgrade HelmRelease API to v2 in these disabled apps 

### DIFF
--- a/apps/ccd/ccd-int/ccd-int.yaml.disabled
+++ b/apps/ccd/ccd-int/ccd-int.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-int

--- a/apps/ccd/demo-disabled/ccd-backend-frontend.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-backend-frontend.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-back-front

--- a/apps/ccd/demo-disabled/ccd-backend.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-backend.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-backend

--- a/apps/ccd/demo-disabled/ccd-demo.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-demo.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-demo

--- a/apps/ccd/demo-disabled/ccd-develop.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-develop.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-develop

--- a/apps/ccd/demo-disabled/ccd-full-with-pay.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-full-with-pay.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-full-with-pay

--- a/apps/ccd/demo-disabled/ccd-full.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-full.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-full

--- a/apps/ccd/demo-disabled/ccd-importer.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-importer.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-import

--- a/apps/ccd/demo-disabled/ccd-integration.yaml.disabled
+++ b/apps/ccd/demo-disabled/ccd-integration.yaml.disabled
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-integration

--- a/apps/ccd/demo-disabled/latest-ccd-chart.yaml.disabled
+++ b/apps/ccd/demo-disabled/latest-ccd-chart.yaml.disabled
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: ccd-demo

--- a/docs/app-deployment-v2.md
+++ b/docs/app-deployment-v2.md
@@ -68,7 +68,7 @@ All application deployments are managed with `HelmRelease`.
    ```
 - Add a comment next to `image` section in HelmRelease with ImagePolicy name as shown below.
     ```yaml
-    apiVersion: helm.toolkit.fluxcd.io/v2beta2
+    apiVersion: helm.toolkit.fluxcd.io/v2
     kind: HelmRelease
     metadata:
       name: <component-name>
@@ -106,7 +106,7 @@ If you want to add a new app only to a one environment, see [Add application to 
 - If you wish to override this default behaviour in a specific environment, create a environment patch as described in the previous section and override image automation comment like below: 
 
 ```yaml
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: <component-name>


### PR DESCRIPTION
### Jira link (if applicable)

[DTSPO-17582](https://tools.hmcts.net/jira/browse/DTSPO-17582) / [DTSPO-17587](https://tools.hmcts.net/jira/browse/DTSPO-17587)

### Change description ###
upgrade HelmRelease API to v2 in these disabled apps plus a md file

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines


## 🤖AEP PR SUMMARY🤖


### File Changes
- ccd-int.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-backend-frontend.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-backend.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-demo.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-develop.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-full-with-pay.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-full.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-importer.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- ccd-integration.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- latest-ccd-chart.yaml.disabled
  - Changed apiVersion from v2beta2 to v2 for HelmRelease.
- app-deployment-v2.md
  - Updated examples with `apiVersion: helm.toolkit.fluxcd.io/v2` for HelmRelease.