### PR TITLE
PCQ disable spot instances on pcq-backend

### DIFF
--- a/apps/pcq/pcq-backend/aat.yaml
+++ b/apps/pcq/pcq-backend/aat.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   values:
     java:
+      spotInstances:
+        enabled: false
       environment:
         S2S_URL: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
         DB_ALLOW_DELETE_RECORD: "true"

--- a/apps/pcq/pcq-backend/ithc.yaml
+++ b/apps/pcq/pcq-backend/ithc.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   values:
     java:
+      spotInstances:
+        enabled: false

--- a/apps/pcq/pcq-backend/perftest.yaml
+++ b/apps/pcq/pcq-backend/perftest.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   values:
     java:
+      spotInstances:
+        enabled: false


### PR DESCRIPTION
### Change description ###
Disable spot instances on pcq-backend


## 🤖AEP PR SUMMARY🤖


- **aat.yaml**
  - Added configuration to disable spot instances in the java spec for the AAT environment.

- **ithc.yaml, perftest.yaml**
  - Added configuration to disable spot instances in the java spec for both the ITHC and perftest environments.