### PR TITLE
add demo idam url

### DIFF
--- a/apps/em/em-hrs-ingestor/demo.yaml
+++ b/apps/em/em-hrs-ingestor/demo.yaml
@@ -10,6 +10,7 @@ spec:
       environment:
         VH_PROCESS_BACK_TO_DAY: 2
         VH_PROCESS: true
+        IDAM_API_URL: https://idam-api.demo.platform.hmcts.net
       # Run every 30 minutes as demo is a single cluster
       spotInstances:
         enabled: true


### PR DESCRIPTION
add demo idam url

## 🤖AEP PR SUMMARY🤖


- In `demo.yaml`, the `IDAM_API_URL` environment variable has been added with the value `https://idam-api.demo.platform.hmcts.net`.