### PR TITLE
[ADOP-2425] ITHC no longer needs to be pointed to ADOP-2323 PR

### DIFF
--- a/apps/adoption/adoption-web/ithc-image-policy.yaml
+++ b/apps/adoption/adoption-web/ithc-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: ithc-adoption-web
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1536-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: adoption-web


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/ADOP-2425


### Change description ###
Changing ITHC image policy so ITHC no longer pointed at PR.

## 🤖AEP PR SUMMARY🤖


- ithc-image-policy.yaml```:
  - Removed annotations for prod-automated.
  - Removed filterTags, extract, and policy fields.
  - Updated imageRepositoryRef to remove the alphabetical order and set it to asc.