### PR TITLE
Aso: servicebus resources from v1beta to v1api

### DIFF
--- a/apps/am/preview/aso/am-servicebus.yaml
+++ b/apps/am/preview/aso/am-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/am/preview/aso/am-servicebus.yaml
+++ b/apps/am/preview/aso/am-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/azureserviceoperator-system/resources/servicebus-namespace.yaml
+++ b/apps/azureserviceoperator-system/resources/servicebus-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/azureserviceoperator-system/resources/servicebus-namespace.yaml
+++ b/apps/azureserviceoperator-system/resources/servicebus-namespace.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/bsp/preview/aso/bsp-servicebus.yaml
+++ b/apps/bsp/preview/aso/bsp-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/bsp/preview/aso/bsp-servicebus.yaml
+++ b/apps/bsp/preview/aso/bsp-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/ccd/preview/aso/ccd-servicebus.yaml
+++ b/apps/ccd/preview/aso/ccd-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/ccd/preview/aso/ccd-servicebus.yaml
+++ b/apps/ccd/preview/aso/ccd-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/chart-tests/azure-service-operator/aso.yaml
+++ b/apps/chart-tests/azure-service-operator/aso.yaml
@@ -24,7 +24,7 @@ spec:
     environment: development
     exemptFromAutoLock: "true"
 ---
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: chart-tests-servicebus

--- a/apps/chart-tests/azure-service-operator/aso.yaml
+++ b/apps/chart-tests/azure-service-operator/aso.yaml
@@ -24,7 +24,7 @@ spec:
     environment: development
     exemptFromAutoLock: "true"
 ---
-apiVersion: servicebus.azure.com/v1api20211101
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: chart-tests-servicebus

--- a/apps/civil/preview/aso/civil-servicebus.yaml
+++ b/apps/civil/preview/aso/civil-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/civil/preview/aso/civil-servicebus.yaml
+++ b/apps/civil/preview/aso/civil-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/et/preview/aso/et-servicebus.yaml
+++ b/apps/et/preview/aso/et-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/et/preview/aso/et-servicebus.yaml
+++ b/apps/et/preview/aso/et-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/fees-pay/preview/aso/fees-pay-servicebus.yaml
+++ b/apps/fees-pay/preview/aso/fees-pay-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/fees-pay/preview/aso/fees-pay-servicebus.yaml
+++ b/apps/fees-pay/preview/aso/fees-pay-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/hmc/preview/aso/hmc-servicebus.yaml
+++ b/apps/hmc/preview/aso/hmc-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/hmc/preview/aso/hmc-servicebus.yaml
+++ b/apps/hmc/preview/aso/hmc-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/ia/preview/aso/ia-servicebus.yaml
+++ b/apps/ia/preview/aso/ia-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/ia/preview/aso/ia-servicebus.yaml
+++ b/apps/ia/preview/aso/ia-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/rd/preview/aso/rd-servicebus.yaml
+++ b/apps/rd/preview/aso/rd-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/rd/preview/aso/rd-servicebus.yaml
+++ b/apps/rd/preview/aso/rd-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/reform-scan/preview/aso/reform-scan-servicebus.yaml
+++ b/apps/reform-scan/preview/aso/reform-scan-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/reform-scan/preview/aso/reform-scan-servicebus.yaml
+++ b/apps/reform-scan/preview/aso/reform-scan-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/sptribs/preview/aso/sptribs-servicebus.yaml
+++ b/apps/sptribs/preview/aso/sptribs-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/sptribs/preview/aso/sptribs-servicebus.yaml
+++ b/apps/sptribs/preview/aso/sptribs-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/sscs/preview/aso/sscs-servicebus.yaml
+++ b/apps/sscs/preview/aso/sscs-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1beta20210101preview
+apiVersion: servicebus.azure.com/v1api20210101preview
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/apps/sscs/preview/aso/sscs-servicebus.yaml
+++ b/apps/sscs/preview/aso/sscs-servicebus.yaml
@@ -1,4 +1,4 @@
-apiVersion: servicebus.azure.com/v1api20210101preview
+apiVersion: servicebus.azure.com/v1api20211101
 kind: Namespace
 metadata:
   name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/docs/aso-setup-v2.md
