### PR TITLE
Adds flux config for testing failed-deployments alerting

### DIFF
--- a/apps/monitoring/aat/01/kustomization.yaml
+++ b/apps/monitoring/aat/01/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 - botkube-values.enc.yaml
+- ../../failed-deployments
 patches:
 - path: ../../kube-prometheus-stack/aat/01.yaml

--- a/apps/monitoring/automation/kustomization.yaml
+++ b/apps/monitoring/automation/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../helm-base-versions/image-repo.yaml
   - ../helm-base-versions/image-policy.yaml
+  - ../failed-deployments/image-repo.yaml
+  - ../failed-deployments/image-policy.yaml

--- a/apps/monitoring/failed-deployments/failed-deployments.yaml
+++ b/apps/monitoring/failed-deployments/failed-deployments.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: failed-deployments
+  namespace: monitoring
+  labels:
+    app: failed-deployments
+spec:
+  schedule: "*/20 * * * *"
+  concurrencyPolicy: "Forbid"
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: failed-deployments-sa
+          containers:
+            - name: failed-deployments
+              image: hmctspublic.azurecr.io/failed-deployments:prod-3b5d5ed-20240611134008 #{"$imagepolicy": "flux-system:failed-deployments"}
+              imagePullPolicy: Always
+              env:
+                - name: CLUSTER_NAME
+                  value: "cft-${CLUSTER_FULL_NAME}-aks"
+                - name: COSMOS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: helm-base-versions #Use's same secrets as helm-chart-base-version
+                      key: cosmos-key
+                - name: SLACK_WEBHOOK
+                  valueFrom:
+                    secretKeyRef:
+                      name: helm-base-versions #Use's same secrets as helm-chart-base-version
+                      key: slack-webhook
+                - name: ARTIFACT_URL
+                  value: "http://source-controller.flux-system.svc.cluster.local."
+                - name: API_SERVER_URL
+                  value: "https://kubernetes.default.svc.cluster.local"

--- a/apps/monitoring/failed-deployments/image-policy.yaml
+++ b/apps/monitoring/failed-deployments/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: failed-deployments
+spec:
+  imageRepositoryRef:
+    name: failed-deployments

--- a/apps/monitoring/failed-deployments/image-repo.yaml
+++ b/apps/monitoring/failed-deployments/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: failed-deployments
+spec:
+  image: hmctspublic.azurecr.io/failed-deployments

--- a/apps/monitoring/failed-deployments/kustomization.yaml
+++ b/apps/monitoring/failed-deployments/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - failed-deployments.yaml
+  - rbac.yaml

--- a/apps/monitoring/failed-deployments/rbac.yaml
+++ b/apps/monitoring/failed-deployments/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: failed-deployments-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: failed-deployments-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: failed-deployments-sa
+    namespace: monitoring
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: failed-deployments-clusterrole
+rules:
+  - apiGroups: ['']
+    resources: ['namespaces']
+    verbs: ['list', 'get']
+  - apiGroups: ['apps']
+    resources: ['deployments']
+    verbs: ['list', 'get']
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: failed-deployments-sa
+  namespace: monitoring


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-14217

### Change description ###

Adds flux config for testing failed-deployments alerting against aat-01 where there is a failing deployment in em namespace



## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process with error: Internal Server Error. Request ID: 1c4f4928-27f6-11ef-9af6-ba02d9a72f49