### PR TITLE
Bump memory for Docmosis prod and perftest

### DIFF
--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -8,8 +8,8 @@ spec:
     ingressHost: docmosis.perftest.platform.hmcts.net
     image: hmctsprivate.azurecr.io/docmosis:perftest-4e6120f-626389 #{"$imagepolicy": "flux-system:perftest-docmosis"}
     java:
-      memoryRequests: "3Gi"
-      memoryLimits: "4Gi"
+      memoryRequests: "4Gi"
+      memoryLimits: "5Gi"
       keyVaults:
         docmosis-infra:
           secrets:

--- a/apps/docmosis/docmosis/prod.yaml
+++ b/apps/docmosis/docmosis/prod.yaml
@@ -7,8 +7,8 @@ spec:
     replicas: 3
     ingressHost: docmosis.platform.hmcts.net
     java:
-      memoryRequests: "3Gi"
-      memoryLimits: "4Gi"
+      memoryRequests: "4Gi"
+      memoryLimits: "5Gi"
       keyVaults:
         docmosis-infra:
           secrets:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16639


### Change description ###
- Bumps memory requests and limits by 1gb in both prod and perftest

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `perftest.yaml` 🔄 Updated memory requests from \"3Gi\" to \"4Gi\" and memory limits from \"4Gi\" to \"5Gi\".
- `prod.yaml` 🔄 Updated memory requests from \"3Gi\" to \"4Gi\" and memory limits from \"4Gi\" to \"5Gi\".