### PR TITLE
Patch dynatrace to v1.1.0

### DIFF
--- a/apps/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v0.15.0/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.1.0/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.0.0
+      version: 1.1.0
       sourceRef:
         name: dynatrace-operator
         kind: HelmRepository

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 0.15.0
+      version: 1.0.0
       sourceRef:
         name: dynatrace-operator
         kind: HelmRepository


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17585

### Change description ###

Patch dynatrace to v1.1.0

## 🤖AEP PR SUMMARY🤖


- Updated `kustomization.yaml`: Changed the URL in the resources section from v0.15.0 to v1.1.0 of Dynatrace operator crd.
- Updated `dynatrace-operator.yaml`: Changed the version in the spec section from 0.15.0 to 1.1.0.