### PR TITLE
Change docmosis timeout

### DIFF
--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -4,6 +4,7 @@ metadata:
   name: docmosis
 spec:
   releaseName: docmosis
+  timeout: 10m
   values:
     disableTraefikTls: true
     language: java


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
- Changes default helm timeout for Docmosis from 5min to 10min
- Required for helm upgrade to complete

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
