### PR TITLE
Increasing memory on CCD data store in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -13,7 +13,7 @@ spec:
         minReplicas: 2
         maxReplicas: 15
       memoryRequests: '4096Mi'
-      memoryLimits: '5120Mi'
+      memoryLimits: '6144Mi'
       cpuRequests: '1000m'
       cpuLimits: '3000m'
       environment:


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Increasing memory on CCD data store in perftest for HPA performance testing


## 🤖AEP PR SUMMARY🤖


- Modified file: perftest.yaml
- Updated the memoryLimits from '5120Mi' to '6144Mi'