### PR TITLE
DTSSTCI-191: Remove env vars used to test individual cases

### DIFF
--- a/apps/sptribs/sptribs-cron-migrate-global-search-fields/demo/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-global-search-fields/demo/00.yaml
@@ -8,9 +8,6 @@ spec:
     job:
       image: hmctspublic.azurecr.io/sptribs/case-api:pr-1799-d4070ca-20240725135908 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
       schedule: "0,10,20,30,40,50 8-17 * * 1-5"
-      environment:
-        GLOBAL_SEARCH_MIGRATION_ENABLED: true
-        GLOBAL_SEARCH_MIGRATION_TEST_CASE_REF: "1692798754832368"
     global:
       jobKind: CronJob
       enableKeyVaults: true

--- a/apps/sptribs/sptribs-cron-migrate-global-search-fields/demo/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-global-search-fields/demo/00.yaml
@@ -8,6 +8,8 @@ spec:
     job:
       image: hmctspublic.azurecr.io/sptribs/case-api:pr-1799-d4070ca-20240725135908 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
       schedule: "0,10,20,30,40,50 8-17 * * 1-5"
+      environment:
+        GLOBAL_SEARCH_MIGRATION_ENABLED: true
     global:
       jobKind: CronJob
       enableKeyVaults: true


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `00.yaml` in `sptribs-cron-migrate-global-search-fields/demo` has had the `GLOBAL_SEARCH_MIGRATION_TEST_CASE_REF` parameter removed.