### PR TITLE
adding the azurelinux node pool to test plum

### DIFF
--- a/apps/cnp/plum-batch/sbox.yaml
+++ b/apps/cnp/plum-batch/sbox.yaml
@@ -9,9 +9,5 @@ spec:
     startingDeadlineSeconds: 300
     schedule: "*/1 * * * *"
     nodeSelector:
-      agentpool: spotinstance
+      agentpool: azurelinux
     tolerations:
-      - key: kubernetes.azure.com/scalesetpriority
-        effect: NoSchedule
-        operator: Equal
-        value: spot


### PR DESCRIPTION
### Jira link - https://tools.hmcts.net/jira/browse/DTSPO-18233



### Change description ###

Testing plum using the new Azure Linux nodepool that we have created here - https://github.com/hmcts/aks-cft-deploy/blob/83f42d1098c4e94eba960413dd738ba42507c2af/components/aks/aks.tf

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `sbox.yaml` in `apps/cnp/plum-batch`: 
  - Removed tolerations for spot instances and updated nodeSelector to use `azurelinux` agent pool.
  - Schedule was not changed.