### PR TITLE
DTSPO-18399 adding slack ingress as a patch

### DIFF
--- a/apps/response/sbox-intsvc/base/kustomization.yaml
+++ b/apps/response/sbox-intsvc/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - ../../base
   - response-secret.yaml
   - postgres-hr.yaml
-  - slack-ingress.yaml
 patches:
   - path: ../../serviceaccount/ptl.yaml
   - path: patches/response-frontend.yaml

--- a/apps/response/sbox-intsvc/base/kustomization.yaml
+++ b/apps/response/sbox-intsvc/base/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
   - path: ../../serviceaccount/ptl.yaml
   - path: patches/response-frontend.yaml
   - path: patches/response-api.yaml
+  - path: patches/slack-ingress.yaml

--- a/apps/response/sbox-intsvc/base/patches/slack-ingress.yaml
+++ b/apps/response/sbox-intsvc/base/patches/slack-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: rpe-response-api-slack-sandbox
+  name: rpe-response-api-slack
   namespace: response
   annotations:
     kubernetes.io/ingress.class: traefik
@@ -15,6 +15,4 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: rpe-response-api-nodejs-sandbox
-                port:
-                  number: 80
+                name: rpe-response-api-nodejs


### PR DESCRIPTION
### Jira link (if applicable)

[DTSPO-18399](https://tools.hmcts.net/jira/browse/DTSPO-18399)

### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed file: kustomization.yaml
  - Removed \"slack-ingress.yaml\" from the resources and added \"patches/slack-ingress.yaml\" in the patches section.

- Renamed file: slack-ingress.yaml
  - The file was renamed to \"patches/slack-ingress.yaml\" and the content was modified to update the metadata name from \"rpe-response-api-slack\" to \"rpe-response-api-slack\".