### PR TITLE
Add path rewrite to docmosis demo

### DIFF
--- a/apps/docmosis/demo/base/docmosis-ingress.yaml
+++ b/apps/docmosis/demo/base/docmosis-ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-rstoapipathrewrite@kubernetescrd
+  name: docmosis-ingress
+  namespace: docmosis
+spec:
+  rules:
+    - host: docmosis.demo.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: docmosis-base
+                port:
+                  number: 80
+            path: /rs
+            pathType: Prefix
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: rstoapipathrewrite
+  namespace: docmosis
+spec:
+  replacePathRegex:
+    regex: "^/rs/(.*)"
+    replacement: "/api/$1"

--- a/apps/docmosis/demo/base/kustomization.yaml
+++ b/apps/docmosis/demo/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
 namespace: docmosis
 patches:
   - path: ../../docmosis/demo.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18048


### Change description ###
- Deploying new ingress to demo with middleware to rewrite `/rs/...` to `/api/...`
- Used to test docmosis upgrade

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created a new file `docmosis-ingress.yaml` to define the Ingress for the docmosis application with route and middleware configurations.
- Updated the `kustomization.yaml` file to include the new `docmosis-ingress.yaml` file in the resources section.