### PR TITLE
Adding vault name input to be used by set_env script for all reports

### DIFF
--- a/apps/monitoring/version-reporter/aksversions/aks-versions.yaml
+++ b/apps/monitoring/version-reporter/aksversions/aks-versions.yaml
@@ -33,6 +33,7 @@ spec:
     imagePullPolicy: Always
     environment:
       COSMOS_DB_CONTAINER: aksversions
+      VAULT_NAME: version-reporter-ptl
     keyVaults:
       version-reporter-ptl:
         excludeEnvironmentSuffix: true

--- a/apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
+++ b/apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
@@ -32,6 +32,7 @@ spec:
     imagePullPolicy: Always
     environment:
       COSMOS_DB_CONTAINER: docsoutdated
+      VAULT_NAME: version-reporter-ptl
     keyVaults:
       version-reporter-ptl:
         excludeEnvironmentSuffix: true

--- a/apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
+++ b/apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
@@ -38,6 +38,7 @@ spec:
       ENVIRONMENT: ptl-intsvc
       MAX_VERSIONS_AWAY: 2
       COSMOS_DB_CONTAINER: helmcharts
+      VAULT_NAME: version-reporter-ptl
     keyVaults:
       version-reporter-ptl:
         excludeEnvironmentSuffix: true

--- a/apps/monitoring/version-reporter/paloalto/palo-alto.yaml
+++ b/apps/monitoring/version-reporter/paloalto/palo-alto.yaml
@@ -36,6 +36,7 @@ spec:
       HUB_SUBSCRIPTION_ID: 0978315c-75fe-4ada-9d11-1eb5e0e0b214
       DESIRED_VERSION: 11.0.2
       COSMOS_DB_CONTAINER: paloalto
+      VAULT_NAME: version-reporter-ptl
     keyVaults:
       version-reporter-ptl:
         excludeEnvironmentSuffix: true


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17828


### Change description ###
Adding vault name input to be used by set_env script for all reports


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed `aks-versions.yaml`: Added `VAULT_NAME: version-reporter-ptl` to the environment variables.
- Changed `docs-outdated.yaml`: Added `VAULT_NAME: version-reporter-ptl` to the environment variables.
- Changed `helm-charts.yaml`: Added `VAULT_NAME: version-reporter-ptl` to the environment variables.
- Changed `palo-alto.yaml`: Added `VAULT_NAME: version-reporter-ptl` to the environment variables.