### PR TITLE
IA - to test hmc API failures 

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -7,3 +7,5 @@ spec:
     java:
       image: hmctspublic.azurecr.io/ia/hearings-api:pr-386-d6e6746-20240604101449 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
+      environment:
+        HMC_API_URL: "http://hmc-cft-hearing-service-test.service.core-compute-test.internal"


### PR DESCRIPTION
### Jira link (if applicable)

IA - to test hmc API failures 

### Change description ###

IA - to test hmc API failures 
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified file: `apps/ia/ia-hearings-api/demo.yaml`
- Added environment variable `HMC_API_URL` with value `\"http://hmc-cft-hearing-service-test.service.core-compute-test.internal\"` to the demo environment.