### PR TITLE
AM-3044 Decommission V11 JBS DB - Perftest Dummy Var as not all pods …

### DIFF
--- a/apps/am/am-judicial-booking-service/perftest.yaml
+++ b/apps/am/am-judicial-booking-service/perftest.yaml
@@ -17,3 +17,4 @@ spec:
           averageUtilization: 90
       environment:
         AM_INFO: true
+        DUMMY_VAR: true


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-3044
Decommission V11 JBS DB - Perftest Dummy Var as not all pods have latest images

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified file: perftest.yaml
- Added a new environment variable DUMMY_VAR with the value true.