### PR TITLE
EM-6031 remove unused idam env vars

### DIFF
--- a/apps/em/em-hrs-ingestor/prod.yaml
+++ b/apps/em/em-hrs-ingestor/prod.yaml
@@ -7,8 +7,6 @@ spec:
     job:
       schedule: "*/30 * * * *"
       environment:
-        IDAM_API_BASE_URI: "https://idam-api.platform.hmcts.net"
-        OPEN_ID_API_BASE_URI: "https://hmcts-access.service.gov.uk/o"
         ENABLE_CRONJOB: true
         MAX_FILES_TO_PROCESS: 250
         USE_AD_AUTH_FOR_SOURCE_BLOB_CONNECTION: true


### PR DESCRIPTION
### Jira link (if applicable)
EM-6031 remove unused idam env vars


## 🤖AEP PR SUMMARY🤖


### apps/em/em-hrs-ingestor/prod.yaml
- Removed `IDAM_API_BASE_URI` and `OPEN_ID_API_BASE_URI` environment variables.
- Updated the job schedule to run every 30 minutes.
- Enabled `CRONJOB` with a maximum of 250 files to process and AD authentication for source blob connection.