### PR TITLE
Point AAT pods to use prod image as newly published image is broken

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -7,6 +7,7 @@ spec:
   values:
     java:
       aadIdentityName: sscs
+      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-86fa0e1-20240808092639
       environment:
         CREATE_CCD_ENDPOINT: true
         UPLOAD_AUDIO_VIDEO_EVIDENCE_FEATURE: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `aat.yaml` in `apps/sscs/sscs-tribunals-api` has added the `image` configuration for the `sscs/tribunals-api` with the value `hmctspublic.azurecr.io/sscs/tribunals-api:prod-86fa0e1-20240808092639` and updated the `environment` section.