### PR TITLE
DTSPO-18399 -adding-enable-key-vault-false

### DIFF
--- a/apps/response/sbox-intsvc/base/patches/response-frontend.yaml
+++ b/apps/response/sbox-intsvc/base/patches/response-frontend.yaml
@@ -6,3 +6,5 @@ metadata:
 spec:
   values:
     ingressHost: response.sandbox.platform.hmcts.net
+    global:
+      enableKeyVaults: false


### PR DESCRIPTION
### Jira link (if applicable)
[DTSPO-18399](https://tools.hmcts.net/jira/browse/DTSPO-18399)


### Change description ###

trying to connect to wrong keyvault, giving pod errors

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **response-frontend.yaml**:
  - Removed the `\` character and added a new `global` section with `enableKeyVaults` set to `false`.