### PR TITLE
Disable Docmosis path rewrite in ITHC

### DIFF
--- a/apps/docmosis/ithc/base/kustomization.yaml
+++ b/apps/docmosis/ithc/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
-  - docmosis-ingress.yaml
+  # - docmosis-ingress.yaml
 namespace: docmosis
 patches:
   - path: ../../docmosis/ithc.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18542


### Change description ###
- Commenting out the docmosis ingress from ITHC kustomization.yaml to disable the path rewrite.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_



- Updated kustomization.yaml
- Removed docmosis-ingress.yaml from resources
- Added namespace: docmosis
- Applied a patch to docmosis-itch.yaml
```