### PR TITLE
DTSPO-15798: add summary field to base flux alert resource

### DIFF
--- a/apps/base/alert.yaml
+++ b/apps/base/alert.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   providerRef:
     name: slack
+  summary: ${TEAM_NOTIFICATION_CHANNEL} - ${NAMESPACE}
   eventSeverity: info
   eventSources:
     - kind: Kustomization


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- username field on slack provider being ignored so cluster info not reported in Slack alerts/difficult to tell cluster origin
- add cluster info to summary spec on alert provider for bring info to Slack alerts


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/base/alert.yaml
- Added the `summary` field with a variable `${TEAM_NOTIFICATION_CHANNEL} - ${NAMESPACE}`.