### PR TITLE
FACT-1783 SFTP downtime change revert

### DIFF
--- a/apps/bsp/rpe-send-letter-service/prod.yaml
+++ b/apps/bsp/rpe-send-letter-service/prod.yaml
@@ -9,8 +9,8 @@ spec:
       memoryRequests: "1Gi"
       environment:
         SMTP_HOST: smtp.office365.com
-        FTP_DOWNTIME_FROM: 08:00
-        FTP_DOWNTIME_TO: 10:00
+        FTP_DOWNTIME_FROM: 16:00
+        FTP_DOWNTIME_TO: 18:00
         UPLOAD_SUMMARY_REPORT_ENABLED: true
         FILE_CLEANUP_ENABLED: false
         OLD_LETTER_CONTENT_CLEANUP_ENABLED: false


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/FACT-1783

### Change description ###

Revert SFTP downtime change to standard timings.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/bsp/rpe-send-letter-service/prod.yaml
- Changed downtime from 20:00 to 18:00 for FTP.
- Enabled upload summary report and disabled file cleanup and old letter content cleanup.