### PR TITLE
CIV-11851 - update demo image for next hearing date testing

### DIFF
--- a/apps/civil/civil-service/demo-image-policy.yaml
+++ b/apps/civil/civil-service/demo-image-policy.yaml
@@ -1,7 +1,14 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-civil-service
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-3959-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:prod-9d3d89f-20240530165403 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:pr-3959-115b05b-20240522093441 #{"$imagepolicy": "flux-system:demo-civil-service"}
       environment:
         TESTING_SUPPORT_ENABLED: true
         EM_CCD_ORCHESTRATOR_URL: http://em-ccd-orchestrator-demo.service.core-compute-demo.internal


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖



- demo-image-policy.yaml
    - Added annotations to disable prod-automated for the demo-civil-service
    - Updated the image policy to filter tags based on a specific pattern and extract a timestamp, with an alphabetical order policy for images

- demo.yaml
    - Updated the Java image version for civil service to 'pr-3959-115b05b-20240522093441' for the demo environment
