### PR TITLE
FACT-1668 - Restrict Blob Router perftest memory to 1gb

### DIFF
--- a/apps/reform-scan/reform-scan-blob-router/perftest.yaml
+++ b/apps/reform-scan/reform-scan-blob-router/perftest.yaml
@@ -5,7 +5,8 @@ metadata:
 spec:
   values:
     java:
-      memoryLimits: "2048Mi"
+      image: hmctspublic.azurecr.io/reform-scan/blob-router:pr-2182
+      memoryLimits: "1024Mi"
       environment:
         # settings should be as prod-like as possible
         STORAGE_BULKSCAN_URL: https://bulkscanperftest.blob.core.windows.net


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/FACT-1668

### Change description ###

Points Perftest env to same PR as demo and restricts memory to same limit demo had when it was crashing so that the conditions that was causing the crashes can be investigated.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Apps/reform-scan/reform-scan-blob-router/perftest.yaml
- Updated the `image` field to `hmctspublic.azurecr.io/reform-scan/blob-router:pr-2182`
- Changed the `memoryLimits` from \"2048Mi\" to \"1024Mi\"