### PR TITLE
RWA-3464: Exclude wa-performance from WA dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -284,7 +284,7 @@ spec:
                     title: Civil SDT Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/wa-.+\/master
+                      ^HMCTS.*\/wa-(?!performance).+\/master
                     name: WA
                     recurse: true
                     title: WA


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RWA-3464


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)
- [x ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


yaml
apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
- Updated the includeRegex pattern in the buildMonitor section to exclude branches with \"performance\" in their names.
```