### PR TITLE
Update the app url for AAT

### DIFF
--- a/apps/idam/idam-hmcts-access/aat.yaml
+++ b/apps/idam/idam-hmcts-access/aat.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: idam-hmcts-access
+  namespace: idam
+spec:
+  releaseName: idam-hmcts-access
+  values:
+    nodejs:
+      environment:
+        APP_URL: 'https://hmcts-access.aat.platform.hmcts.net'


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created a new file `aat.yaml` under `apps/idam/idam-hmcts-access` for deploying a HelmRelease
- Added configuration for `idam-hmcts-access` HelmRelease to set the `APP_URL` environment variable to 'https://hmcts-access.aat.platform.hmcts.net' in the `nodejs` section