### PR TITLE
Update Docmosis ingress in sbox

### DIFF
--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.middlewares: docmosis-apiredirect@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-api-rewrite@kubernetescrd
   name: docmosis-ingress
   namespace: docmosis
 spec:
@@ -18,15 +18,15 @@ spec:
                 name: docmosis-base
                 port:
                   number: 80
-            path: /
-            pathType: ImplementationSpecific
+            path: /rs
+            pathType: Prefix
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  name: apiredirect
+  name: api-rewrite
   namespace: docmosis
 spec:
-  redirectRegex:
-    regex: ^http://docmosis.sandbox.platform.hmcts.net/rs/(.*)
-    replacement: https://docmosis.sandbox.platform.hmcts.net/api/$1
+  replacePathRegex:
+    regex: "^/rs/(.*)"
+    replacement: "/api/$1"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18048


### Change description ###
- Trying to get path rewrite working in sbox
- Redirect works but rewrite seems more suitable for this case

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- In `docmosis-ingress.yaml`, the middleware annotation was updated from `docmosis-apiredirect` to `docmosis-api-rewrite` for traefik. The path was also updated from `/` to `/rs` and `redirectRegex` was replaced with `replacePathRegex` with corresponding regex and replacement values.