### PR TITLE
Updating CCD datastore HPA in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -12,6 +12,8 @@ spec:
         enabled: true
         minReplicas: 2
         maxReplicas: 15
+        memory:
+          averageUtilization: 125
       memoryRequests: '4096Mi'
       memoryLimits: '6144Mi'
       cpuRequests: '1000m'


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Updating CCD datastore HPA in perftest for performance testing

## 🤖AEP PR SUMMARY🤖


### apps/ccd/ccd-data-store-api/perftest.yaml
- Increased the average memory utilization to 125%.
- Updated memory limits to '6144Mi' and memory requests to '4096Mi'.