### PR TITLE
Temporarily add debug logging to civil-sdt prod

### DIFF
--- a/apps/civil/civil-sdt/prod-00.yaml
+++ b/apps/civil/civil-sdt/prod-00.yaml
@@ -11,3 +11,4 @@ spec:
         RETRY_SEND_CRON: 0 0 * * * 4,5,6,7
         REQUEUE_SCHEDULE_CRON: 0 */20 * * * 4,5,6,7
         IDAM_API_URL: https://idam-api.platform.hmcts.net
+        LOGGING_LEVEL_UK_GOV_MOJ_SDT: DEBUG

--- a/apps/civil/civil-sdt/prod-01.yaml
+++ b/apps/civil/civil-sdt/prod-01.yaml
@@ -11,3 +11,4 @@ spec:
         RETRY_SEND_CRON: 0 0 * * * 1,2,3
         REQUEUE_SCHEDULE_CRON: 0 */20 * * * 1,2,3
         IDAM_API_URL: https://idam-api.platform.hmcts.net
+        LOGGING_LEVEL_UK_GOV_MOJ_SDT: DEBUG


### PR DESCRIPTION
### Jira link (if applicable)
N/A

### Change description ###
Temporarily add debug logging to prod deployment of civil-sdt.  This will be used to support a dry run test being carried out this weekend.  Change will be reverted after test is completed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated `prod-00.yaml` and `prod-01.yaml` in `civil-sdt` folder:
  - Added `LOGGING_LEVEL_UK_GOV_MOJ_SDT` with value `DEBUG` to the environment variables.