### PR TITLE
Disabling CCD HPA in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -6,10 +6,10 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      replicas: 4
+      replicas: 15
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-e0feff4-20240520115505 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
-        enabled: true
+        enabled: false
         minReplicas: 4
         maxReplicas: 8
         memory:


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Disabling CCD HPA in perftest

## 🤖AEP PR SUMMARY🤖


### apps/ccd/ccd-data-store-api/perftest.yaml
- Updated the number of replicas from 4 to 15
- Changed the autoscaling `enabled` value from true to false
- Updated the `minReplicas` to 4 and `maxReplicas` to 8