### PR TITLE
Revert "Hmc bcp testing 30 05 2024"

### DIFF
--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 0
       image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:prod-38f8859-20240425144638 #{"$imagepolicy": "flux-system:demo-hmc-inbound-adapter"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 0
       image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-153560c-20240429100245 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#32123

## 🤖AEP PR SUMMARY🤖


### apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
- Removed the \"replicas\" configuration for the \"java\" environment.

### apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
- Removed the \"replicas\" configuration for the \"java\" environment.