### PR TITLE
Disable spot to try to fix dynatrace one-agent error

### DIFF
--- a/apps/monitoring/version-reporter/platopsapps/platops-apps.yaml
+++ b/apps/monitoring/version-reporter/platopsapps/platops-apps.yaml
@@ -22,6 +22,8 @@ spec:
       enableKeyVaults: true
     schedule: "30 8 * * 1-5" # interval 8:30am weekdays
     concurrencyPolicy: "Forbid"
+    spotInstances:
+      enabled: false
     failedJobsHistoryLimit: 5
     startingDeadlineSeconds: 300
     successfulJobsHistoryLimit: 5


### PR DESCRIPTION

MountVolume.SetUp failed for volume "oneagent-bin" : kubernetes.io/csi: mounter.SetUpAt failed to get CSI client: driver name csi.oneagent.dynatrace.com not found in the list of registered CSI drivers


Seen this resolved in green a few times by disabling spot for the job -- need to look into the root cause though too


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated file: `apps/monitoring/version-reporter/platopsapps/platops-apps.yaml`
  - Added a new configuration for spot instances, with the `enabled` flag set to `false`.