### PR TITLE
CCD-5232 Update ithc.yaml remove secret overrides. 

### DIFF
--- a/apps/ccd/ccd-data-store-api/ithc.yaml
+++ b/apps/ccd/ccd-data-store-api/ithc.yaml
@@ -13,31 +13,6 @@ spec:
       memoryLimits: '5Gi'
       cpuRequests: '1'
       cpuLimits: '3'
-      keyVaults:
-        ccd:
-          secrets:
-            - name: data-store-api-POSTGRES-USER-V15
-              alias: DATA_STORE_DB_USERNAME
-            - name: data-store-api-POSTGRES-PASS-V15
-              alias: DATA_STORE_DB_PASSWORD
-            - name: data-store-api-draft-key
-              alias: CCD_DRAFT_ENCRYPTION_KEY
-            - name: ccd-data-s2s-secret
-              alias: DATA_STORE_IDAM_KEY
-            - name: ccd-ELASTIC-SEARCH-URL
-              alias: ELASTIC_SEARCH_HOSTS
-            - name: ccd-ELASTIC-SEARCH-DATA-NODES-URL
-              alias: ELASTIC_SEARCH_DATA_NODES_HOSTS
-            - name: ccd-ELASTIC-SEARCH-PASSWORD
-              alias: ELASTIC_SEARCH_PASSWORD
-            - name: app-insights-connection-string
-              alias: app-insights-connection-string
-            - name: idam-data-store-client-secret
-              alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
-            - name: idam-data-store-system-user-username
-              alias: IDAM_DATA_STORE_SYSTEM_USER_USERNAME
-            - name: idam-data-store-system-user-password
-              alias: IDAM_DATA_STORE_SYSTEM_USER_PASSWORD
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-e0feff4-20240520115505 #{"$imagepolicy": "flux-system:ithc-ccd-data-store-api"}
       environment:
         CCD_DOCUMENT_URL_PATTERN: ^https?://(((?:api-gateway\.preprod\.dm\.reform\.hmcts\.net|dm-store-ithc\.service\.core-compute-ithc\.internal(?::\d+)?)\/documents\/[A-Za-z0-9-]+(?:\/binary)?)|(em-hrs-api-ithc\.service\.core-compute-ithc\.internal(?::\d+)?\/hearing-recordings\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/((segments\/[0-9]+)|(file/\S+))))


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### apps/ccd/ccd-data-store-api/ithc.yaml
- The keyVaults section has been removed and the secrets have been replaced with environment variables.
- The image has been updated to hmctspublic.azurecr.io/ccd/data-store-api:prod-e0feff4-20240520115505.
- The environment variable CCD_DOCUMENT_URL_PATTERN has been updated.