### PR TITLE
Disable secure doc store in demo

### DIFF
--- a/apps/financial-remedy/finrem-cos/demo.yaml
+++ b/apps/financial-remedy/finrem-cos/demo.yaml
@@ -18,7 +18,7 @@ spec:
         CASE_DOCUMENT_AM_URL: "http://ccd-case-document-am-api-demo.service.core-compute-demo.internal"
         FEATURE_SEND_LETTER_RECIPIENT_CHECK: false
         FEATURE_CFV_ENABLED: true
-        SECURE_DOC_ENABLED: true
+        SECURE_DOC_ENABLED: false
         TRIGGER_DEPLOY: trigger1
       spotInstances:
         enabled: true


### PR DESCRIPTION
### Change description ###
FR is getting permissions errors in its EvidenceManagementDownloadService which seem to be related to the secure_doc_store config which is switched on in demo but not in AAT or prod.

