### PR TITLE
Updated FM5 cron to every 30 min & hearing away days to 14 away

### DIFF
--- a/apps/private-law/prl-cron-fm5-reminder/prod.yaml
+++ b/apps/private-law/prl-cron-fm5-reminder/prod.yaml
@@ -35,7 +35,7 @@ spec:
       image: hmctspublic.azurecr.io/prl/cos:prod-5ffc34f-20240524155420 #{"$imagepolicy": "flux-system:prl-cos"}
       environment:
         TASK_NAME: Fm5ReminderNotificationTask
-        HEARING_AWAY_DAYS: 18
+        HEARING_AWAY_DAYS: 14
         VAR: trigger1
         FEATURE_EXAMPLE: true
         APP_ENV: "prod"
@@ -50,7 +50,7 @@ spec:
         XUI_URL: https://manage-case.platform.hmcts.net/cases/case-details
         CITIZEN_URL: www.apply-to-court-about-child-arrangements-c100.service.gov.uk
         FM5_REMINDER_APPLICANT_RESPONDENT_SOLICITOR: d-b6b04932b1ac464b9a8c718d1b1a604a
-      schedule: 00,10,20,30,40,50 * * * *
+      schedule: 00,30 * * * *
     global:
       jobKind: CronJob
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/private-law/prl-cron-fm5-reminder/prod.yaml
- Changed the value of HEARING_AWAY_DAYS from 18 to 14.
- Updated the schedule from every 10 minutes to every 30 minutes.