### PR TITLE
DTSPO-18303: swap xui containo.us crds to traefik.io non prod

### DIFF
--- a/apps/xui/aat/base/register-org-ingress.yaml
+++ b/apps/xui/aat/base/register-org-ingress.yaml
@@ -22,7 +22,7 @@ spec:
             pathType: ImplementationSpecific
 
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: registerorgredirect

--- a/apps/xui/demo/base/register-org-ingress.yaml
+++ b/apps/xui/demo/base/register-org-ingress.yaml
@@ -22,7 +22,7 @@ spec:
             path: /
             pathType: ImplementationSpecific
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: registerorgredirect

--- a/apps/xui/ithc/base/register-org-ingress.yaml
+++ b/apps/xui/ithc/base/register-org-ingress.yaml
@@ -21,7 +21,7 @@ spec:
             path: /
             pathType: ImplementationSpecific
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: registerorgredirect

--- a/apps/xui/perftest/base/register-org-ingress.yaml
+++ b/apps/xui/perftest/base/register-org-ingress.yaml
@@ -21,7 +21,7 @@ spec:
             path: /
             pathType: ImplementationSpecific
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: registerorgredirect


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18303


### Change description

- swap containo.us crds to traefik.io crds across non-prod envs with XUI
- XUI target as they have ingress def across envs
- crd apiversion swap tested in sbox already


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/xui/aat/base/register-org-ingress.yaml`:
  - Changed from `apiVersion: traefik.containo.us/v1alpha1` to `apiVersion: traefik.io/v1alpha1` for Middleware.

- `apps/xui/demo/base/register-org-ingress.yaml`:
  - Changed from `apiVersion: traefik.containo.us/v1alpha1` to `apiVersion: traefik.io/v1alpha1` for Middleware.

- `apps/xui/ithc/base/register-org-ingress.yaml`:
  - Changed from `apiVersion: traefik.containo.us/v1alpha1` to `apiVersion: traefik.io/v1alpha1` for Middleware.

- `apps/xui/perftest/base/register-org-ingress.yaml`:
  - Changed from `apiVersion: traefik.containo.us/v1alpha1` to `apiVersion: traefik.io/v1alpha1` for Middleware.