### PR TITLE
Update docmosis ingress

### DIFF
--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -17,7 +17,7 @@ spec:
               service:
                 name: docmosis-base
                 port:
-                  number: 8080
+                  number: 80
             path: /rs
             pathType: Prefix
 ---

--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -18,7 +18,7 @@ spec:
                 name: docmosis-base
                 port:
                   number: 80
-            path: /rs
+            path: /
             pathType: Prefix
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -17,7 +17,7 @@ spec:
                 name: docmosis-base
                 port:
                   number: 80
-            path: /
+            path: /rs
             pathType: Prefix
 ---
 apiVersion: traefik.containo.us/v1alpha1

--- a/apps/docmosis/sbox/base/docmosis-ingress.yaml
+++ b/apps/docmosis/sbox/base/docmosis-ingress.yaml
@@ -8,7 +8,6 @@ metadata:
   name: docmosis-ingress
   namespace: docmosis
 spec:
-  ingressClassName: traefik
   rules:
     - host: docmosis.sandbox.platform.hmcts.net
       http:


### PR DESCRIPTION
### Jira link (if applicable)


### Change description ###
- Changes backend port back to `80`
- Removes `ingressClassName`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **docmosis-ingress.yaml**
  - Changed the port number from 8080 to 80 for the `docmosis-base` service.