### PR TITLE
Remove kustomization from alert spec

### DIFF
--- a/apps/base/alert.yaml
+++ b/apps/base/alert.yaml
@@ -10,9 +10,6 @@ spec:
   summary: ${CLUSTER_FULL_NAME}-aks
   eventSeverity: error
   eventSources:
-    - kind: Kustomization
-      namespace: flux-system
-      name: ${NAMESPACE}
     - kind: HelmRelease
       namespace: ${NAMESPACE}
       name: '*'


### PR DESCRIPTION
 - Flux alert integration is intermittently firing false error events occuring when kustomization takes place with latest flux repo revision
 - Some of these come from prod cluster and worrying dev teams

- this PR removes kustomization from alert spec for time being


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/base/alert.yaml
- Removed the eventSources block specifying kind, namespace, and name under the spec key.