### PR TITLE
Revert "Removing nodes from ITHC to deploy cluster fix"

### DIFF
--- a/apps/family-public-law/fpl-case-service/ithc.yaml
+++ b/apps/family-public-law/fpl-case-service/ithc.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 0
       image: hmctspublic.azurecr.io/fpl/case-service:pr-5391-27b1603-20240807145537 #{"$imagepolicy": "flux-system:ithc-fpl-case-service"}
       ingressHost: fpl-case-service-ithc.service.core-compute-ithc.internal
       environment:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#33593

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/family-public-law/fpl-case-service/ithc.yaml
- Removed a configuration for `java` replicas and image, and `ingressHost` in the `ithc` environment.

  - replicas: 0
- image: hmctspublic.azurecr.io/fpl/case-service:pr-5391-27b1603-20240807145537
- ingressHost: fpl-case-service-ithc.service.core-compute-ithc.internal```