### PR TITLE
DTSSTCI-864

### DIFF
--- a/apps/sptribs/sptribs-case-api/demo-image-policy.yaml
+++ b/apps/sptribs/sptribs-case-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1802-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/sptribs/sptribs-case-api/demo.yaml
+++ b/apps/sptribs/sptribs-case-api/demo.yaml
@@ -7,6 +7,6 @@ spec:
     java:
       spotInstances:
         enabled: false
-      image: hmctspublic.azurecr.io/sptribs/case-api:pr-1802-28dfe0d-20240614164716 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
+      image: hmctspublic.azurecr.io/sptribs/case-api:prod-0f15b8f-20240617165312 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
       environment:
         S2S_AUTHORISED_SERVICES: ccd_definition,ccd_data,xui_webapp,sptribs_case_api,ccd_gw,sptribs_frontend,sptribs_dss_update_case_web


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSSTCI-864

### Change description ###
Revert back to prod image in demo sptribs case api

## 🤖AEP PR SUMMARY🤖


- In `demo-image-policy.yaml`, the `filterTags` pattern has been updated from `'^pr-1802-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`.
- In `demo.yaml`, the image tag has been updated from `hmctspublic.azurecr.io/sptribs/case-api:pr-1802-28dfe0d-20240614164716` to `hmctspublic.azurecr.io/sptribs/case-api:prod-0f15b8f-20240617165312`.