### PR TITLE
DTSPO-15798: fix slack provider secret for flux notifications

### DIFF
--- a/apps/base/provider.yaml
+++ b/apps/base/provider.yaml
@@ -8,4 +8,4 @@ spec:
   channel: ${TEAM_NOTIFICATION_CHANNEL}
   username: ${CLUSTER_FULL_NAME}-aks
   secretRef:
-    name: slack-url
+    name: slack-token


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- point to slack-token not slack-url secret for slack provider


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `provider.yaml` file has been modified to update the secret reference from `slack-url` to `slack-token`.