### PR TITLE
EM-6031 fix idam prod url

### DIFF
--- a/apps/em/em-hrs-ingestor/prod.yaml
+++ b/apps/em/em-hrs-ingestor/prod.yaml
@@ -19,5 +19,6 @@ spec:
         VH_PROCESS: true
         VH_LEASED_FOR_MINUTES: 360
         CVP_PROCESS: true
+        IDAM_API_URL: "https://idam-api.platform.hmcts.net"
       spotInstances:
         enabled: false


### PR DESCRIPTION
### Jira link (if applicable)
EM-6031 fix idam prod url


## 🤖AEP PR SUMMARY🤖


- The `prod.yaml` file in `em-hrs-ingestor` app has had the following changes made:
  - Added a new environment variable `IDAM_API_URL` with the value \"https://idam-api.platform.hmcts.net\".