### PR TITLE
Add aat image policy for lau frontend

### DIFF
--- a/apps/lau/automation/kustomization.yaml
+++ b/apps/lau/automation/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../lau-frontend/demo-image-policy.yaml
   - ../lau-frontend/demo-int-image-policy.yaml
   - ../lau-frontend/image-policy.yaml
+  - ../lau-frontend/aat-image-policy.yaml
   - ../lau-case-backend/image-repo.yaml
   - ../lau-case-backend/demo-image-policy.yaml
   - ../lau-case-backend/demo-int-image-policy.yaml
@@ -13,4 +14,3 @@ resources:
   - ../lau-idam-backend/demo-image-policy.yaml
   - ../lau-idam-backend/demo-int-image-policy.yaml
   - ../lau-idam-backend/image-policy.yaml
-  - ../lau-frontend/aat-image-policy.yaml

--- a/apps/lau/automation/kustomization.yaml
+++ b/apps/lau/automation/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ../lau-idam-backend/demo-image-policy.yaml
   - ../lau-idam-backend/demo-int-image-policy.yaml
   - ../lau-idam-backend/image-policy.yaml
+  _ ../lau-frontend/aat-image-policy.yaml

--- a/apps/lau/automation/kustomization.yaml
+++ b/apps/lau/automation/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
   - ../lau-idam-backend/demo-image-policy.yaml
   - ../lau-idam-backend/demo-int-image-policy.yaml
   - ../lau-idam-backend/image-policy.yaml
-  _ ../lau-frontend/aat-image-policy.yaml
+  - ../lau-frontend/aat-image-policy.yaml

--- a/apps/lau/lau-frontend/aat-image-policy.yaml
+++ b/apps/lau/lau-frontend/aat-image-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: aat-lau-frontend
+spec:
+  filterTags:
+    pattern: "^staging-[a-f0-9]+-(?P<ts>[0-9]+)"
+    extract: "$ts"
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: lau-frontend

--- a/apps/lau/lau-frontend/aat.yaml
+++ b/apps/lau/lau-frontend/aat.yaml
@@ -5,5 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
+      image: hmctspublic.azurecr.io/lau/frontend:staging-323e991-20240725141526 #{"$imagepolicy": "flux-system:aat-lau-frontend"}
       spotInstances:
         enabled: false

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -18,6 +18,7 @@ EXCLUSIONS_LIST=(
     apps/sscs/sscs-tribunals-api/aat.yaml
     apps/sscs/sscs-tya-notif/aat.yaml
     apps/lau/lau-frontend/aat.yaml
+    apps/lau/lau-frontend/aat-image-policy.yaml
     .*perftest.*
     .*sbox.*
     .*test.*

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -17,6 +17,7 @@ EXCLUSIONS_LIST=(
     apps/sscs/sscs-tribunals-frontend/*
     apps/sscs/sscs-tribunals-api/aat.yaml
     apps/sscs/sscs-tya-notif/aat.yaml
+    apps/lau/lau-frontend/aat.yaml
     .*perftest.*
     .*sbox.*
     .*test.*


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18412


### Change description ###
- Adds `aat-image-policy.yaml` for lau-frontend to pull latest staging image
- Sets image for aat to `staging-323e991-20240725141526` as requested by team

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change












## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed kustomization.yaml```:
  - Added a new image policy file ```aat-image-policy.yaml``` for lau-frontend.

- Added new file ```aat-image-policy.yaml```:
  - Contains API version, kind, metadata, and spec for image policy.

- Updated ```aat.yaml```:
  - Added a new image for nodejs in the spec values.

- Updated ```flux-v2-image-automation.sh```:
  - Added paths for ```lau-frontend/aat.yaml``` and ```lau-frontend/aat-image-policy.yaml``` to the exclusions list.