### PR TITLE
update perftest image

### DIFF
--- a/apps/probate/probate-back-office/perftest-image-policy.yaml
+++ b/apps/probate/probate-back-office/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2568-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-back-office/perftest.yaml
+++ b/apps/probate/probate-back-office/perftest.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/probate/back-office:pr-2568-81a0b48-20240523120523
       environment:
         CCD_GATEWAY_HOST: https://manage-case.perftest.platform.hmcts.net
         BLOB_STORAGE_SMEEANDFORD_FEATURE_ENABLED: true

--- a/apps/probate/probate-frontend/perftest.yaml
+++ b/apps/probate/probate-frontend/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/probate/frontend:pr-1999-859e2bf-20240520115252 #{"$imagepolicy": "flux-system:perftest-probate-frontend"}
+      image: hmctspublic.azurecr.io/probate/frontend:pr-2015-d8039cd-20240530164242 #{"$imagepolicy": "flux-system:perftest-probate-frontend"}
       environment:
         EQUALITY_URL: https://pcq.perftest.platform.hmcts.net
         LAUNCHDARKLY_ENABLED: true


### PR DESCRIPTION
### Change description ###
update perftest image

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- perftest-image-policy.yaml
  - Changed the image tag pattern from 'pr-2568' to 'prod' for filtering tags.

- perftest.yaml
  - Updated the image tag for the back-office service to 'prod' instead of 'pr-2568'.

- perftest.yaml
  - Updated the image tag for the frontend service to 'pr-2015' along with the timestamp '20240530164242' instead of 'pr-1999'.