### PR TITLE
Revert "Revert "Readding replicas""

### DIFF
--- a/apps/ccd/ccd-definition-store-api/aat.yaml
+++ b/apps/ccd/ccd-definition-store-api/aat.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-definition-store-api
   values:
     java:
-      replicas: 0
+      replicas: 2
       memoryRequests: "2Gi"
       memoryLimits: "8Gi"
       cpuRequests: "1"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#32797

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `apps/ccd/ccd-definition-store-api/aat.yaml` has increased the number of replicas from 0 to 2 for the Java service. Memory requests have also been updated to \"2Gi\" and memory limits to \"8Gi\". CPU requests remain the same at \"1\".