### PR TITLE
schedule interpreter language migration release

### DIFF
--- a/apps/sscs/sscs-case-loader/prod-00.yaml
+++ b/apps/sscs/sscs-case-loader/prod-00.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0-10 20-23,0-7 * * *"
+      schedule: "0/10 20-23,0-7 * * *"
       startingDeadlineSeconds: 1800
       concurrencyPolicy: Forbid
       memoryRequests: "768Mi"

--- a/apps/sscs/sscs-case-loader/prod-00.yaml
+++ b/apps/sscs/sscs-case-loader/prod-00.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 21-23,0-7 * * *"
+      schedule: "0-10 20-23,0-7 * * *"
       startingDeadlineSeconds: 1800
       concurrencyPolicy: Forbid
       memoryRequests: "768Mi"
@@ -22,9 +22,9 @@ spec:
         APACHE_LOG_LEVEL: DEBUG
         PROCESS_MINOR_EVENTS: false
         USE_EXISTING_DATE: false
-        CASE_LOADER_START_HOUR: 21
+        CASE_LOADER_START_HOUR: 24
         CASE_LOADER_END_HOUR: 24
-        INTERPRETER_DATA_MIGRATION_ENABLED: false
+        INTERPRETER_DATA_MIGRATION_ENABLED: true
         INTERPRETER_MIGRATION_ROLLBACK: false
         INTERPRETER_MIGRATION_START_HOUR: 20
         INTERPRETER_MIGRATION_END_HOUR: 24


### PR DESCRIPTION
### Jira link (if applicable)
- https://tools.hmcts.net/jira/browse/SSCSCI-815

### Change description ###
- schedule interpreter language migration release




## 🤖AEP PR SUMMARY🤖


- Updated `prod-00.yaml`
  - Changed job schedule from \"0 21-23,0-7 * * *\" to \"0/10 20-23,0-7 * * *\"
  - Modified values for `CASE_LOADER_START_HOUR` from 21 to 24 and `INTERPRETER_DATA_MIGRATION_ENABLED` from false to true.