### PR TITLE
Dtspo-16639, increase docmosis replicas on prod

### DIFF
--- a/apps/docmosis/docmosis/prod.yaml
+++ b/apps/docmosis/docmosis/prod.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     memoryRequests: "2Gi"
+    replicas: 3
     ingressHost: docmosis.platform.hmcts.net
     java:
       memoryRequests: "2Gi"


### PR DESCRIPTION
Test for resolution of issue in dtspo-16639
Examples of errors commonly seen at about 9.30-10am
ERROR DocumentConverter - Conversion failed :
com.docmosis.document.converter.ConversionServiceFailureException: request to open office to "load" took too long and has been aborted.
ERROR DocumentConverterRestfulService - Unable to convert file
com.docmosis.document.converter.pool.ConverterPoolException: Took too long to get converter.  Max wait is (ms):60000

## 🤖AEP PR SUMMARY🤖


- Changed file: prod.yaml
- Added a new key \"replicas\" with a value of 3 under the \"spec\" section.