### PR TITLE
Fix docmosis sbox middleware

### DIFF
--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -4,7 +4,7 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.middlewares: docmosis-api-rewrite@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-rstoapipathrewrite@kubernetescrd
   name: docmosis-ingress
   namespace: docmosis
 spec:
@@ -17,14 +17,14 @@ spec:
               service:
                 name: docmosis-base
                 port:
-                  number: 80
+                  number: 8080
             path: /rs
             pathType: Prefix
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
-  name: docmosis-api-rewrite
+  name: rstoapipathrewrite
   namespace: docmosis
 spec:
   replacePathRegex:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18048


### Change description ###
- Updates middleware name to not include namespace
- Updates backend port to `8080` as used by Docmosis service

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Modified file: `docmosis-ingress.yaml`
- Updated the router middlewares annotation from `docmosis-api-rewrite` to `docmosis-rstoapipathrewrite`
- Changed the port number from `80` to `8080`
- Updated the middleware name from `docmosis-api-rewrite` to `rstoapipathrewrite`