### PR TITLE
Revert "Update aat-image-policy.yaml"

### DIFF
--- a/apps/private-law/prl-citizen-frontend/aat-image-policy.yaml
+++ b/apps/private-law/prl-citizen-frontend/aat-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: aat-prl-citizen-frontend
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: prl-citizen-frontend
-  filterTags:
-    pattern: '^pr-1473-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc

--- a/apps/private-law/prl-citizen-frontend/aat.yaml
+++ b/apps/private-law/prl-citizen-frontend/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/prl/citizen-frontend:pr-1473-e7db3b7-20240723111420 #{"$imagepolicy": "flux-system:aat-prl-citizen-frontend"}
+      image: hmctspublic.azurecr.io/prl/citizen-frontend:prod-b77c14d-20240726111024 #{"$imagepolicy": "flux-system:prl-citizen-frontend"}
       cpuLimits: "1000m"
       cpuRequests: "500m"
       replicas: 2


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#33250

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `aat-image-policy.yaml`:
  - Removed `annotations` and `filterTags` sections.
- Updated `aat.yaml`:
  - Changed the `image` field from `hmctspublic.azurecr.io/prl/citizen-frontend:pr-1473-e7db3b7-20240723111420` to `hmctspublic.azurecr.io/prl/citizen-frontend:prod-b77c14d-20240726111024`.
  - Updated `replicas` to 2.