### PR TITLE
Updating CCD Data Store HPA config in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -6,12 +6,12 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      replicas: 2
+      replicas: 4
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-e0feff4-20240520115505 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
         enabled: true
-        minReplicas: 2
-        maxReplicas: 15
+        minReplicas: 4
+        maxReplicas: 8
         memory:
           averageUtilization: 125
       memoryRequests: '4096Mi'


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Updating CCD Data Store HPA config in perftest

## 🤖AEP PR SUMMARY🤖


### apps/ccd/ccd-data-store-api/perftest.yaml
- Increased the number of replicas for the `java` service from 2 to 4.
- Updated the minimum replicas for autoscaling from 2 to 4, and the maximum replicas from 15 to 8.
- Adjusted the `memoryRequests` to '4096Mi'.