### PR TITLE
Revert aat images to prod

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     java:
       aadIdentityName: sscs
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:pr-3886-1c4270f-20240729085042
       environment:
         CREATE_CCD_ENDPOINT: true
         UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true
@@ -21,7 +20,7 @@ spec:
         DUMMY_PROPERTY: true
         POST_HEARINGS_FEATURE: true
         POST_HEARINGS_B_FEATURE: true
-        WORK_ALLOCATION_FEATURE: true
+        WORK_ALLOCATION_FEATURE: false
         RD_LOCATION_REF_API_URL: http://rd-location-ref-api-aat.service.core-compute-aat.internal
         GAPS_SWITCHOVER_FEATURE: true
         CASE_ACCESS_MANAGEMENT_FEATURE: true

--- a/apps/sscs/sscs-tya-notif/aat.yaml
+++ b/apps/sscs/sscs-tya-notif/aat.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: sscs-tya-notif
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tya-notif:pr-2511-75f723f-20240729091501
       environment:
         JOB_SCHEDULER_DB_USERNAME: pgadmin
         JOB_SCHEDULER_DB_NAME: notification


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/sscs/sscs-tribunals-api/aat.yaml`:
  - Removed the image definition and set `WORK_ALLOCATION_FEATURE` to `false`.

- `apps/sscs/sscs-tya-notif/aat.yaml`:
  - Removed the image definition for the Java environment and set environment variables for the job scheduler.