### PR TITLE
FACT-1787 removal of aat dynatrace pr

### DIFF
--- a/apps/fact/fact-frontend/aat.yaml
+++ b/apps/fact/fact-frontend/aat.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/fact/frontend:pr-769
       autoscaling:
         enabled: false


### PR DESCRIPTION
### Jira link (if applicable)
https://github.com/hmcts/fact-frontend/pull/769


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- The file `aat.yaml` in `fact-frontend` has removed the `autoscaling` section, with `enabled` set to `false`.
