### PR TITLE
DTSAM-430 enable civil_wa_1_5 flag on ORM Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,4 +9,4 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: sscs_wa_1_3
+        DB_FEATURE_FLAG_ENABLE: civil_wa_1_5


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSAM-430

### Change description ###

Enable 'civil_wa_1_5' ORM flag in lower environment and refresh users ready for CIVIL to test

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- File: apps/am/am-org-role-mapping-service/demo.yaml
- Changed the value of DB_FEATURE_FLAG_ENABLE from \"sscs_wa_1_3\" to \"civil_wa_1_5\"