### PR TITLE
putting civil service and ga demo back to prod image

### DIFF
--- a/apps/civil/civil-general-applications/demo-image-policy.yaml
+++ b/apps/civil/civil-general-applications/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-civil-general-applications
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: civil-general-applications
-  filterTags:
-    pattern: '^pr-1338-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc

--- a/apps/civil/civil-general-applications/demo.yaml
+++ b/apps/civil/civil-general-applications/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/general-applications:pr-1338-fdc9531-20240612155010 #{"$imagepolicy": "flux-system:demo-civil-general-applications"}
+      image: hmctspublic.azurecr.io/civil/general-applications:prod-8aa9a37-20240612181027 #{"$imagepolicy": "flux-system:demo-civil-general-applications"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/apps/civil/civil-service/demo-image-policy.yaml
+++ b/apps/civil/civil-service/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-civil-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-4861-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-4861-f95ce9a-20240612104332 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-5e3de67-20240612180522 #{"$imagepolicy": "flux-system:demo-civil-service"}
       environment:
         TESTING_SUPPORT_ENABLED: true
         EM_CCD_ORCHESTRATOR_URL: http://em-ccd-orchestrator-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- demo-image-policy.yaml```:
  - Removed annotations and filterTags.
  - Adjusted imageRepositoryRef and policy settings.
  
- ```demo.yaml```:
  - Updated the image tag to point to a production image in both ```civil-general-applications``` and ```civil-service``` applications. This includes changing the tag from a PR build to a production build.