### PR TITLE
[ADOP-2471] added new social worker domain

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -61,6 +61,7 @@ spec:
           - adoptionteesvalley.org.uk
           - adoptersforadoption.com
           - diagrama.org
+          - sloughchildrenfirst.co.uk
         COR_VAL: 'Cornwall Council'
         WOL_VAL: 'Wolverhampton City Council'
         SMC_VAL: 'Sandwell Metropolitan Council'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/ADOP-2471

### Change description ###
Add new social worker domain



## 🤖AEP PR SUMMARY🤖


### apps/adoption/adoption-web/adoption-web.yaml
- Added the domain \"sloughchildrenfirst.co.uk\" to the list of allowed domains.