### PR TITLE
fix: disable idam-testing-support-api in AAT to allow prod release

### DIFF
--- a/apps/idam/idam-testing-support-api/aat.yaml
+++ b/apps/idam/idam-testing-support-api/aat.yaml
@@ -7,6 +7,9 @@ spec:
   releaseName: idam-testing-support-api
   values:
     java:
+      replicas: 0
+      autoscaling:
+        enabled: false
       ingressHost: idam-testing-support-api.aat.platform.hmcts.net
       environment:
         IDAM_API_URL: https://idam-api.aat.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)
The cleanup-users process (which looks to run from idam-testing-support-api) is hammering IDAM in aat and causing test failures. This is blocking the IA Bails Ref data production release. Disabling the idam-test-support-api in AAT.


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `aat.yaml` in `idam-testing-support-api`:
  - Disabled autoscaling by setting `replicas: 0` and `autoscaling: enabled: false` for the Java service.
  - Updated `ingressHost` to `idam-testing-support-api.aat.platform.hmcts.net`.
  - Updated `environment` variable `IDAM_API_URL` to `https://idam-api.aat.platform.hmcts.net`.