### PR TITLE
Adds notify mode to aat-00, adds check to other envs

### DIFF
--- a/apps/monitoring/aat/00/kustomization.yaml
+++ b/apps/monitoring/aat/00/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../base
 - botkube-values.enc.yaml
 - ../../helm-base-versions-slack
+- ../../failed-deployments-slack
 
 patches:
 - path: ../../kube-prometheus-stack/aat/00.yaml

--- a/apps/monitoring/aat/01/kustomization.yaml
+++ b/apps/monitoring/aat/01/kustomization.yaml
@@ -3,6 +3,5 @@ kind: Kustomization
 resources:
 - ../base
 - botkube-values.enc.yaml
-- ../../failed-deployments
 patches:
 - path: ../../kube-prometheus-stack/aat/01.yaml

--- a/apps/monitoring/aat/base/kustomization.yaml
+++ b/apps/monitoring/aat/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - acr-sync.yaml
   - oneagent-values.yaml
   - helm-base-versions.enc.yaml
+  - ../../failed-deployments

--- a/apps/monitoring/demo/base/kustomization.yaml
+++ b/apps/monitoring/demo/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - prometheus-values.yaml
   - helm-base-versions.enc.yaml
   - ../../helm-base-versions
+  - ../../failed-deployments

--- a/apps/monitoring/failed-deployments-slack/kustomization.yaml
+++ b/apps/monitoring/failed-deployments-slack/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameSuffix: "-slack"
+resources:
+  - ../failed-deployments/failed-deployments.yaml
+patches:
+  - patch: |-
+      - op: add
+        path: "/spec/jobTemplate/spec/template/spec/containers/0/env/-"
+        value:
+          name: MODE
+          value: "notify"
+      - op: replace
+        path: "/spec/schedule"
+        value: "00 11 * * 1-5"
+    target:
+      kind: CronJob
+      namespace: monitoring
+      name: failed-deployments

--- a/apps/monitoring/failed-deployments/failed-deployments.yaml
+++ b/apps/monitoring/failed-deployments/failed-deployments.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: failed-deployments
 spec:
-  schedule: "*/20 * * * *"
+  schedule: "0 10 * * 1-5"
   concurrencyPolicy: "Forbid"
   failedJobsHistoryLimit: 3
   startingDeadlineSeconds: 300

--- a/apps/monitoring/ithc/base/kustomization.yaml
+++ b/apps/monitoring/ithc/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - prometheus-values.yaml
   - helm-base-versions.enc.yaml
   - ../../helm-base-versions
+  - ../../failed-deployments

--- a/apps/monitoring/perftest/base/kustomization.yaml
+++ b/apps/monitoring/perftest/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - oneagent-values.yaml
   - helm-base-versions.enc.yaml
   - ../../helm-base-versions
+  - ../../failed-deployments

--- a/apps/monitoring/prod/base/kustomization.yaml
+++ b/apps/monitoring/prod/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - oneagent-values.yaml
   - helm-base-versions.enc.yaml
   - ../../helm-base-versions
+  - ../../failed-deployments


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-14217

### Change description ###

Adds notify mode to aat-00, adds check to other envs

## 🤖AEP PR SUMMARY🤖


- `apps/monitoring/aat/00/kustomization.yaml`
  - Added `././failed-deployments-slack` to resources.
  - Removed `././helm-base-versions-slack` from resources.

- `apps/monitoring/aat/01/kustomization.yaml`
  - Removed `././failed-deployments` from resources.

- `apps/monitoring/aat/base/kustomization.yaml`
  - Added `././failed-deployments` to resources.

- `apps/monitoring/demo/base/kustomization.yaml`
  - Added `././helm-base-versions` and `././failed-deployments` to resources.

- Added file `apps/monitoring/failed-deployments-slack/kustomization.yaml`.

- `apps/monitoring/failed-deployments/failed-deployments.yaml`
  - Changed schedule from \"*/20 * * * *\" to \"0 10 * * 1-5\".

- `apps/monitoring/ithc/base/kustomization.yaml`
  - Added `././helm-base-versions` and `././failed-deployments` to resources.

- `apps/monitoring/perftest/base/kustomization.yaml`
  - Added `././helm-base-versions` and `././failed-deployments` to resources.

- `apps/monitoring/prod/base/kustomization.yaml`
  - Added `././helm-base-versions` and `././failed-deployments` to resources.