### PR TITLE
Revert "DTSPB-4070: Point to demo"

### DIFF
--- a/apps/probate/probate-back-office/demo-image-policy.yaml
+++ b/apps/probate/probate-back-office/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2613-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2650-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-frontend/demo-image-policy.yaml
+++ b/apps/probate/probate-frontend/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2021-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-orchestrator-service/demo-image-policy.yaml
+++ b/apps/probate/probate-orchestrator-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-941-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-submit-service/demo-image-policy.yaml
+++ b/apps/probate/probate-submit-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-838-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Change description ###
Revert "DTSPB-4070: Point to demo"

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated demo-image-policy.yaml in probate-back-office, probate-frontend, probate-orchestrator-service, and probate-submit-service
- Changed the filter pattern from 'pr-2613' to 'pr-2650' in probate-back-office
- Changed the filter pattern from 'pr-2021' to 'prod' in probate-frontend
- Changed the filter pattern from 'pr-941' to 'prod' in probate-orchestrator-service
- Changed the filter pattern from 'pr-838' to 'prod' in probate-submit-service