### PR TITLE
SSCSCI-215 - Enable welsh webchat on prod

### DIFF
--- a/apps/sscs/sscs-tribunals-frontend/prod.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/prod.yaml
@@ -41,4 +41,4 @@ spec:
         MULTIPLE_DRAFTS_ENABLED: "true"
         DUMMY_PROPERTY: "false"
         WEBCHAT_OPENING_TIME_8_5: "true"
-        WELSH_WEBCHAT_ENABLED: "false"
+        WELSH_WEBCHAT_ENABLED: "true"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SSCSCI-215


### Change description ###
Turn on feature flag for Welsh webchat in production


## 🤖AEP PR SUMMARY🤖


### sscs-tribunals-frontend/prod.yaml
- Changed `WELSH_WEBCHAT_ENABLED` from \"false\" to \"true\" 🏴