### PR TITLE
DTSPO-15798: fix summary field to cluster name for flux notification alerts

### DIFF
--- a/apps/base/alert.yaml
+++ b/apps/base/alert.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   providerRef:
     name: slack
-  summary: ${TEAM_NOTIFICATION_CHANNEL} - ${NAMESPACE}
+  summary: ${CLUSTER_FULL_NAME}-aks
   eventSeverity: info
   eventSources:
     - kind: Kustomization


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- fix summary field to cluster name for flux notification alerts


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **alert.yaml**
  - Changed the `summary` field to `${CLUSTER_FULL_NAME}-aks` from `${TEAM_NOTIFICATION_CHANNEL}-${NAMESPACE}`.
  - Updated `eventSeverity` to `info`.
  - Modified `eventSources` to include `kind: Kustomization`.