### PR TITLE
FACT-1395 replacing bulk-scan-processor image in demo for validation test

### DIFF
--- a/apps/bsp/bulk-scan-processor/demo.yaml
+++ b/apps/bsp/bulk-scan-processor/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/bulk-scan/processor:prod-7659508-20240606080756 #{"$imagepolicy": "flux-system:demo-bulk-scan-processor"}
+      image: hmctspublic.azurecr.io/bulk-scan/processor:pr-3269-4cbf12e-20240614140500 #{"$imagepolicy": "flux-system:demo-bulk-scan-processor"}
       environment:
         #60 days in seconds
         SAS_TOKEN_VALIDITY: "5184000"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FACT-1395


### Change description ###
removing validation for probate, they need to test in demo

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- demo.yaml```:
  - Updated the `image` value from `hmctspublic.azurecr.io/bulk-scan/processor:prod-7659508-20240606080756` to `hmctspublic.azurecr.io/bulk-scan/processor:pr-3269-4cbf12e-20240614140500` in the `java` section.