### PR TITLE
Docmosis: increase memory requests and limits for docmosis (prod and perftest)

### DIFF
--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -4,10 +4,12 @@ metadata:
   name: docmosis
 spec:
   values:
+    replicas: 3
     ingressHost: docmosis.perftest.platform.hmcts.net
     image: hmctsprivate.azurecr.io/docmosis:perftest-a166909-607396 #{"$imagepolicy": "flux-system:perftest-docmosis"}
     java:
-      memoryRequests: "2Gi"
+      memoryRequests: "3Gi"
+      memoryLimits: "4Gi"
       keyVaults:
         docmosis-infra:
           secrets:

--- a/apps/docmosis/docmosis/prod.yaml
+++ b/apps/docmosis/docmosis/prod.yaml
@@ -4,11 +4,11 @@ metadata:
   name: docmosis
 spec:
   values:
-    memoryRequests: "2Gi"
     replicas: 3
     ingressHost: docmosis.platform.hmcts.net
     java:
-      memoryRequests: "2Gi"
+      memoryRequests: "3Gi"
+      memoryLimits: "4Gi"
       keyVaults:
         docmosis-infra:
           secrets:


### PR DESCRIPTION
An issue is open due to intermittent errors in docmosis
Seeing some OOM Killed errors
Perftest mirrors production updates

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `perftest.yaml`: 
  - Changed memoryRequests from \"2Gi\" to \"3Gi\" and added memoryLimits \"4Gi\", and adjusted replicas to 3.

- Updated `prod.yaml`: 
  - Changed memoryRequests from \"2Gi\" to \"3Gi\" and added memoryLimits \"4Gi\".