### PR TITLE
Update to patch service account in all envs

### DIFF
--- a/apps/monitoring/aat/base/kustomization.yaml
+++ b/apps/monitoring/aat/base/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
   - ../../failed-deployments
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
+patches:
+- path: ../../serviceaccount/aat.yaml

--- a/apps/monitoring/aat/base/kustomization.yaml
+++ b/apps/monitoring/aat/base/kustomization.yaml
@@ -15,4 +15,4 @@ resources:
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
 patches:
-- path: ../../serviceaccount/aat.yaml
+  - path: ../../serviceaccount/aat.yaml

--- a/apps/monitoring/demo/base/kustomization.yaml
+++ b/apps/monitoring/demo/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - ../../failed-deployments
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
+patches:
+- path: ../../serviceaccount/demo.yaml

--- a/apps/monitoring/demo/base/kustomization.yaml
+++ b/apps/monitoring/demo/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
 patches:
-- path: ../../serviceaccount/demo.yaml
+  - path: ../../serviceaccount/demo.yaml

--- a/apps/monitoring/ithc/base/kustomization.yaml
+++ b/apps/monitoring/ithc/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
 patches:
-- path: ../../serviceaccount/ithc.yaml
+  - path: ../../serviceaccount/ithc.yaml

--- a/apps/monitoring/ithc/base/kustomization.yaml
+++ b/apps/monitoring/ithc/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - ../../failed-deployments
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
+patches:
+- path: ../../serviceaccount/ithc.yaml

--- a/apps/monitoring/perftest/base/kustomization.yaml
+++ b/apps/monitoring/perftest/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
 patches:
-- path: ../../serviceaccount/perftest.yaml
+  - path: ../../serviceaccount/perftest.yaml

--- a/apps/monitoring/perftest/base/kustomization.yaml
+++ b/apps/monitoring/perftest/base/kustomization.yaml
@@ -11,3 +11,5 @@ resources:
   - ../../failed-deployments
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
+patches:
+- path: ../../serviceaccount/perftest.yaml

--- a/apps/monitoring/prod/base/kustomization.yaml
+++ b/apps/monitoring/prod/base/kustomization.yaml
@@ -15,4 +15,4 @@ resources:
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
 patches:
-- path: ../../serviceaccount/sbox.yaml
+- path: ../../serviceaccount/prod.yaml

--- a/apps/monitoring/prod/base/kustomization.yaml
+++ b/apps/monitoring/prod/base/kustomization.yaml
@@ -15,4 +15,4 @@ resources:
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
 patches:
-- path: ../../serviceaccount/prod.yaml
+  - path: ../../serviceaccount/prod.yaml

--- a/apps/monitoring/prod/base/kustomization.yaml
+++ b/apps/monitoring/prod/base/kustomization.yaml
@@ -14,3 +14,5 @@ resources:
   - ../../failed-deployments
   - ../../version-reporter/rbac.yaml
   - ../../version-reporter/platopsapps/platops-apps.yaml
+patches:
+- path: ../../serviceaccount/sbox.yaml

--- a/apps/monitoring/sbox/base/kustomization.yaml
+++ b/apps/monitoring/sbox/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 
 patches:
 - path: ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml
+- path: ../../serviceaccount/sbox.yaml

--- a/apps/monitoring/sbox/base/kustomization.yaml
+++ b/apps/monitoring/sbox/base/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
 - prometheus-values.yaml
 
 patches:
-  - path: ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml
-  - path: ../../serviceaccount/sbox.yaml
+- path: ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml
+- path: ../../serviceaccount/sbox.yaml

--- a/apps/monitoring/sbox/base/kustomization.yaml
+++ b/apps/monitoring/sbox/base/kustomization.yaml
@@ -7,5 +7,5 @@ resources:
 - prometheus-values.yaml
 
 patches:
-- path: ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml
-- path: ../../serviceaccount/sbox.yaml
+  - path: ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml
+  - path: ../../serviceaccount/sbox.yaml


### PR DESCRIPTION
Missed this from previous pr: https://github.com/hmcts/cnp-flux-config/pull/new/fix-service-accounts

So service accounts are not annotated, so they are not using workload identity

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/monitoring/aat/base/kustomization.yaml
- Added a new patch to the kustomization file for serviceaccount/aat.yaml.

### apps/monitoring/demo/base/kustomization.yaml
- Added a new patch to the kustomization file for serviceaccount/demo.yaml.

### apps/monitoring/ithc/base/kustomization.yaml
- Added a new patch to the kustomization file for serviceaccount/ithc.yaml.

### apps/monitoring/perftest/base/kustomization.yaml
- Added a new patch to the kustomization file for serviceaccount/perftest.yaml.

### apps/monitoring/prod/base/kustomization.yaml
- Added a new patch to the kustomization file for serviceaccount/prod.yaml.

### apps/monitoring/sbox/base/kustomization.yaml
- Added a new patch to the kustomization file for serviceaccount/sbox.yaml.