### PR TITLE
Move ingress from Docmosis demo to ithc for testing

### DIFF
--- a/apps/docmosis/demo/base/kustomization.yaml
+++ b/apps/docmosis/demo/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
-  - docmosis-ingress.yaml
 namespace: docmosis
 patches:
   - path: ../../docmosis/demo.yaml

--- a/apps/docmosis/ithc/base/docmosis-ingress.yaml
+++ b/apps/docmosis/ithc/base/docmosis-ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-rstoapipathrewrite@kubernetescrd
+  name: docmosis-ingress
+  namespace: docmosis
+spec:
+  rules:
+    - host: docmosis.ithc.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: docmosis-base
+                port:
+                  number: 80
+            path: /rs
+            pathType: Prefix
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: rstoapipathrewrite
+  namespace: docmosis
+spec:
+  replacePathRegex:
+    regex: "^/rs/(.*)"
+    replacement: "/api/$1"

--- a/apps/docmosis/ithc/base/kustomization.yaml
+++ b/apps/docmosis/ithc/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
 namespace: docmosis
 patches:
   - path: ../../docmosis/ithc.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18048


### Change description ###
- Removes ingress from demo `kustomization.yaml`
- Adds `docmosis-ingress.yaml` to `ithc/base`
- Adds ingress to ithc `kustomization.yaml`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/docmosis/demo/base/kustomization.yaml
- Removed the reference to `docmosis-ingress.yaml` in the resources list.

### apps/docmosis/ithc/base/docmosis-ingress.yaml
- Added a new file for Ingress configuration with hostname and path rules.
- Added a middleware configuration for path rewriting.

### apps/docmosis/ithc/base/kustomization.yaml
- Added the reference to `docmosis-ingress.yaml` in the resources list.