### PR TITLE
DTSAM-458 enable `civil_wa_1_8` on ORM Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: civil_wa_1_6
+        DB_FEATURE_FLAG_ENABLE: civil_wa_1_8
         REFRESH_JOB: LEGAL_OPERATIONS-CIVIL-ABORTED-0-47
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSAM-458

### Change description ###

Enable `civil_wa_1_8` ORM flag in `demo` and refresh users ready for CIVIL to test

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


#### apps/am/am-org-role-mapping-service/demo.yaml
- Updated the value of `DB_FEATURE_FLAG_ENABLE` from `civil_wa_1_6` to `civil_wa_1_8`.