### PR TITLE
DTSPO-15798 - CNP sbox:  alert severity to info

### DIFF
--- a/apps/cnp/sbox/base/alert-patch.yaml
+++ b/apps/cnp/sbox/base/alert-patch.yaml
@@ -7,8 +7,4 @@ metadata:
 spec:
   providerRef:
     name: slack
-  eventSeverity: error
-  eventSources:
-    - kind: HelmRelease
-      namespace: ${NAMESPACE}
-      name: 'plum-frontend'
+  eventSeverity: info


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- alert severity to info for cnp
- expand from just plum-frontend HR
- trying to invoke alert through to Slack to test summary field


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **alert-patch.yaml**
  - Changed eventSeverity from error to info. The eventSources section was removed.