### PR TITLE
Increasing TT production memory limits

### DIFF
--- a/apps/tax-tribunals/tax-tribunals-application/tax-tribunals-application.yaml
+++ b/apps/tax-tribunals/tax-tribunals-application/tax-tribunals-application.yaml
@@ -18,8 +18,8 @@ spec:
       image: hmctspublic.azurecr.io/tax-tribunals/application:prod-f476f76-20240716134045 # {"$imagepolicy": "flux-system:tax-tribunals-application"}
       disableTraefikTls: true
       replicas: 2
-      memoryRequests: 512Mi
-      memoryLimits: 2048Mi
+      memoryRequests: 2Gi
+      memoryLimits: 3Gi
       autoscaling:
         enabled: true
         maxReplicas: 4


### PR DESCRIPTION
### Change description ###
Increasing memory limits in prod. Runing rails console is crashing pods.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated tax-tribunals-application.yaml```
  - Increased memory requests from 512Mi to 2Gi and memory limits from 2048Mi to 3Gi.