### PR TITLE
DTSPO-17912 - Remove ptlsbox backstage

### DIFF
--- a/clusters/sbox-intsvc/base/kustomization.yaml
+++ b/clusters/sbox-intsvc/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../apps/kured/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml
   - ../../../apps/artifactory/base/kustomize.yaml
-  - ../../../apps/backstage/base/kustomize.yaml
   - ../../../apps/pact-broker/base/kustomize.yaml
   - ../../../apps/jenkins/base/kustomize.yaml
   - ../../../apps/azure-devops/base/kustomize.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17912

### Change description ###
This hasn't been running for some time since the ptlsbox flexible server was no longer created by default
https://github.com/hmcts/backstage-infra/commit/b5721c82e55d2dd392d13041dfbbe33438aa6f25

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **clusters/sbox-intsvc/base/kustomization.yaml**
  - Removed the reference to `./././apps/backstage/base/kustomize.yaml` from the list of resources.
  - Updated the kustomization file.