### PR TITLE
ASO: fix sbox patches

### DIFF
--- a/apps/azureserviceoperator-system/sbox/base/kustomization.yaml
+++ b/apps/azureserviceoperator-system/sbox/base/kustomization.yaml
@@ -11,6 +11,7 @@ patches:
         value: --crd-pattern=managedidentity.azure.com/*;servicebus.azure.com/*;resources.azure.com/*;managedidentity.azure.com/*;storage.azure.com/*;dbforpostgresql.azure.com/*
     target:
       kind: Deployment
+      name: azureserviceoperator-controller-manager
   - patch: |-
       - op: replace
         path: /spec/template/spec/nodeSelector
@@ -18,6 +19,8 @@ patches:
           kubernetes.azure.com/agentpool: system
     target:
       kind: Deployment
+      name: azureserviceoperator-controller-manager
   - target:
       kind: Deployment
+      name: azureserviceoperator-controller-manager
     path: toleration_replicas_patch.yaml


### PR DESCRIPTION
Moved around to just upgrade sbox but patches applying to cert-manager when it didn't before so have fixed that



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### File Changed: kustomization.yaml
- Added a new target for a Kubernetes deployment with the name `azureserviceoperator-controller-manager`.
- Includes a patch to add a toleration for the `azureserviceoperator-controller-manager` deployment.
- Updated the patches for nodeSelector and tolerations for the `azureserviceoperator-controller-manager` deployment.