### PR TITLE
Dtspo 17999 remove arm jenkins agents

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -122,35 +122,3 @@ spec:
                           galleryImageDefinition: "jenkins-ubuntu"
                           galleryImageVersion: "1.4.152"
                         <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-builders-arm"
-                        templateDesc: "Jenkins build agents running on ARM64 CPUs"
-                        labels: "arm"
-                        maxVirtualMachinesLimit: 20
-                        retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
-                        usageMode: "EXCLUSIVE"
-                        virtualMachineSize: "Standard_D4pds_v5"
-                        imageReference:
-                          galleryName: "hmcts"
-                          galleryResourceGroup: "hmcts-image-gallery-rg"
-                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                          galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.152"
-                        <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-builders-arm-daily"
-                        templateDesc: "Jenkins build agents running on ARM64 CPUs"
-                        labels: "arm arm-daily"
-                        maxVirtualMachinesLimit: 5
-                        retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
-                        usageMode: "EXCLUSIVE"
-                        virtualMachineSize: "Standard_D4pds_v5"
-                        imageReference:
-                          galleryName: "hmcts"
-                          galleryResourceGroup: "hmcts-image-gallery-rg"
-                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                          galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.152"
-                        <<: *vm_template_values_anchor

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -119,32 +119,3 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                         <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-builders-arm"
-                        templateDesc: "Jenkins build agents running on ARM64 CPUs"
-                        labels: "arm"
-                        maxVirtualMachinesLimit: 3
-                        usageMode: "EXCLUSIVE"
-                        virtualMachineSize: "Standard_D4pds_v5"
-                        imageReference:
-                          galleryName: "hmcts"
-                          galleryResourceGroup: "hmcts-image-gallery-rg"
-                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                          galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.152"
-                        <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-builders-arm-daily"
-                        templateDesc: "Jenkins build agents for daily builds running on ARM64 CPUs"
-                        labels: "arm arm-daily"
-                        maxVirtualMachinesLimit: 3
-                        retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
-                        usageMode: "EXCLUSIVE"
-                        virtualMachineSize: "Standard_D4pds_v5"
-                        imageReference:
-                          galleryName: "hmcts"
-                          galleryResourceGroup: "hmcts-image-gallery-rg"
-                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                          galleryImageDefinition: "jenkins-ubuntu-arm"
-                          galleryImageVersion: "1.4.152"
-                        <<: *vm_template_values_anchor


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17999


### Change description ###
- Removes arm agent templates from Jenkins sbox and ptl

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- `jenkins-azure-vm-agent.yaml`:
  - Removed configurations related to ARM64 CPU build agents for both ptl-intsvc``` and ```sbox-intsvc``` Jenkins services.
  - Updated maxVirtualMachinesLimit to 3 for ARM64 CPU build agents in ```sbox-intsvc``` Jenkins service.