### PR TITLE
Update SOPS secret documentation to communicate base64 encoding.

### DIFF
--- a/docs/secrets-sops-encryption.md
+++ b/docs/secrets-sops-encryption.md
@@ -31,7 +31,7 @@ Create the secret:
  kubectl create secret generic prometheus-values -n monitoring --from-file=values.yaml --type=Opaque -o yaml --dry-run=client > prometheus-values.enc.yaml
 ```
 
-Your prometheus-values.enc.yaml content will look like this:
+Your prometheus-values.enc.yaml content will look like this, note the secret value is encoded in base64:
 ```
 apiVersion: v1
 data:
@@ -100,4 +100,12 @@ If you ever need to decrypt the file e.g. to update the secret value or change t
 
 ```
 sops --decrypt --in-place prometheus-values.enc.yaml
+```
+
+The file output by SOPS will encode the secret in base64. You can get the plaintext value of the secret by decoding it:
+
+```
+echo $MY_SECRET | base64 -d
+extraArgs:
+  slack-hook-url: https://hooks.slack.com/services/11111111111111111111/22222222222222
 ```


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18334

### Change description ###

Updates the documentation for SOPS secret encryption to reflect the fact that secrets decrypted by SOPS will be in base64 format and need to be decoded before they can be used.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `secrets-sops-encryption.md` 📝
  - Updated the example of `prometheus-values.enc.yaml` to indicate that the secret value is encoded in base64.
  - Added a section explaining how to decode the encoded secret value to obtain the plaintext value.