### PR TITLE
Ensure that Plum Front End Only Runs on a Specific Node Pool

### DIFF
--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -17,6 +17,6 @@ spec:
       ingressHost: plum.sandbox.platform.hmcts.net
       spotInstances:
         enabled: false
-      replicas: 4
+      replicas: 2
       autoscaling:
-        minReplicas: 2
+        minReplicas: 1


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18233

### Ensure that Plum Front End Only Runs on a Specific Node Pool

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `sbox.yaml` in `apps/cnp/plum-frontend` has been modified.
- The `replicas` value has been changed from 4 to 2.
- The `minReplicas` value has been changed from 2 to 1.