### PR TITLE
Upgrade HelmRepository API to v1 from v1beta2 in all apps

### DIFF
--- a/apps/admin/external-dns-2/external-dns-helmrepo.yaml
+++ b/apps/admin/external-dns-2/external-dns-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-dns

--- a/apps/admin/traefik2/traefik2-helmrepo.yaml
+++ b/apps/admin/traefik2/traefik2-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik

--- a/apps/backstage/backstage/backstage-helmrepo.yaml
+++ b/apps/backstage/backstage/backstage-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: backstage

--- a/apps/ccd/logstash/elastic-helmrepo.yaml
+++ b/apps/ccd/logstash/elastic-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: elastic

--- a/apps/dynatrace/dynatrace-operator-helmrepo.yaml
+++ b/apps/dynatrace/dynatrace-operator-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: dynatrace-operator

--- a/apps/flux-system/base/hmctspublic-helmrepo.yaml
+++ b/apps/flux-system/base/hmctspublic-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: hmctspublic

--- a/apps/jenkins/jenkins/jenkins-helmrepo.yaml
+++ b/apps/jenkins/jenkins/jenkins-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jenkins

--- a/apps/keda/keda/keda-helmrepo.yaml
+++ b/apps/keda/keda/keda-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: keda

--- a/apps/kured/kured/kured-helmrepo.yaml
+++ b/apps/kured/kured/kured-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kured

--- a/apps/monitoring/kube-prometheus-stack/prometheus-helmrepo.yaml
+++ b/apps/monitoring/kube-prometheus-stack/prometheus-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus

--- a/apps/monitoring/node-problem-detector/deliveryhero-helmrepo.yaml
+++ b/apps/monitoring/node-problem-detector/deliveryhero-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: deliveryhero

--- a/apps/monitoring/opentelemetry-collector/opentelemetry-helmrepo.yaml
+++ b/apps/monitoring/opentelemetry-collector/opentelemetry-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: opentelemetry


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17582 
https://tools.hmcts.net/jira/browse/DTSPO-17587


### Change description ###
Upgrade HelmRepository API to v1 from v1beta2 in all apps

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines



## 🤖AEP PR SUMMARY🤖


- `external-dns-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `traefik2-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `backstage-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `elastic-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `dynatrace-operator-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `hmctspublic-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `jenkins-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `keda-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `kured-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `prometheus-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `deliveryhero-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.

- `opentelemetry-helmrepo.yaml`:
  - Changed `apiVersion` from `source.toolkit.fluxcd.io/v1beta2` to `source.toolkit.fluxcd.io/v1`.