### PR TITLE
DTSSTCI-1006: Added LD key to fix HTTP 401 error for the cron jobs

### DIFF
--- a/apps/sptribs/sptribs-cron-migrate-case-flags/sptribs-cron-migrate-case-flags.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-flags/sptribs-cron-migrate-case-flags.yaml
@@ -22,6 +22,8 @@ spec:
               alias: IDAM_SYSTEM_UPDATE_USERNAME
             - name: idam-systemupdate-password
               alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
       environment:
         TASK_NAME: SystemMigrateCaseFlagsTask
       schedule: 0/10 * * * *

--- a/apps/sptribs/sptribs-cron-migrate-case-links/sptribs-cron-migrate-case-links.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-case-links/sptribs-cron-migrate-case-links.yaml
@@ -22,6 +22,8 @@ spec:
               alias: IDAM_SYSTEM_UPDATE_USERNAME
             - name: idam-systemupdate-password
               alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
       environment:
         TASK_NAME: SystemMigrateCaseLinksTask
       schedule: 0 18 * * *

--- a/apps/sptribs/sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml
@@ -22,6 +22,8 @@ spec:
               alias: IDAM_SYSTEM_UPDATE_USERNAME
             - name: idam-systemupdate-password
               alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
       environment:
         TASK_NAME: SystemMigrateGlobalSearchTask
       schedule: 0 8 * * 1-5


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSSTCI-1006

### Change description ###

Fixed LD warning

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **sptribs-cron-migrate-case-flags.yaml**
  - Added a new environment variable \"launchDarkly-sdk-key\" with an alias \"LAUNCH_DARKLY_SDK_KEY\"
  - Updated the schedule to run every 10 minutes.

- **sptribs-cron-migrate-case-links.yaml**
  - Added a new environment variable \"launchDarkly-sdk-key\" with an alias \"LAUNCH_DARKLY_SDK_KEY\"
  - Updated the schedule to run at 6:00 PM every day.

- **sptribs-cron-migrate-global-search-fields.yaml**
  - Added a new environment variable \"launchDarkly-sdk-key\" with an alias \"LAUNCH_DARKLY_SDK_KEY\"
  - Updated the schedule to run at 8:00 AM every weekday.