### PR TITLE
Update to use linux node pool

### DIFF
--- a/apps/monitoring/version-reporter/platopsapps/platops-apps.yaml
+++ b/apps/monitoring/version-reporter/platopsapps/platops-apps.yaml
@@ -45,7 +45,7 @@ spec:
           - name: cosmos-db-name
             alias: COSMOS_DB_NAME
     nodeSelector:
-      agentpool: cronjob
+      agentpool: linux
     tolerations:
       - key: dedicated
         effect: NoSchedule

--- a/apps/monitoring/version-reporter/platopsapps/platops-apps.yaml
+++ b/apps/monitoring/version-reporter/platopsapps/platops-apps.yaml
@@ -20,7 +20,7 @@ spec:
     global:
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
-    schedule: "30 8 * * 1-5" # interval 8:30am weekdays
+    schedule: "30 9 * * 1" # interval 9:30am Monday
     concurrencyPolicy: "Forbid"
     failedJobsHistoryLimit: 5
     startingDeadlineSeconds: 300


### PR DESCRIPTION
Raised this PR yesterday to allow scheduling to cronjob nodes - https://github.com/hmcts/cnp-flux-config/pull/new/schedule-linux but this is allow not enforce -- so there was a few errors this morning still in envs where dynatrace is involved and csidriver pods hadn't been scheduled in the desired place

This PR would move the platopsapp job to run on linux nodepool so the pods are always guaranteed to run


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated schedule time in `platops-apps.yaml` from \"30 8 * * 1-5\" to \"30 9 * * 1\"
- Updated `agentpool` in `platops-apps.yaml` from `cronjob` to `linux`