### PR TITLE
IA deploy appeals ref data & run migration tool in demo

### DIFF
--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/case-api:prod-db4b8c7-20240802142447 #{"$imagepolicy": "flux-system:ia-case-api"}
+      image: hmctspublic.azurecr.io/ia/case-api:prod-db4b8c7-20240802142447 #{"$imagepolicy": "flux-system:demo-ia-case-api"}
       keyVaults:
         ia:
           resourceGroup: ia

--- a/apps/ia/ia-cron-ccd-migration-tool/demo-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/demo-00.yaml
@@ -6,8 +6,8 @@ spec:
   releaseName: ia-cron-ccd-migration-tool
   values:
     job:
-      schedule: "* * 31 2 *"
-      image: hmctspublic.azurecr.io/ia/cron-ccd-migration-tool:prod-1b22554-20240724135814 #{"$imagepolicy": "flux-system:ia-cron-ccd-migration-tool"}
+      schedule: "16 50 * * *"
+      image: hmctspublic.azurecr.io/ia/cron-ccd-migration-tool:prod-1b22554-20240724135814 #{"$imagepolicy": "flux-system:demo-ia-cron-ccd-migration-tool"}
       cpuRequests: "1000m"
       cpuLimits: "2500m"
       memoryRequests: "1024Mi"

--- a/apps/ia/ia-cron-ccd-migration-tool/demo-image-policy.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ia-cron-ccd-migration-tool
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-145-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: ia-cron-ccd-migration-tool

--- a/apps/ia/ia-cron-ccd-migration-tool/prod-00.yaml
+++ b/apps/ia/ia-cron-ccd-migration-tool/prod-00.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ia-cron-ccd-migration-tool
   values:
     job:
-      schedule: "03 12 * * *"
+      schedule: "* * 31 2 *"
       cpuRequests: "1000m"
       cpuLimits: "2500m"
       memoryRequests: "1024Mi"

--- a/apps/ia/ia-cron-unnotified-hearings-processor/demo-00.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/demo-00.yaml
@@ -11,7 +11,7 @@ spec:
       cpuLimits: "2500m"
       memoryRequests: "1024Mi"
       memoryLimits: "2048Mi"
-      image: hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337 #{"$imagepolicy": "flux-system:ia-cron-unnotified-hearings-processor"}
+      image: hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337 #{"$imagepolicy": "flux-system:demo-ia-cron-unnotified-hearings-processor"}
       environment:
         HEARINGS_API_URL: "https://ia-hearings-api-demo.service.core-compute-demo.internal"
         CCD_URL: "http://ccd-data-store-api-demo.service.core-compute-demo.internal"

--- a/apps/ia/ia-cron-unnotified-hearings-processor/demo-01.yaml
+++ b/apps/ia/ia-cron-unnotified-hearings-processor/demo-01.yaml
@@ -11,7 +11,7 @@ spec:
       cpuLimits: "2500m"
       memoryRequests: "1024Mi"
       memoryLimits: "2048Mi"
-      image: hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337 #{"$imagepolicy": "flux-system:ia-cron-unnotified-hearings-processor"}
+      image: hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337 #{"$imagepolicy": "flux-system:demo-ia-cron-unnotified-hearings-processor"}
       environment:
         HEARINGS_API_URL: "https://ia-hearings-api-demo.service.core-compute-demo.internal"
         CCD_URL: "http://ccd-data-store-api-demo.service.core-compute-demo.internal"

--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337 #{"$imagepolicy": "flux-system:ia-hearings-api"}
+      image: hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
       spotInstances:
         enabled: true


### PR DESCRIPTION
### Jira link (if applicable)
IA deploy appeals ref data & run migration tool in demo


### Change description ###
IA deploy appeals ref data & run migration tool in demo

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ia/ia-case-api/demo.yaml
- Updated the Java image for the IA case API to `hmctspublic.azurecr.io/ia/case-api:prod-db4b8c7-20240802142447`.

### apps/ia/ia-cron-ccd-migration-tool/demo-00.yaml
- Changed the schedule for the cron-ccd-migration-tool job from `\"* * 31 2 *\"` to `\"16 50 * * *\"`.
- Updated the image for the cron-ccd-migration-tool to `hmctspublic.azurecr.io/ia/cron-ccd-migration-tool:prod-1b22554-20240724135814`.

### apps/ia/ia-cron-ccd-migration-tool/demo-image-policy.yaml
- Added annotations disabling prod automation for the image policy.

### apps/ia/ia-cron-ccd-migration-tool/prod-00.yaml
- Updated the schedule for the cron-ccd-migration-tool job from `\"03 12 * * *\"` to `\"* * 31 2 *\"`.

### apps/ia/ia-cron-unnotified-hearings-processor/demo-00.yaml
- Updated the image for the unnotified-hearings-processor to `hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337`.
- Updated environment variables for the unnotified-hearings-processor.

### apps/ia/ia-cron-unnotified-hearings-processor/demo-01.yaml
- Updated the image for the unnotified-hearings-processor to `hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337`.
- Updated environment variables for the unnotified-hearings-processor.

### apps/ia/ia-hearings-api/demo.yaml
- Updated the Java image for the IA hearings API to `hmctspublic.azurecr.io/ia/hearings-api:prod-3effcc2-20240726111337`.