### PR TITLE
[NFDIV-4080] Extend NoC migration hours to start from 6 pm

### DIFF
--- a/apps/nfdiv/nfdiv-ccd-case-migration/nfdiv-ccd-case-migration.yaml
+++ b/apps/nfdiv/nfdiv-ccd-case-migration/nfdiv-ccd-case-migration.yaml
@@ -8,7 +8,7 @@ spec:
     job:
       image: hmctspublic.azurecr.io/nfdiv/ccd-case-migration:prod-28aed66-20240729063317 #{"$imagepolicy": "flux-system:nfdiv-ccd-case-migration"}
       disableActiveClusterCheck: false
-      schedule: "0,15,30,45 18-22 * * *"
+      schedule: "0,15,30,45 17-23 * * *"
       suspend: true
       environment:
         MIGRATION_ID: NFDIV-4080


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/NFDIV-4080


### Change description ###
Extending the NoC migration hours to process more cases. CCD is usually down to 1/6th of peak traffic by 6 pm and other services seem to start their slow running crons after midnight:
<img width="622" alt="image" src="https://github.com/user-attachments/assets/19da158e-2be0-4458-b532-87c84c1a4623">

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated file: nfdiv-ccd-case-migration.yaml
- Updated schedule from \"0,15,30,45 18-22 * * *\" to \"0,15,30,45 17-23 * * *\"
- Job schedule updated to run from 5 PM to 11 PM.