### PR TITLE
Ensure that Plum Front End Only Runs on a Specific Node Pool

### DIFF
--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -5,7 +5,16 @@ metadata:
 spec:
   values:
     nodeSelector:
-      agentpool: azurelinux
+      agentpool: azurelinux        # Ensures pods run on nodes with this label
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: agentpool
+                  operator: In
+                  values:
+                    - azurelinux   # Ensures the pod is only scheduled on 'azurelinux' nodes
     nodejs:
       ingressHost: plum.sandbox.platform.hmcts.net
       spotInstances:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18233

### Change description

Ensure that Plum Front End Only Runs on a Specific Node Pool


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/cnp/plum-frontend/sbox.yaml
- Added node affinity for the `azurelinux` agent pool.
- Updated the `nodeSelector` values for `nodejs`.
- Updated the `ingressHost` to `plum.sandbox.platform.hmcts.net`.
- Updated spotInstances configurations.