### PR TITLE
DTSRD-3041

### DIFF
--- a/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
+++ b/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
@@ -17,7 +17,7 @@ spec:
       imagePullPolicy: Always
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
+++ b/apps/rd/rd-caseworker-ref-api/rd-caseworker-ref-api.yaml
@@ -17,6 +17,7 @@ spec:
       imagePullPolicy: Always
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-commondata-api/rd-commondata-api.yaml
+++ b/apps/rd/rd-commondata-api/rd-commondata-api.yaml
@@ -16,6 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/commondata-api:prod-5960c7c-20240618160639 #{"$imagepolicy": "flux-system:rd-commondata-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-commondata-api/rd-commondata-api.yaml
+++ b/apps/rd/rd-commondata-api/rd-commondata-api.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/commondata-api:prod-5960c7c-20240618160639 #{"$imagepolicy": "flux-system:rd-commondata-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-judicial-api/rd-judicial-api.yaml
+++ b/apps/rd/rd-judicial-api/rd-judicial-api.yaml
@@ -16,6 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/judicial-api:prod-6f8d01f-20240617202017 #{"$imagepolicy": "flux-system:rd-judicial-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-judicial-api/rd-judicial-api.yaml
+++ b/apps/rd/rd-judicial-api/rd-judicial-api.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/judicial-api:prod-6f8d01f-20240617202017 #{"$imagepolicy": "flux-system:rd-judicial-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-judicial-data-load/rd-judicial-data-load.yaml
+++ b/apps/rd/rd-judicial-data-load/rd-judicial-data-load.yaml
@@ -9,6 +9,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/judicial-data-load:prod-9c04ad0-20240606170610 #{"$imagepolicy": "flux-system:rd-judicial-data-load"}
       environment:
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-judicial-data-load/rd-judicial-data-load.yaml
+++ b/apps/rd/rd-judicial-data-load/rd-judicial-data-load.yaml
@@ -9,7 +9,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/judicial-data-load:prod-9c04ad0-20240606170610 #{"$imagepolicy": "flux-system:rd-judicial-data-load"}
       environment:
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
+++ b/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
@@ -16,6 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/location-ref-api:prod-a0c22c7-20240621102007 #{"$imagepolicy": "flux-system:rd-location-ref-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
+++ b/apps/rd/rd-location-ref-api/rd-location-ref-api.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/location-ref-api:prod-a0c22c7-20240621102007 #{"$imagepolicy": "flux-system:rd-location-ref-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-location-ref-data-load/rd-location-ref-data-load.yaml
+++ b/apps/rd/rd-location-ref-data-load/rd-location-ref-data-load.yaml
@@ -9,7 +9,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/location-ref-data-load:prod-2d2f1e0-20240704114959 #{"$imagepolicy": "flux-system:rd-location-ref-data-load"}
       environment:
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-location-ref-data-load/rd-location-ref-data-load.yaml
+++ b/apps/rd/rd-location-ref-data-load/rd-location-ref-data-load.yaml
@@ -9,6 +9,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/rd/location-ref-data-load:prod-2d2f1e0-20240704114959 #{"$imagepolicy": "flux-system:rd-location-ref-data-load"}
       environment:
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-professional-api/rd-professional-api.yaml
+++ b/apps/rd/rd-professional-api/rd-professional-api.yaml
@@ -16,6 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/professional-api:prod-63a0021-20240617202037 #{"$imagepolicy": "flux-system:rd-professional-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-professional-api/rd-professional-api.yaml
+++ b/apps/rd/rd-professional-api/rd-professional-api.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/professional-api:prod-63a0021-20240617202037 #{"$imagepolicy": "flux-system:rd-professional-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-profile-sync/rd-profile-sync.yaml
+++ b/apps/rd/rd-profile-sync/rd-profile-sync.yaml
@@ -16,6 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/profile-sync:prod-6d44e8f-20240704100558 #{"$imagepolicy": "flux-system:rd-profile-sync"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-profile-sync/rd-profile-sync.yaml
+++ b/apps/rd/rd-profile-sync/rd-profile-sync.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/profile-sync:prod-6d44e8f-20240704100558 #{"$imagepolicy": "flux-system:rd-profile-sync"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: false
   chart:
     spec:

--- a/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
+++ b/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
@@ -14,7 +14,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/user-profile-api:prod-65cfcde-20240617202024 #{"$imagepolicy": "flux-system:rd-user-profile-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
-        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:

--- a/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
+++ b/apps/rd/rd-user-profile-api/rd-user-profile-api.yaml
@@ -14,6 +14,7 @@ spec:
       image: hmctspublic.azurecr.io/rd/user-profile-api:prod-65cfcde-20240617202024 #{"$imagepolicy": "flux-system:rd-user-profile-api"}
       environment:
         ROOT_LOGGING_LEVEL: WARN
+        TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX : hmctspublic.azurecr.io/imported/
         DUMMY_VAR: true
   chart:
     spec:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSRD-3041

### Change description ###

set prefix for docker images to point to hmctspublic registry

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `rd-caseworker-ref-api.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-commondata-api.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-judicial-api.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-judicial-data-load.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-location-ref-api.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-location-ref-data-load.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-professional-api.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-profile-sync.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.

- `rd-user-profile-api.yaml`:
  - Added environment variable `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` with value `hmctspublic.azurecr.io/imported/`.