### PR TITLE
updating perftest to use a PR image

### DIFF
--- a/apps/camunda/automation/kustomization.yaml
+++ b/apps/camunda/automation/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - ../camunda/image-repo.yaml
   - ../camunda/image-policy.yaml
   - ../camunda/upgrade-image-policy.yaml
+  - ../camunda/perftest-image-policy.yaml

--- a/apps/camunda/camunda-api/perftest.yaml
+++ b/apps/camunda/camunda-api/perftest.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivate.azurecr.io/camunda/bpm:pr-849-ecbff45-20240702091349 #{"$imagepolicy": "flux-system:camunda"}
       memoryRequests: '2Gi'
       memoryLimits: '4Gi'
       cpuRequests: '1'

--- a/apps/camunda/camunda-ui/perftest.yaml
+++ b/apps/camunda/camunda-ui/perftest.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivate.azurecr.io/camunda/bpm:pr-849-ecbff45-20240702091349 #{"$imagepolicy": "flux-system:camunda"}
       ingressClass: traefik

--- a/apps/camunda/camunda/perftest-image-policy.yaml
+++ b/apps/camunda/camunda/perftest-image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: perftest-camunda
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: '^pr-849-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: camunda


### PR DESCRIPTION
### Jira link (https://tools.hmcts.net/jira/browse/DTSPO-18166)



### Updating Perf Test Camunda to use a PR image ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **apps/camunda/automation/kustomization.yaml**
  - Added a new image policy file for performance testing.

- **apps/camunda/camunda-api/perftest.yaml**
  - Updated the Java image to \"hmctsprivate.azurecr.io/camunda/bpm:pr-849-ecbff45-20240702091349\".
  - Adjusted memory requests, memory limits, and CPU requests.

- **apps/camunda/camunda-ui/perftest.yaml**
  - Updated the Java image to \"hmctsprivate.azurecr.io/camunda/bpm:pr-849-ecbff45-20240702091349\".
  - Set the ingress class to \"traefik\".

- **apps/camunda/camunda/perftest-image-policy.yaml**
  - Added a new file for image policy related to performance testing.