### PR TITLE
pr-3702 on the int2-demo deployment

### DIFF
--- a/apps/xui/xui-webapp-integration2/demo-image-policy.yaml
+++ b/apps/xui/xui-webapp-integration2/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-3687-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-3702-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/xui/xui-webapp-integration2/demo.yaml
+++ b/apps/xui/xui-webapp-integration2/demo.yaml
@@ -7,7 +7,7 @@ spec:
     nodejs:
       ingressHost: manage-case-int2.demo.platform.hmcts.net
       environment:
-        DUMMY_VAR_FOR_RESTART: 2
+        DUMMY_VAR_FOR_RESTART: 1
         FEATURE_SECURE_COOKIE_ENABLED: false
         FEATURE_JRD_E_LINKS_V2_ENABLED: true
         SERVICES_MARKUP_API: http://em-npa-demo.service.core-compute-demo.internal
@@ -41,4 +41,4 @@ spec:
         MC_BASE_URL: https://manage-case-int2.demo.platform.hmcts.net
         SERVICES_TRANSLATION_API_URL: http://ts-translation-service-demo.service.core-compute-demo.internal
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
-      image: hmctspublic.azurecr.io/xui/webapp:pr-3687-07aae92-20240528163259 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration2"}
+      image: hmctspublic.azurecr.io/xui/webapp:pr-3702-6886ff5-20240528154421 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration2"}


### PR DESCRIPTION
pr-3702 on the int2-demo deployment

## 🤖AEP PR SUMMARY🤖


- Updated `demo-image-policy.yaml`: updated the pattern to match the new pr-3702 branch
- Updated `demo.yaml`: Changed the value of DUMMY_VAR_FOR_RESTART from 2 to 1, and updated the image tag to pr-3702-6886ff5-20240528154421