### PR TITLE
Point ST demo to prod image

### DIFF
--- a/apps/sptribs/sptribs-case-api/demo-image-policy.yaml
+++ b/apps/sptribs/sptribs-case-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1872-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/sptribs/sptribs-case-api/demo.yaml
+++ b/apps/sptribs/sptribs-case-api/demo.yaml
@@ -7,7 +7,7 @@ spec:
     java:
       spotInstances:
         enabled: false
-      image: hmctspublic.azurecr.io/sptribs/case-api:pr-1872-782a561-20240815130417 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
+      image: hmctspublic.azurecr.io/sptribs/case-api:prod-07d8de7-20240819150120 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
       environment:
         S2S_AUTHORISED_SERVICES: ccd_definition,ccd_data,xui_webapp,sptribs_case_api,ccd_gw,sptribs_frontend,sptribs_dss_update_case_web
         WA_FEATURE_ENABLED: true

--- a/apps/sptribs/sptribs-case-api/sptribs-case-api.yaml
+++ b/apps/sptribs/sptribs-case-api/sptribs-case-api.yaml
@@ -17,6 +17,8 @@ spec:
       memoryLimits: "4Gi"
       cpuRequests: "1000m"
       cpuLimits: "2000m"
+      environment:
+        GLOBAL_SEARCH_MIGRATION_ENABLED: false
   chart:
     spec:
       chart: ./stable/sptribs-case-api


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSSTCI-178

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


md
- demo-image-policy.yaml
  - Changed the filterTag pattern from '^pr-1872-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
- demo.yaml
  - Updated the image from 'hmctspublic.azurecr.io/sptribs/case-api:pr-1872-782a561-20240815130417' to 'hmctspublic.azurecr.io/sptribs/case-api:prod-07d8de7-20240819150120'
- sptribs-case-api.yaml
  - Added a new environment variable: GLOBAL_SEARCH_MIGRATION_ENABLED: false
```