### PR TITLE
Update aat.yaml civil service to prod flag

### DIFF
--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -46,7 +46,7 @@ spec:
               alias: robotics.notification.sender
             - name: robotics-notification-recipient
               alias: robotics.notification.recipient
-            - name: launch-darkly-sdk-key-non-prod
+            - name: launch-darkly-sdk-key
               alias: LAUNCH_DARKLY_SDK_KEY
             - name: robotics-notification-multipartyrecipient
               alias: robotics.notification.multipartyrecipient


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/aat.yaml
- Updated the name of the launch-darkly-sdk-key-non-prod to just launch-darkly-sdk-key. 🔄