+++ b/docs/aso-setup-v2.md
@@ -24,7 +24,7 @@ Note: You need to [install yq](https://mikefarah.gitbook.io/yq/) for these scrip
 - Create a patch `<namespace>-servicebus.yaml` in `apps/<namespace>/<environment>/aso` as below:
 
     ```yaml
-    apiVersion: servicebus.azure.com/v1beta20210101preview
+    apiVersion: servicebus.azure.com/v1api20210101preview
     kind: Namespace
     metadata:
       name: ${NAMESPACE}-servicebus-${ENVIRONMENT}
@@ -37,7 +37,7 @@ Note: You need to [install yq](https://mikefarah.gitbook.io/yq/) for these scrip
   You can get correct application tag value from [team config](https://github.com/hmcts/cnp-jenkins-config/blob/master/team-config.yml)
 - ServiceBus namespace is setup as `Basic` tier by default. [If you want any features not in `Basic`](https://www.azure.cn/en-us/pricing/details/service-bus/) like Topics/ Sessions, you can override the tier in the patch file created above.
      ```yaml
-    apiVersion: servicebus.azure.com/v1beta20210101preview
+    apiVersion: servicebus.azure.com/v1api20210101preview
     kind: Namespace
     metadata:
       name: ${NAMESPACE}-servicebus-${ENVIRONMENT}

--- a/docs/aso-setup-v2.md
+++ b/docs/aso-setup-v2.md
@@ -24,7 +24,7 @@ Note: You need to [install yq](https://mikefarah.gitbook.io/yq/) for these scrip
 - Create a patch `<namespace>-servicebus.yaml` in `apps/<namespace>/<environment>/aso` as below:
 
     ```yaml
-    apiVersion: servicebus.azure.com/v1api20210101preview
+    apiVersion: servicebus.azure.com/v1api20211101
     kind: Namespace
     metadata:
       name: ${NAMESPACE}-servicebus-${ENVIRONMENT}
@@ -37,7 +37,7 @@ Note: You need to [install yq](https://mikefarah.gitbook.io/yq/) for these scrip
   You can get correct application tag value from [team config](https://github.com/hmcts/cnp-jenkins-config/blob/master/team-config.yml)
 - ServiceBus namespace is setup as `Basic` tier by default. [If you want any features not in `Basic`](https://www.azure.cn/en-us/pricing/details/service-bus/) like Topics/ Sessions, you can override the tier in the patch file created above.
      ```yaml
-    apiVersion: servicebus.azure.com/v1api20210101preview
+    apiVersion: servicebus.azure.com/v1api20211101
     kind: Namespace
     metadata:
       name: ${NAMESPACE}-servicebus-${ENVIRONMENT}


### PR DESCRIPTION
Necessary to enable upgrading Azure Service Operator fully
v1api20210101preview is right for current v2.3 of aso that we are on

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- am-servicebus.yaml```:
  - Changed the `apiVersion` from `servicebus.azure.com/v1beta20210101preview` to `servicebus.azure.com/v1api20211101`

- ```servicebus-namespace.yaml```:
  - Changed the `apiVersion` from `servicebus.azure.com/v1beta20210101preview` to `servicebus.azure.com/v1api20211101`

- ```bsp-servicebus.yaml```:
  - Changed the `apiVersion` from `servicebus.azure.com/v1beta20210101preview` to `servicebus.azure.com/v1api20211101`

- ```fees-pay-servicebus.yaml```:
  - Changed the `apiVersion` from `servicebus.azure.com/v1beta20210101preview` to `servicebus.azure.com/v1api20211101`

- ```rd-servicebus.yaml```:
  - Changed the `apiVersion` from `servicebus.azure.com/v1beta20210101preview` to `servicebus.azure.com/v1api20211101`

- ```aso-setup-v2.md```:
  - Updated the `apiVersion` from `servicebus.azure.com/v1beta20210101preview` to `servicebus.azure.com/v1api20211101` for different files.