### PR TITLE
ADOP-2351 Update demo-image-policy.yaml to point to Spring Boot PR

### DIFF
--- a/apps/adoption/adoption-cos-api/demo-image-policy.yaml
+++ b/apps/adoption/adoption-cos-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-917-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-930-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link (if applicable)
ADOP-2351


### Change description ###
Spring Boot 3


## 🤖AEP PR SUMMARY🤖


### apps/adoption/adoption-cos-api/demo-image-policy.yaml
- Updated the `pattern` under `filterTags` from `'^pr-917-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^pr-930-[a-f0-9]+-(?P<ts>[0-9]+)'`.