### PR TITLE
ADOP-2489 stop updating ITHC based on Demo Image Policy

### DIFF
--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -7,7 +7,6 @@ spec:
   interval: 1m
   values:
     java:
-      image: hmctspublic.azurecr.io/adoption/cos-api:pr-917-2cf7756-20240610114151 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
         RELEASE: AGAIN
         APP_INSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/ADOP-2489

### Change description ###
stop updating ITHC based on Demo Image Policy


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cos-api/ithc.yaml
- Removed the image configuration for the Java environment.
- Removed the environment variables for RELEASE and APP_INSIGHTS_KEY.