### PR TITLE
DTSPO-18303 - Neuvector AAT: swap apiversion neuvector ingress route

### DIFF
--- a/apps/neuvector/aat/00/api-ingress-route.yaml
+++ b/apps/neuvector/aat/00/api-ingress-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: nv-ingressroute-api

--- a/apps/neuvector/aat/01/api-ingress-route.yaml
+++ b/apps/neuvector/aat/01/api-ingress-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: nv-ingressroute-api


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18303


### Change description

- double check the IngressRouteTCP crd swap works correctly
- this is the only resource kind left to check api swap


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `api-ingress-route.yaml`:
  - Changed `apiVersion` from `traefik.containo.us/v1alpha1` to `traefik.io/v1alpha1` for IngressRouteTCP.