### PR TITLE
Revert "Update perftest-image-policy.yaml"

### DIFF
--- a/apps/private-law/prl-cos/perftest-image-policy.yaml
+++ b/apps/private-law/prl-cos/perftest-image-policy.yaml
@@ -1,14 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: perftest-prl-cos
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: prl-cos
-  filterTags:
-    pattern: '^pr-2544-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#33249

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/private-law/prl-cos/perftest-image-policy.yaml
- Removed annotations section.
- Removed filterTags section.
- Removed policy section.
- Updated apiVersion to image.toolkit.fluxcd.io/v1beta1.
- Updated kind to ImagePolicy.