### PR TITLE
Set migration to true for civil demo

### DIFF
--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -18,9 +18,9 @@ spec:
         STITCHING_API_ENABLED: true
         HMC_HEARINGS_SUBSCRIPTION_ENABLED: true
         TEMP_VAR: 3
-        REFERENCE_DATABASE_MIGRATION: false
+        REFERENCE_DATABASE_MIGRATION: true
         SPRING_FLYWAY_TABLE: schema_version
-        SPRING_FLYWAY_BASELINE_ON_MIGRATE: false
+        SPRING_FLYWAY_BASELINE_ON_MIGRATE: true
         CUI_URL: https://moneyclaims.demo.platform.hmcts.net
         CUI_URL_RESPOND_TO_CLAIM: https://moneyclaims.demo.platform.hmcts.net/first-contact/start
         OCMC_CLIENT_URL: https://moneyclaims1.demo.platform.hmcts.net


### PR DESCRIPTION
### Change description ###
Setting migration to true for civil-demo



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/demo.yaml
- Enabled database migration by changing `REFERENCE_DATABASE_MIGRATION` from `false` to `true`
- Enabled flyway baseline on migrate by changing `SPRING_FLYWAY_BASELINE_ON_MIGRATE` from `false` to `true`