### PR TITLE
DTSPO-18303 - Traefik: upgrade traefik non-prod to 30.0.2

### DIFF
--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/aat/01.yaml
+++ b/apps/admin/traefik2/aat/01.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 29.0.0
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 29.0.0
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/apps/admin/traefik2/preview/01.yaml
+++ b/apps/admin/traefik2/preview/01.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this
-      version: 27.0.2
+      version: 30.0.2
       sourceRef:
         kind: HelmRepository
         name: traefik

--- a/clusters/aat/base/kustomization.yaml
+++ b/clusters/aat/base/kustomization.yaml
@@ -63,4 +63,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/aat/base/kustomize.yaml
   - path: ../../../apps/admin/aat/base/kustomize.yaml
-  - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v30.0.2/kustomize.yaml

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -59,4 +59,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
-  - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v30.0.2/kustomize.yaml

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -64,4 +64,4 @@ patches:
   - path: ../../../apps/tax-tribunals/ithc/base/kustomize.yaml
   - path: ../../../apps/neuvector/ithc/base/kustomize.yaml
   - path: ../../../apps/admin/ithc/base/kustomize.yaml
-  - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v30.0.2/kustomize.yaml

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -57,4 +57,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/perftest/base/kustomize.yaml
-  - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v30.0.2/kustomize.yaml

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -60,4 +60,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/preview/base/kustomize.yaml
   - path: ../../../apps/admin/preview/base/kustomize.yaml
-  - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v30.0.2/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18303


### Change description

- upgrade traefik in non-prod envs to 30.0.2
- tested in sbox


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated apps/admin/traefik2/aat/00.yaml, 01.yaml, demo/00.yaml, demo/01.yaml, ithc/00.yaml, ithc/01.yaml, perftest/00.yaml, perftest/01.yaml, preview/00.yaml, and preview/01.yaml:
  - Changed traefik chart version from 27.0.2 to 30.0.2.

- Updated clusters/aat/base/kustomization.yaml, demo/base/kustomization.yaml, ithc/base/kustomization.yaml, perftest/base/kustomization.yaml, and preview/base/kustomization.yaml:
  - Updated path for apps/admin/traefik-crds-upgrade from v27.0.2 to v30.0.2.