### PR TITLE
Revert "schedule venue migration"

### DIFF
--- a/apps/sscs/sscs-case-loader/prod-00.yaml
+++ b/apps/sscs/sscs-case-loader/prod-00.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0/10 19-23,0-6 * * *"
+      schedule: "0 21-23,0-7 * * *"
       startingDeadlineSeconds: 1800
       concurrencyPolicy: Forbid
       memoryRequests: "768Mi"
@@ -22,15 +22,15 @@ spec:
         APACHE_LOG_LEVEL: DEBUG
         PROCESS_MINOR_EVENTS: false
         USE_EXISTING_DATE: false
-        CASE_LOADER_START_HOUR: 24
+        CASE_LOADER_START_HOUR: 21
         CASE_LOADER_END_HOUR: 24
         INTERPRETER_DATA_MIGRATION_ENABLED: false
         INTERPRETER_MIGRATION_ROLLBACK: false
         INTERPRETER_MIGRATION_START_HOUR: 20
         INTERPRETER_MIGRATION_END_HOUR: 24
-        VENUE_MIGRATION_ENABLED: true
+        VENUE_MIGRATION_ENABLED: false
         VENUE_MIGRATION_ROLLBACK: false
-        VENUE_MIGRATION_START_HOUR: 19
+        VENUE_MIGRATION_START_HOUR: 20
         VENUE_MIGRATION_END_HOUR: 24
     global:
       environment: prod


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#32747

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/sscs/sscs-case-loader/prod-00.yaml
- Updated the job schedule from \"0/10 19-23,0-6 * * *\" to \"0 21-23,0-7 * * *\"
- Changed the value of CASE_LOADER_START_HOUR from 24 to 21
- Updated the value of INTERPRETER_MIGRATION_START_HOUR from 20 to 21
- Changed the value of VENUE_MIGRATION_ENABLED from true to false
- Updated the value of VENUE_MIGRATION_START_HOUR from 19 to 20