### PR TITLE
Change DummyVar for  Restart 

### DIFF
--- a/apps/xui/xui-webapp-ac-integration/demo.yaml
+++ b/apps/xui/xui-webapp-ac-integration/demo.yaml
@@ -7,7 +7,7 @@ spec:
     nodejs:
       ingressHost: manage-case-ac-int.demo.platform.hmcts.net
       environment:
-        DUMMY_VAR_FOR_RESTART: 2
+        DUMMY_VAR_FOR_RESTART: 1
         FEATURE_JRD_E_LINKS_V2_ENABLED: true
         FEATURE_SECURE_COOKIE_ENABLED: false
         SERVICES_MARKUP_API: http://em-npa-demo.service.core-compute-demo.internal


### PR DESCRIPTION
Change DummyVar for  Restart  ac-int-demo

## 🤖AEP PR SUMMARY🤖


- **demo.yaml**:
  - Changed the value of `DUMMY_VAR_FOR_RESTART` from 2 to 1.
  - Enabled `FEATURE_JRD_E_LINKS_V2_ENABLED` and disabled `FEATURE_SECURE_COOKIE_ENABLED`.
  - Updated `SERVICES_MARKUP_API` to `http://em-npa-demo.service.core-compute-demo.internal`.