### PR TITLE
LAU-891 run PCQ backend with 120 days

### DIFF
--- a/apps/pcq/pcq-backend/prod.yaml
+++ b/apps/pcq/pcq-backend/prod.yaml
@@ -11,4 +11,4 @@ spec:
       autoscaling:
         maxReplicas: 3
       environment:
-        NUMBER_OF_DAYS_LIMIT: 90
+        NUMBER_OF_DAYS_LIMIT: 120

--- a/apps/pcq/pcq-consolidation-service/prod.yaml
+++ b/apps/pcq/pcq-consolidation-service/prod.yaml
@@ -7,6 +7,6 @@ spec:
     job:
       spotInstances:
         enabled: false
-      schedule: "12 13 * * *"
+      schedule: "45 13 * * *"
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/LAU-891

### Change description ###
Run PCQ consolidator with 120 days looking back


## 🤖AEP PR SUMMARY🤖


- `apps/pcq/pcq-backend/prod.yaml`:
  - Changed the `NUMBER_OF_DAYS_LIMIT` environment variable from 90 to 120.

- `apps/pcq/pcq-consolidation-service/prod.yaml`:
  - Updated the job schedule from \"12 13 * * *\" to \"45 13 * * *\".