### PR TITLE
Revert "[NFDIV-4261] Adjust job params to migrate cases in awaiting documents"

### DIFF
--- a/apps/nfdiv/nfdiv-ccd-case-migration/nfdiv-ccd-case-migration.yaml
+++ b/apps/nfdiv/nfdiv-ccd-case-migration/nfdiv-ccd-case-migration.yaml
@@ -8,7 +8,7 @@ spec:
     job:
       image: hmctspublic.azurecr.io/nfdiv/ccd-case-migration:prod-36c310d-20240806061752 #{"$imagepolicy": "flux-system:nfdiv-ccd-case-migration"}
       disableActiveClusterCheck: false
-      schedule: "0,15,30,45 17-21 * * *"
+      schedule: "0 22 * * *"
       suspend: true
       environment:
         MIGRATION_ID: NFDIV-4080


### PR DESCRIPTION
Reverts job timing changes made in hmcts/cnp-flux-config#33462, as the migration completed successfully and we no longer need to migrate a large batch of cases

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/nfdiv/nfdiv-ccd-case-migration/nfdiv-ccd-case-migration.yaml
- Changed the job schedule from \"0,15,30,45 17-21 * * *\" to \"0 22 * * *\" ⏰
- Updated the schedule for the job to run at a specific time.