### PR TITLE
HMAN-581-add demo images

### DIFF
--- a/apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-465'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-cft-hearing-service/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-ffeb2e3-20240523161041 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
+      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-465 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
       keyVaults:
         hmc:
           secrets:

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-hmc-hmi-outbound-adapter
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-219'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-153560c-20240429100245 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
+      image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:pr-219 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


The following changes were made in this pull request:

apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
- Updated the filterTags pattern from '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-465'
  
apps/hmc/hmc-cft-hearing-service/demo.yaml
- Updated the image value from hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-ffeb2e3-20240523161041 to hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-465
  
apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
- Updated the filterTags pattern from '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-219'
  
apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
- Updated the image value from hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-153560c-20240429100245 to hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:pr-219
- Added environment variables for logging levels