### PR TITLE
Fix typo in Docmosis middleware

### DIFF
--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  name: api-rewrite
+  name: docmosis-api-rewrite
   namespace: docmosis
 spec:
   replacePathRegex:


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
- Updates name of path rewrite middleware to match annotation
- Trying to fix below Traefik error

`time="2024-07-01T13:28:30Z" level=error msg="middleware \"docmosis-api-rewrite@kubernetescrd\" does not exist" entryPointName=web routerName=docmosis-docmosis-ingress-docmosis-sandbox-platform-hmcts-net-rs@kubernetes`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/docmosis/sbox/base/docmosis-ingress.yaml
- Updated the middleware `name` from `api-rewrite` to `docmosis-api-rewrite`.