### PR TITLE
Revert "IA - to test hmc API failures "

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -7,5 +7,3 @@ spec:
     java:
       image: hmctspublic.azurecr.io/ia/hearings-api:pr-386-69cd135-20240604162645 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
-      environment:
-        HMC_API_URL: "http://hmc-cft-hearing-service-test.service.core-compute-test.internal"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#32230

## 🤖AEP PR SUMMARY🤖


### apps/ia/ia-hearings-api/demo.yaml
- Removed the environment variables section.
- Updated the ingressHost to \"ia-hearings-api-demo.service.core-compute-demo.internal\" and the java image to \"hmctspublic.azurecr.io/ia/hearings-api:pr-386-69cd135-20240604162645\".