### PR TITLE
DTSPO-15798: fix Flux notification slack provider spec

### DIFF
--- a/apps/base/provider.yaml
+++ b/apps/base/provider.yaml
@@ -7,5 +7,6 @@ spec:
   type: slack
   channel: ${TEAM_NOTIFICATION_CHANNEL}
   username: ${CLUSTER_FULL_NAME}-aks
+  address: https://slack.com/api/chat.postMessage
   secretRef:
     name: slack-token


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- fix Flux notification slack provider spec


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/base/provider.yaml
- Added a new `address` field with value `https://slack.com/api/chat.postMessage` under the `spec` section. 
- The `address` field is used to specify the address where the message will be sent.