### PR TITLE
IA - configure dummy URL to force failure calling HMC API

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -8,4 +8,4 @@ spec:
       image: hmctspublic.azurecr.io/ia/hearings-api:pr-386-ad7cdf3-20240617102538 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
       environment:
-        HMC_API_URL: "http://hmc-cft-hearing-service-test.service.core-compute-test.internal"      
+        HMC_API_URL: "http://hmc-cft-hearing-service-test.service.core-compute-test.internal"

--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -7,3 +7,5 @@ spec:
     java:
       image: hmctspublic.azurecr.io/ia/hearings-api:pr-386-ad7cdf3-20240617102538 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
+      environment:
+        HMC_API_URL: "http://hmc-cft-hearing-service-test.service.core-compute-test.internal"      


### PR DESCRIPTION
### Jira link (if applicable)

IA - configure dummy URL to force failure calling HMC API

### Change description ###

IA - configure dummy URL to force failure calling HMC API
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ia/ia-hearings-api/demo.yaml
- Added a new environment variable `HMC_API_URL` with the value \"http://hmc-cft-hearing-service-test.service.core-compute-test.internal\" 🆕