### PR TITLE
Upgrade ImageUpdateAutomation API to v1beta2 from v1beta1

### DIFF
--- a/apps/flux-system/base/image-update-automation.yaml
+++ b/apps/flux-system/base/image-update-automation.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageUpdateAutomation
 metadata:
   name: imageautomation


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17582
https://tools.hmcts.net/jira/browse/DTSPO-17587

### Change description ###

https://github.com/fluxcd/flux2/releases/tag/v2.3.0
The ImageUpdateAutomation kind was promoted from v1beta1 to v1beta2.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines


## 🤖AEP PR SUMMARY🤖


yaml
- apps/flux-system/base/image-update-automation.yaml
- Update apiVersion from v1beta1 to v1beta2
```