### PR TITLE
DFR-396 Enable spot instances in demo

### DIFF
--- a/apps/ia/ia-case-access-api/demo.yaml
+++ b/apps/ia/ia-case-access-api/demo.yaml
@@ -6,3 +6,5 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/ia/case-access-api:prod-ed6a3d6-20240701095032 #{"$imagepolicy": "flux-system:ia-case-access-api"}
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -44,3 +44,5 @@ spec:
         POSTGRES_HOST: ia-case-api-postgres-db-v15-demo.postgres.database.azure.com
         POSTGRES_USERNAME: pgadmin
         LOCATION_REF_DATA_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-case-documents-api/demo.yaml
+++ b/apps/ia/ia-case-documents-api/demo.yaml
@@ -10,3 +10,5 @@ spec:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net
         DUMMY: true
         CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-demo.service.core-compute-demo.internal
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-case-notifications-api/demo.yaml
+++ b/apps/ia/ia-case-notifications-api/demo.yaml
@@ -10,3 +10,5 @@ spec:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net
         DUMMY: true
         CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-demo.service.core-compute-demo.internal
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-case-payments-api/demo.yaml
+++ b/apps/ia/ia-case-payments-api/demo.yaml
@@ -15,3 +15,5 @@ spec:
         PAY_CALLBACK_URL: "http://ia-case-payments-api-demo.service.core-compute-demo.internal/service-request-update"
         PROF_REF_DATA_URL: "http://rd-professional-api-demo.service.core-compute-demo.internal"
         DUMMY: true
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -7,3 +7,5 @@ spec:
     java:
       image: hmctspublic.azurecr.io/ia/hearings-api:pr-386-34809f4-20240716132649 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-home-office-integration-api/demo.yaml
+++ b/apps/ia/ia-home-office-integration-api/demo.yaml
@@ -9,3 +9,5 @@ spec:
       environment:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net
         DUMMY: true
+      spotInstances:
+        enabled: true

--- a/apps/ia/ia-timed-event-service/demo.yaml
+++ b/apps/ia/ia-timed-event-service/demo.yaml
@@ -33,3 +33,5 @@ spec:
       environment:
         POSTGRES_HOST: ia-timed-event-service-postgres-db-v15-demo.postgres.database.azure.com
         POSTGRES_USERNAME: pgadmin
+      spotInstances:
+        enabled: true


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIAC-396

We will proceed with enabling spot instances in demo.

Teams to enable spot instances in demo via Flux config using the override:

spotInstances: 
   enabled: true

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated demo.yaml in apps/ia/ia-case-access-api, apps/ia/ia-case-api, apps/ia/ia-case-documents-api, apps/ia/ia-case-notifications-api, apps/ia/ia-case-payments-api, apps/ia/ia-hearings-api, apps/ia/ia-home-office-integration-api, and apps/ia/ia-timed-event-service
- Added spotInstances and set enabled to true in all files.