### PR TITLE
Revert "point BO back to prod"

### DIFF
--- a/apps/probate/probate-back-office/demo-image-policy.yaml
+++ b/apps/probate/probate-back-office/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2607-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#32893

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/probate/probate-back-office/demo-image-policy.yaml
- Changed filterTags pattern from `^prod-[a-f0-9]+-(?P<ts>[0-9]+)` to `^pr-2607-[a-f0-9]+-(?P<ts>[0-9]+)` for demo image policy.