### PR TITLE
DFPL-2339: Update Cron schedule for Kent migration

### DIFF
--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: fpl-cron-ccd-data-migration-tool
   values:
     job:
-      schedule: "15 00 29 05 *"
+      schedule: "00 15 29 05 *"
       environment:
         ENABLED: true
         MIGRATION_ID: DFPL-2339

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
@@ -6,10 +6,10 @@ spec:
   releaseName: fpl-cron-ccd-data-migration-tool
   values:
     job:
-      schedule: "30 12 22 05 *"
+      schedule: "16 00 29 05 *"
       environment:
         ENABLED: true
-        MIGRATION_ID: DFPL-log
+        MIGRATION_ID: DFPL-2339
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         USE_CASE_ID_MAPPING: true
         DEFAULT_THREAD_DELAY: 19

--- a/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
+++ b/apps/family-public-law/fpl-cron-ccd-data-migration-tool/prod/00.yaml
@@ -6,13 +6,9 @@ spec:
   releaseName: fpl-cron-ccd-data-migration-tool
   values:
     job:
-      schedule: "16 00 29 05 *"
+      schedule: "15 00 29 05 *"
       environment:
         ENABLED: true
         MIGRATION_ID: DFPL-2339
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         USE_CASE_ID_MAPPING: true
-        DEFAULT_THREAD_DELAY: 19
-        DEFAULT_THREAD_LIMIT: 1
-        CASE_MIGRATION_TIMEOUT: 18000
-        RETRY_FAILURES: false


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2339

Update schedule time and migration Id for kent outsourcing migration





## 🤖AEP PR SUMMARY🤖


- Updated file: `fpl-cron-ccd-data-migration-tool/prod/00.yaml`
- Changed the job schedule from \"30 12 22 05 *\" to \"00 15 29 05 *\"
- Updated the value of MIGRATION_ID from \"DFPL-log\" to \"DFPL-2339\"
- Removed the environment variables DEFAULT_THREAD_DELAY, DEFAULT_THREAD_LIMIT, CASE_MIGRATION_TIMEOUT, and RETRY_FAILURES