### PR TITLE
DTSPO-15798: Higher flux alert severity to error

### DIFF
--- a/apps/base/alert.yaml
+++ b/apps/base/alert.yaml
@@ -8,7 +8,7 @@ spec:
   providerRef:
     name: slack
   summary: ${CLUSTER_FULL_NAME}-aks
-  eventSeverity: info
+  eventSeverity: error
   eventSources:
     - kind: Kustomization
       namespace: flux-system


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- change severity to error for flux alert slack integration


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/base/alert.yaml
- Changed eventSeverity from info to error.
- The eventSeverity field was updated from info to error in the alert.yaml file.