### PR TITLE
CIV-0000 Update aat.yaml with prod image

### DIFF
--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-4710
       environment:
         OIDC_ISSUER: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts
         TESTING_SUPPORT_ENABLED: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- The file `aat.yaml` in `apps/civil/civil-service` had the `environment` section modified, removing the `image` field for Java and the `OIDC_ISSUER` and `TESTING_SUPPORT_ENABLED` environment variables.