### PR TITLE
Civil perftest - disable migration

### DIFF
--- a/apps/civil/civil-service/perftest.yaml
+++ b/apps/civil/civil-service/perftest.yaml
@@ -13,9 +13,9 @@ spec:
       environment:
         TESTING_SUPPORT_ENABLED: true
         DOCUMENT_MANAGEMENT_SECURED: true
-        REFERENCE_DATABASE_MIGRATION: true
+        REFERENCE_DATABASE_MIGRATION: false
         SPRING_FLYWAY_TABLE: schema_version
-        SPRING_FLYWAY_BASELINE_ON_MIGRATE: true
+        SPRING_FLYWAY_BASELINE_ON_MIGRATE: false
         POLLING_EVENT_EMITTER_ENABLED: false
         SERVICE_REQUEST_UPDATE: http://civil-service-perftest.service.core-compute-perftest.internal/service-request-update
         ASYNC_HANDLER_CORE_POOL_SIZE: 50


### PR DESCRIPTION
### Change description ###
Disable database migrations for civil-service perftest environment

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [y] commit messages are meaningful and follow good commit message guidelines
- [n README and other documentation has been updated / added (if needed)
- [n] tests have been updated / new tests has been added (if needed)
- [n] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `perftest.yaml`: 
  - Changed `REFERENCE_DATABASE_MIGRATION` from `true` to `false`
  - Changed `SPRING_FLYWAY_BASELINE_ON_MIGRATE` from `true` to `false`