### PR TITLE
update url to try and fix ithc probateman

### DIFF
--- a/apps/ccd/ithc/base/probatemandb.yaml
+++ b/apps/ccd/ithc/base/probatemandb.yaml
@@ -1,11 +1,27 @@
 apiVersion: v1
 data:
-    DB_PWD: UlFIWXBERTBlSUUtZUxLQzR2YUIK
-    DB_URL: amRiYzpwb3N0Z3Jlc3FsOi8vcHJvYmF0ZW1hbmRiLXBvc3RncmVzLWZsZXhpYmxlLWRiLWl0aGMucG9zdGdyZXMuZGF0YWJhc2UuYXp1cmUuY29tOjU0MzIvcHJvYmF0ZW1hbmRiCg==
-    DB_USER: cGdhZG1pbgo=
+    DB_PWD: ENC[AES256_GCM,data:BQMUxCQKBy49gTSllFqPMw2V/WN2keGGdCAiTw==,iv:gAKWC3YRWe8hWLGjbNoz1X1aCQPdaWqrTC7MnIFp0c4=,tag:IveJqTz6UoxL37AkBINghQ==,type:str]
+    DB_URL: ENC[AES256_GCM,data:MmLZa1Ffq+0xKmqjpY20rPmOHlvKc5Z2IcddjFA4D8hxoz62CtMJ++SZB050kHc5dzDcW1Jtm9QB10+E7oZa+/CN/t25VmekAJqFTJ7NPicwBX/Tb2iuLFaPEj+gP1AQGJ55E9Q2qOnINfrxu/RlQEnm2+VivmANCwd07F4YQ9o6LebyAUVeQ8oPmoQ=,iv:HtZSPYx57N5tt8tlP+apfVO/2moAMT4UYUV4otBo2VU=,tag:hOGwPlZpP79lJnyuBQm7Og==,type:str]
+    DB_USER: ENC[AES256_GCM,data:fzlWHbq8Ikh3wGoN,iv:qWR2yLMR7fRrxooplPVG9TGjq/ijB8gwYgzYCwrm1Dg=,tag:atHC93E7xLJo83PJQ64Iqg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
     name: probatemandb
     namespace: ccd
 type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv:
+        - vault_url: https://dcdcftappsithckv.vault.azure.net
+          name: sops-key
+          version: 48292d8b68d74d0080f5484f065f171d
+          created_at: "2024-06-21T08:35:25Z"
+          enc: dD89ovWVs3Q-WHehYJZjcmQ9q2gL4Q_pdSPvgD3QuBLysbn2qH8r-Bp7qWjN8rA0bV4GoZQFZNBGYR5yyvanKYfvvLtVeW8SevM64SGKgTa3Fn-xyViujyBG4xE1LfD3QlGt2GHeKuD8nwRk7HCwhmOFLGl88kIHa1qI6ipCmm_i64_wJX6LJEhu_-7GuRboJmNg4VaA5_AFcrdP7SDJDcAJzyZ1bh3M_rtSMMCeYdssW3LdGcC6b35Wb6zCweO4C2nAC4fv5cT08d4rlPIkYrCt7St0cQiXmmxFudKLnd9VaU1JKOIHHT3dt6yNGDxdbyH8X6iNh255syx-FD1WDw
+    hc_vault: []
+    age: []
+    lastmodified: "2024-06-21T08:35:33Z"
+    mac: ENC[AES256_GCM,data:oAZUiM0hBDLqURpcA8r5g8wyq0JRLv52kQq5FjHzUytXRZqlTynXtmk4urTpgI3RJe/1T3Jq0/6KxT1y/HmJfNWGweVwGDS9hadoUgC2CMsfVIoSMRCY34/lLbxkAYZk77TzvRq5uhSjXVKzFQ+1u8axAtstUuaXnvP5jZ0Eckw=,iv:0qOxYZG3uQwgqLRSMTVO2QCHAM0uj/3b2nXdbLM6ZPk=,tag:eoxxTVMcyWdGhvvV6hiFaw==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPB-4091


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- The `probatemandb.yaml` file has been modified to update the values of `DB_PWD`, `DB_URL`, and `DB_USER` under `apiVersion: v1`.
- The `created_at` and `lastmodified` timestamps have been updated to \"2024-06-21T08:35:25Z\".
- The encryption values for `enc` and `mac` have been replaced with new values.
- Additionally, the `vault_url` and `name` have been altered.