### PR TITLE
Fix namespace value for aat slack-provider token secret

### DIFF
--- a/apps/base/slack-provider/aat/slack-token.enc.yaml
+++ b/apps/base/slack-provider/aat/slack-token.enc.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   creationTimestamp: null
   name: slack-token
-  namespace: toffee
+  namespace: ${NAMESPACE}
 type: Opaque
 sops:
   kms: []


### PR DESCRIPTION
### Change description ###

- Fix namespace value for aat slack-provider token secret


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `slack-token.enc.yaml` file in the `apps/base/slack-provider/aat` directory has been modified to change the value of the `namespace` from `toffee` to `${NAMESPACE}`.