### PR TITLE
Disable autoscaling on sscs

### DIFF
--- a/apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
+++ b/apps/sscs/sscs-bulk-scan/sscs-bulk-scan.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-bulk-scan
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/bulk-scan:prod-98bfc01-20240529150334 #{"$imagepolicy": "flux-system:sscs-bulk-scan"}

--- a/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
+++ b/apps/sscs/sscs-cor-frontend/sscs-cor-frontend.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-cor-frontend
   values:
     nodejs:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs-cor/frontend:prod-ca46755-20240605164903 #{"$imagepolicy": "flux-system:sscs-cor-frontend"}

--- a/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
+++ b/apps/sscs/sscs-hearings-api/sscs-hearings-api.yaml
@@ -6,6 +6,8 @@ spec:
   releaseName: sscs-hearings-api
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       image: hmctspublic.azurecr.io/sscs/hearings-api:prod-ba539a0-20240529150432 #{"$imagepolicy": "flux-system:sscs-hearings-api"}
       useInterpodAntiAffinity: true

--- a/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
+++ b/apps/sscs/sscs-tribunals-api/sscs-tribunals-api.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tribunals-api
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-57741a4-20240605164833 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}

--- a/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
+++ b/apps/sscs/sscs-tribunals-frontend/sscs-tribunals-frontend.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tribunals-frontend
   values:
     nodejs:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tribunals-frontend:prod-019ed3b-20240604115059 #{"$imagepolicy": "flux-system:sscs-tribunals-frontend"}

--- a/apps/sscs/sscs-tya-notif/aat.yaml
+++ b/apps/sscs/sscs-tya-notif/aat.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tya-notif:pr-2511-d4bc0de-20240603111916

--- a/apps/sscs/sscs-tya-notif/demo.yaml
+++ b/apps/sscs/sscs-tya-notif/demo.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       enableOAuth: true
       useInterpodAntiAffinity: true

--- a/apps/sscs/sscs-tya-notif/ithc.yaml
+++ b/apps/sscs/sscs-tya-notif/ithc.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tya-notif:prod-e5e4b3f-20240129224329 #{"$imagepolicy": "flux-system:ithc-sscs-tya-notif"}

--- a/apps/sscs/sscs-tya-notif/perftest.yaml
+++ b/apps/sscs/sscs-tya-notif/perftest.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tya-notif:prod-19bce39-20240530091219 #{"$imagepolicy": "flux-system:sscs-tya-notif"}

--- a/apps/sscs/sscs-tya-notif/prod.yaml
+++ b/apps/sscs/sscs-tya-notif/prod.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
+      autoscaling:
+        enabled: false
       replicas: 2
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/sscs/tya-notif:prod-19bce39-20240530091219 #{"$imagepolicy": "flux-system:sscs-tya-notif"}

--- a/apps/sscs/sscs-tya-notif/sscs-tya-notif.yaml
+++ b/apps/sscs/sscs-tya-notif/sscs-tya-notif.yaml
@@ -5,9 +5,6 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
-  java:
-    autoscaling:
-      enabled: false
   chart:
     spec:
       chart: ./stable/sscs-tya-notif

--- a/apps/sscs/sscs-tya-notif/sscs-tya-notif.yaml
+++ b/apps/sscs/sscs-tya-notif/sscs-tya-notif.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: sscs
 spec:
   releaseName: sscs-tya-notif
+  java:
+    autoscaling:
+      enabled: false
   chart:
     spec:
       chart: ./stable/sscs-tya-notif


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-843
https://tools.hmcts.net/jira/browse/SSCSCI-499

### Change description ###

Disabled autoscaling in

- sscs-bulk-scan
- sscs-cor-frontend
- sscs-hearings-api
- sscs-tribunals-api
- sscs-tribunals-frontend
- sscs-tya-notif









## 🤖AEP PR SUMMARY🤖


- Updated sscs-bulk-scan.yaml: disabled autoscaling and set replicas to 2
- Updated sscs-cor-frontend.yaml: disabled autoscaling and set replicas to 2
- Updated sscs-hearings-api.yaml: disabled autoscaling and set replicas to 2
- Updated sscs-tribunals-api.yaml: disabled autoscaling and set replicas to 2
- Updated sscs-tribunals-frontend.yaml: disabled autoscaling and set replicas to 2
- Updated aat.yaml: disabled autoscaling and set replicas to 2
- Updated demo.yaml: disabled autoscaling and set replicas to 2
- Updated ithc.yaml: disabled autoscaling and set replicas to 2
- Updated perftest.yaml: disabled autoscaling and set replicas to 2
- Updated prod.yaml: disabled autoscaling and set replicas to 2