### PR TITLE
Add docmosis-ingress file to sbox

### DIFF
--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-apireplacepath@kubernetescrd
+  name: docmosis-ingress
+  namespace: docmosis
+spec:
+  rules:
+    - host: docmosis.sandbox.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: docmosis-base
+                port:
+                  number: 80
+            path: /
+            pathType: ImplementationSpecific
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: apireplacepath
+  namespace: docmosis
+spec:
+  replacePathRegex:
+    regex: ^/rs/(.*)
+    replacement: /api/$1

--- a/apps/docmosis/sbox/base/kustomization.yaml
+++ b/apps/docmosis/sbox/base/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- docmosis-secret.yaml
+  - ../../base
+  - docmosis-secret.yaml
+  - docmosis-ingress.yaml
 namespace: docmosis
 patches:
-- path: ../../docmosis/sbox.yaml
+  - path: ../../docmosis/sbox.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18048


### Change description ###
- Adds a `docmosis-ingress.yaml` file to `docmosis/sbox/base`
- Includes a traefik `replacePathRegex` to rewrite `/rs` to `/api`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Added a new file `docmosis-ingress.yaml` which contains Ingress and Middleware configurations for docmosis service in the sbox environment
- Updated `kustomization.yaml` to include the new `docmosis-ingress.yaml` file and removed the reference to `docmosis-secret.yaml` in the base section