### PR TITLE
LondonSouth and Watford case types

### DIFF
--- a/apps/et/et-ccd-case-migration/prod-00.yaml
+++ b/apps/et/et-ccd-case-migration/prod-00.yaml
@@ -15,7 +15,7 @@ spec:
         MIGRATION_ROLLBACK: false
         MIGRATION_QUERY_SIZE: 2000
         MIGRATION_CASE_LIMIT: 2000
-        MIGRATION_CASETYPE: Leeds
+        MIGRATION_CASETYPE: LondonSouth
     global:
       environment: prod
       enableKeyVaults: true

--- a/apps/et/et-ccd-case-migration/prod-01.yaml
+++ b/apps/et/et-ccd-case-migration/prod-01.yaml
@@ -15,7 +15,7 @@ spec:
         MIGRATION_ROLLBACK: false
         MIGRATION_QUERY_SIZE: 2000
         MIGRATION_CASE_LIMIT: 2000
-        MIGRATION_CASETYPE: Bristol
+        MIGRATION_CASETYPE: Watford
     global:
       environment: prod
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RET-4892


### Change description ###
LondonSouth and Watford case types migration

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### Changed files
- `apps/et/et-ccd-case-migration/prod-00.yaml`
  - Changed the value of `MIGRATION_CASETYPE` from `Leeds` to `LondonSouth`
- `apps/et/et-ccd-case-migration/prod-01.yaml`
  - Changed the value of `MIGRATION_CASETYPE` from `Bristol` to `Watford`