### PR TITLE
ASO: Resource group resources to v1api

### DIFF
--- a/apps/azureserviceoperator-system/resources/resource-group.yaml
+++ b/apps/azureserviceoperator-system/resources/resource-group.yaml
@@ -1,4 +1,4 @@
-apiVersion: resources.azure.com/v1beta20200601
+apiVersion: resources.azure.com/v1api20200601
 kind: ResourceGroup
 metadata:
   name: ${NAMESPACE}-aso-${ENVIRONMENT}-rg

--- a/apps/base/workload-identity/workload-identity-rg.yaml
+++ b/apps/base/workload-identity/workload-identity-rg.yaml
@@ -1,4 +1,4 @@
-apiVersion: resources.azure.com/v1beta20200601
+apiVersion: resources.azure.com/v1api20200601
 kind: ResourceGroup
 metadata:
   name: managed-identities-${WI_ENVIRONMENT}-rg

--- a/apps/bsp/preview/aso/resource-group-old.yaml
+++ b/apps/bsp/preview/aso/resource-group-old.yaml
@@ -1,5 +1,5 @@
 # TODO: update resource group name in bulk scan processor and clean up
-apiVersion: resources.azure.com/v1beta20200601
+apiVersion: resources.azure.com/v1api20200601
 kind: ResourceGroup
 metadata:
   name: bulk-scan-aks-rg


### PR DESCRIPTION
Necessary to upgrade ASO fully

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **resource-group.yaml**
  - Updated the `apiVersion` from `resources.azure.com/v1beta20200601` to `resources.azure.com/v1api20200601`.

- **workload-identity-rg.yaml**
  - Updated the `apiVersion` from `resources.azure.com/v1beta20200601` to `resources.azure.com/v1api20200601`.

- **resource-group-old.yaml**
  - Updated the `apiVersion` from `resources.azure.com/v1beta20200601` to `resources.azure.com/v1api20200601`.