### PR TITLE
[NFDIV-4180] Remove references to old images in demo

### DIFF
--- a/apps/nfdiv/nfdiv-case-api/demo-image-policy.yaml
+++ b/apps/nfdiv/nfdiv-case-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-nfdiv-case-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-3783-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: nfdiv-case-api

--- a/apps/nfdiv/nfdiv-case-api/demo.yaml
+++ b/apps/nfdiv/nfdiv-case-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/nfdiv/case-api:pr-3783-f7f2d1e-20240619145112 #{"$imagepolicy": "flux-system:demo-nfdiv-case-api"}
+      image: hmctspublic.azurecr.io/nfdiv/case-api:prod-363a47f-20240716071725 #{"$imagepolicy": "flux-system:demo-nfdiv-case-api"}
       environment:
         CASE_HOLDING_WEEKS: 20
         BULK_ACTION_BATCH_SIZE_MIN: 3

--- a/apps/nfdiv/nfdiv-frontend/demo-image-policy.yaml
+++ b/apps/nfdiv/nfdiv-frontend/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-nfdiv-frontend
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-3545-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: nfdiv-frontend

--- a/apps/nfdiv/nfdiv-frontend/demo.yaml
+++ b/apps/nfdiv/nfdiv-frontend/demo.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     nodejs:
       ingressHost: nfdiv.demo.platform.hmcts.net
-      image: hmctspublic.azurecr.io/nfdiv/frontend:pr-3545-359e1cd-20240618091611 #{"$imagepolicy": "flux-system:demo-nfdiv-frontend"}
+      image: hmctspublic.azurecr.io/nfdiv/frontend:prod-1a2f770-20240716100706 #{"$imagepolicy": "flux-system:demo-nfdiv-frontend"}
       environment:
         WEBCHAT_AVAYA_URL: webchat.pp.ctsc.hmcts.net
         WEBCHAT_AVAYA_CLIENT_URL: webchat-client.pp.ctsc.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/NFDIV-4180


### Change description ###
NFDIV services are using old images in demo and the deployments are failing. Updating the references to match prod.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/nfdiv/nfdiv-case-api/demo-image-policy.yaml
- Removed annotations and policy related to demo image.

### apps/nfdiv/nfdiv-case-api/demo.yaml
- Changed the image version from a PR version to a prod version.

### apps/nfdiv/nfdiv-frontend/demo-image-policy.yaml
- Removed annotations and policy related to demo image.

### apps/nfdiv/nfdiv-frontend/demo.yaml
- Changed the image version from a PR version to a prod version.