### PR TITLE
update ithc to fix service image

### DIFF
--- a/apps/civil/civil-service/ithc-image-policy.yaml
+++ b/apps/civil/civil-service/ithc-image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: ithc-civil-service
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: 'prod-c8b13b2-20240808114855'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: civil-service

--- a/apps/civil/civil-service/ithc.yaml
+++ b/apps/civil/civil-service/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:prod-c8b13b2-20240808114855 #{"$imagepolicy": "flux-system:civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-c8b13b2-20240808114855 #{"$imagepolicy": "flux-system:ithc-civil-service"}
       environment:
         TESTING_SUPPORT_ENABLED: true
         EM_CCD_ORCHESTRATOR_URL: http://em-ccd-orchestrator-ithc.service.core-compute-ithc.internal


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/ithc-image-policy.yaml
- A new file `ithc-image-policy.yaml` is added.
- It defines an ImagePolicy for the ithc-civil-service, with a specified image filter pattern and a disabled prod-automated annotation.

### apps/civil/civil-service/ithc.yaml
- In the `ithc.yaml` file, the image URL for the Java service has been updated to `hmctspublic.azurecr.io/civil/service:prod-c8b13b2-20240808114855`.
- The environment variables for testing support and orchestration URL have been modified accordingly.