### PR TITLE
DTSPO-18399 - Add slack ingress for sbox response bot

### DIFF
--- a/apps/response/sbox-intsvc/base/kustomization.yaml
+++ b/apps/response/sbox-intsvc/base/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - ../../base
   - response-secret.yaml
   - postgres-hr.yaml
+  - slack-ingress.yaml
 patches:
   - path: ../../serviceaccount/ptl.yaml

--- a/apps/response/sbox-intsvc/base/slack-ingress.yaml
+++ b/apps/response/sbox-intsvc/base/slack-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rpe-response-api-slack-sandbox
+  namespace: response
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  rules:
+    - host: response-api-slack-sandbox.platform.hmcts.net
+      http:
+        paths:
+          - path: /slack
+            pathType: Prefix
+            backend:
+              service:
+                name: rpe-response-api-nodejs-sandbox
+                port:
+                  number: 80


### PR DESCRIPTION
### Jira link (if applicable)
DTSPO-18399


### Change description ###
Add slack ingress for sbox response bot

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Modified `kustomization.yaml`:
  - Added `slack-ingress.yaml` to the list of resources.
  - Removed `slack-ingress.yaml` from the list of patches.

- Added `slack-ingress.yaml`:
  - Contains definitions for an Ingress object to route traffic to the Slack API.