### PR TITLE
deploy prod image demo stitching

### DIFF
--- a/apps/em/em-stitching/demo-image-policy.yaml
+++ b/apps/em/em-stitching/demo-image-policy.yaml
@@ -3,12 +3,12 @@ kind: ImagePolicy
 metadata:
   name: demo-em-stitching
   annotations:
-#    hmcts.github.com/prod-automated: enabled
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
+#    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-#    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
-    pattern: '^pr-2242-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+#    pattern: '^pr-2242-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/EM-5986


### Change description ###
deploy prod image demo stitching



## 🤖AEP PR SUMMARY🤖


- The file `demo-image-policy.yaml` has changes where the annotation `hmcts.github.com/prod-automated` has been updated from `disabled` to `enabled`.
- The `filterTags` pattern has been changed from `'^pr-2242-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`.
- An extract has been updated to `'$ts'`.
- The policy has not undergone significant changes.