### PR TITLE
Revert "IA - test hmc failure scenarios"

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -7,5 +7,3 @@ spec:
     java:
       image: hmctspublic.azurecr.io/ia/hearings-api:pr-386-ad7cdf3-20240617102538 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
-      environment:
-        HMC_API_URL: "http://hmc-cft-hearing-service-test.service.core-compute-test.internal"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#32293

## 🤖AEP PR SUMMARY🤖


### apps/ia/ia-hearings-api/demo.yaml
- Removed the `environment` section containing `HMC_API_URL` in the `demo.yaml` file.