### PR TITLE
Revert "HMAN-581"

### DIFF
--- a/apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-465'
+    pattern: '^pr-497'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-cft-hearing-service/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-465 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
+      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-497-db3491a-20240612111353 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
       keyVaults:
         hmc:
           secrets:

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-hmc-hmi-outbound-adapter
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-219'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:pr-219 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
+      image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-153560c-20240429100245 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG


### PR DESCRIPTION
This reverts commit 7a07ddea08bdb8782b2a3e166abc8be141a9d8ee.

### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified file: demo-image-policy.yaml
  - Updated filterTags pattern from '^pr-465' to '^pr-497' for demo-image-policy.yaml
- Modified file: demo.yaml
  - Updated image tag from 'hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-465-4568651-20240617123545' to 'hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-497-db3491a-20240612111353' for demo.yaml
- Modified file: demo-image-policy.yaml
  - Updated hmcts.github.com/prod-automated annotation from disabled to enabled
  - Changed filterTags pattern from '^pr-219' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' for demo-image-policy.yaml
- Modified file: demo.yaml
  - Updated image tag from 'hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:pr-219-d758ea8-20240611082354' to 'hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-153560c-20240429100245' in demo.yaml