### PR TITLE
Revert "fix: disable idam-testing-support-api in AAT to allow prod release

### DIFF
--- a/apps/idam/idam-testing-support-api/aat.yaml
+++ b/apps/idam/idam-testing-support-api/aat.yaml
@@ -7,9 +7,6 @@ spec:
   releaseName: idam-testing-support-api
   values:
     java:
-      replicas: 0
-      autoscaling:
-        enabled: false
       ingressHost: idam-testing-support-api.aat.platform.hmcts.net
       environment:
         IDAM_API_URL: https://idam-api.aat.platform.hmcts.net


### PR DESCRIPTION
This reverts commit 0534c2b737468bd3b7b5f454ae811e718617454b.

### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/idam-testing-support-api/aat.yaml
- Removed replicas and autoscaling configuration for java.
- Removed the \"enabled\" field from the autoscaling configuration.
- Updated the \"ingressHost\" to idam-testing-support-api.aat.platform.hmcts.net.
- Updated the \"IDAM_API_URL\" environment variable to https://idam-api.aat.platform.hmcts.net.