### PR TITLE
Changing Docmosis secret name

### DIFF
--- a/apps/docmosis/docmosis/aat.yaml
+++ b/apps/docmosis/docmosis/aat.yaml
@@ -10,5 +10,5 @@ spec:
         docmosis-infra:
           secrets:
             - name: appinsights-connection-string
-              alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+              alias: appinsights-connection-string
     image: hmctsprivate.azurecr.io/docmosis:aat-1776c3b-587880 #{"$imagepolicy": "flux-system:aat-docmosis"}

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -10,5 +10,5 @@ spec:
         docmosis-infra:
           secrets:
             - name: appinsights-connection-string
-              alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+              alias: appinsights-connection-string
     image: hmctsprivate.azurecr.io/docmosis:demo-1776c3b-587880 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -17,10 +17,10 @@ spec:
     envFromSecret: docmosis-secret
     image: hmctsprivate.azurecr.io/docmosis:prod-1776c3b-587880 #{"$imagepolicy": "flux-system:docmosis"}
     java:
-      memoryRequests: '1024Mi'
-      cpuRequests: '1000m'
-      memoryLimits: '3072Mi'
-      cpuLimits: '2000m'
+      memoryRequests: "1024Mi"
+      cpuRequests: "1000m"
+      memoryLimits: "3072Mi"
+      cpuLimits: "2000m"
   chart:
     spec:
       chart: base

--- a/apps/docmosis/docmosis/ithc.yaml
+++ b/apps/docmosis/docmosis/ithc.yaml
@@ -10,5 +10,5 @@ spec:
         docmosis-infra:
           secrets:
             - name: appinsights-connection-string
-              alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+              alias: appinsights-connection-string
     image: hmctsprivate.azurecr.io/docmosis:ithc-1776c3b-587880 #{"$imagepolicy": "flux-system:ithc-docmosis"}

--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -12,4 +12,4 @@ spec:
         docmosis-infra:
           secrets:
             - name: appinsights-connection-string
-              alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+              alias: appinsights-connection-string

--- a/apps/docmosis/docmosis/prod.yaml
+++ b/apps/docmosis/docmosis/prod.yaml
@@ -12,4 +12,4 @@ spec:
         docmosis-infra:
           secrets:
             - name: appinsights-connection-string
-              alias: APPLICATIONINSIGHTS_CONNECTION_STRING
+              alias: appinsights-connection-string


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-14032


### Change description ###
- Changing alias to `appinsights-connection-string`
- Mounting per environment as not deploying to `sbox`
- Will use `applicationinsights.json` file in docmosis repo to retrieve secret value
- Recommended here - https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-enable?tabs=java#paste-the-connection-string-in-your-environment 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Changed `aat.yaml`: Updated the alias for the `appinsights-connection-string`.
- Changed `demo.yaml`: Updated the alias for the `appinsights-connection-string`.
- Changed `docmosis.yaml`: Updated the CPU and memory request and limit values.
- Changed `ithc.yaml`: Updated the alias for the `appinsights-connection-string`.
- Changed `perftest.yaml`: Updated the alias for the `appinsights-connection-string`.
- Changed `prod.yaml`: Updated the alias for the `appinsights-connection-string`.