### PR TITLE
Default log level to WARN

### DIFF
--- a/apps/rd/rd-caseworker-ref-api/prod.yaml
+++ b/apps/rd/rd-caseworker-ref-api/prod.yaml
@@ -29,6 +29,7 @@ spec:
             - name: app-insights-connection-string
               alias: app-insights-connection-string
       environment:
+        ROOT_LOGGING_LEVEL: INFO
         DELETE_CWR: false
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
         CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync

--- a/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
+++ b/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
@@ -16,6 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/caseworker-ref-api:prod-d813c3b-20240617201919 #{"$imagepolicy": "flux-system:rd-caseworker-ref-api"}
       imagePullPolicy: Always
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-commondata-api/prod.yaml
+++ b/apps/rd/rd-commondata-api/prod.yaml
@@ -6,6 +6,7 @@ spec:
   values:
     java:
       environment:
+        ROOT_LOGGING_LEVEL: INFO
         DELETE_CWR: false
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
         CRD_S2S_AUTHORISED_SERVICES: ccd_data,xui_webapp,sscs,sscs_bulkscan,cui_ra,prl_cos_api,civil_service,iac,sptribs_case_api,et_cos

--- a/apps/rd/rd-commondata-api/rd-commondata-api.yaml
+++ b/apps/rd/rd-commondata-api/rd-commondata-api.yaml
@@ -15,6 +15,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/commondata-api:prod-5960c7c-20240618160639 #{"$imagepolicy": "flux-system:rd-commondata-api"}
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-judicial-api/prod.yaml
+++ b/apps/rd/rd-judicial-api/prod.yaml
@@ -7,6 +7,7 @@ spec:
     java:
       environment:
         DUMMY_VAR: false
+        ROOT_LOGGING_LEVEL: WARN
         DELETE_ORG: false
         IDAM_URL: https://idam-api.platform.hmcts.net
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o

--- a/apps/rd/rd-judicial-api/rd-judicial-api.yaml
+++ b/apps/rd/rd-judicial-api/rd-judicial-api.yaml
@@ -15,6 +15,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/judicial-api:prod-6f8d01f-20240617202017 #{"$imagepolicy": "flux-system:rd-judicial-api"}
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-location-ref-api/prod.yaml
+++ b/apps/rd/rd-location-ref-api/prod.yaml
@@ -6,6 +6,7 @@ spec:
   values:
     java:
       environment:
+        ROOT_LOGGING_LEVEL: INFO
         LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api,rd_judicial_api,ccd_data,xui_webapp,sscs,sscs_bulkscan,adoption_web,civil_service,prl_cos_api,fis_hmc_api,sptribs_case_api,iac,civil_general_applications,et_cos
         DELETE_ORG: false
         IDAM_URL: https://idam-api.platform.hmcts.net

--- a/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
+++ b/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
@@ -15,6 +15,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/location-ref-api:prod-b518fa4-20240619115044 #{"$imagepolicy": "flux-system:rd-location-ref-api"}
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-professional-api/prod.yaml
+++ b/apps/rd/rd-professional-api/prod.yaml
@@ -6,6 +6,7 @@ spec:
   values:
     java:
       environment:
+        ROOT_LOGGING_LEVEL: INFO
         DELETE_ORG: false
         DUMMY_VAR: false
         IDAM_URL: https://idam-api.platform.hmcts.net

--- a/apps/rd/rd-professional-api/rd-professional-api.yaml
+++ b/apps/rd/rd-professional-api/rd-professional-api.yaml
@@ -15,6 +15,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/professional-api:prod-63a0021-20240617202037 #{"$imagepolicy": "flux-system:rd-professional-api"}
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-profile-sync/prod.yaml
+++ b/apps/rd/rd-profile-sync/prod.yaml
@@ -6,5 +6,6 @@ spec:
   values:
     java:
       environment:
+        ROOT_LOGGING_LEVEL: INFO
         DELETE_ORG: true
         IDAM_URL: https://idam-api.platform.hmcts.net

--- a/apps/rd/rd-profile-sync/rd-profile-sync.yaml
+++ b/apps/rd/rd-profile-sync/rd-profile-sync.yaml
@@ -15,6 +15,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/profile-sync:prod-cbd1b0a-20240617202044 #{"$imagepolicy": "flux-system:rd-profile-sync"}
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-user-profile-api/prod.yaml
+++ b/apps/rd/rd-user-profile-api/prod.yaml
@@ -11,6 +11,7 @@ spec:
       cpuLimits: "4000m"
       cpuRequests: "2000m"
       environment:
+        ROOT_LOGGING_LEVEL: INFO
         DELETE_ORG: true
         IDAM_URL: https://idam-api.platform.hmcts.net
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o

--- a/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
+++ b/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
@@ -13,6 +13,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/user-profile-api:prod-65cfcde-20240617202024 #{"$imagepolicy": "flux-system:rd-user-profile-api"}
       environment:
+        ROOT_LOGGING_LEVEL: WARN
         DUMMY_VAR: true
   chart:
     spec:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSRD-730

### Change description ###

changed default logging level to WARN on lower level envs, PROD retains log level INFO

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **prod.yaml**
  - Added ROOT_LOGGING_LEVEL: INFO to app-insights-connection-string environment
  - Added ROOT_LOGGING_LEVEL: WARN to environment variables of rd-caseworker-ref-api, rd-commondata-api, rd-judicial-api, rd-location-ref-api, rd-professional-api, rd-profile-sync, rd-user-profile-api
  - Added OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o to app-insights-connection-string environment

- **rd-caseworker-ref-api.yaml**
  - Added ROOT_LOGGING_LEVEL: WARN to environment variables

- **rd-commondata-api.yaml**
  - Added ROOT_LOGGING_LEVEL: WARN to environment variables

- **rd-judicial-api.yaml**
  - Added ROOT_LOGGING_LEVEL: WARN to environment variables

- **rd-location-ref-api.yaml**
  - Added ROOT_LOGGING_LEVEL: INFO to environment variables 

- **rd-professional-api.yaml**
  - Added ROOT_LOGGING_LEVEL: INFO to environment variables

- **rd-profile-sync.yaml**
  - Added ROOT_LOGGING_LEVEL: WARN to environment variables

- **rd-user-profile-api.yaml**
  - Added ROOT_LOGGING_LEVEL: INFO to environment variables