### PR TITLE
SDT-231: Update civil-sdt AAT image

### DIFF
--- a/apps/civil/civil-sdt/aat-00.yaml
+++ b/apps/civil/civil-sdt/aat-00.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/sdt:prod-a601f4f-20240822100700 #{"$imagepolicy": "flux-system:aat-civil-sdt"}
+      image: hmctspublic.azurecr.io/civil/sdt:pr-620-7535e4d-20240821103023 #{"$imagepolicy": "flux-system:aat-civil-sdt"}
       environment:
         PURGE_SCHEDULE_CRON: 0 15 0 * * 4,5,6,7
         RETRY_SEND_CRON: 0 0 * * * 4,5,6,7

--- a/apps/civil/civil-sdt/aat-01.yaml
+++ b/apps/civil/civil-sdt/aat-01.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/sdt:prod-a601f4f-20240822100700 #{"$imagepolicy": "flux-system:aat-civil-sdt"}
+      image: hmctspublic.azurecr.io/civil/sdt:pr-620-7535e4d-20240821103023 #{"$imagepolicy": "flux-system:aat-civil-sdt"}
       environment:
         PURGE_SCHEDULE_CRON: 0 15 0 * * 1,2,3
         RETRY_SEND_CRON: 0 0 * * * 1,2,3

--- a/apps/civil/civil-sdt/aat-image-policy.yaml
+++ b/apps/civil/civil-sdt/aat-image-policy.yaml
@@ -3,5 +3,11 @@ kind: ImagePolicy
 metadata:
   name: aat-civil-sdt
 spec:
+  filterTags:
+    pattern: '^pr-620-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: civil-sdt


### PR DESCRIPTION
### Jira link

See [SDT-231](https://tools.hmcts.net/jira/browse/SDT-231)

### Change description
Update AAT image for civil-sdt so that a pull request can be QA tested.  Can only use AAT because it's the only environment with a link to an instance of MCOL (which is needed for the test).

### Testing done
Successfully tested in local environment which happens to have a dev version of MCOL in it.  This is not available to QA, hence need to use AAT.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-sdt/aat-00.yaml
- Changed the image tag from `hmctspublic.azurecr.io/civil/sdt:prod-a601f4f-20240822100700` to `hmctspublic.azurecr.io/civil/sdt:pr-620-7535e4d-20240821103023`
- Updated the environment variable `PURGE_SCHEDULE_CRON` from `0 15 0 * * 4,5,6,7` to `0 15 0 * * 4,5,6,7`
- Updated the environment variable `RETRY_SEND_CRON` from `0 0 * * * 4,5,6,7` to `0 0 * * * 4,5,6,7`

### apps/civil/civil-sdt/aat-01.yaml
- Changed the image tag from `hmctspublic.azurecr.io/civil/sdt:prod-a601f4f-20240822100700` to `hmctspublic.azurecr.io/civil/sdt:pr-620-7535e4d-20240821103023`
- Updated the environment variable `PURGE_SCHEDULE_CRON` from `0 15 0 * * 1,2,3` to `0 15 0 * * 1,2,3`
- Updated the environment variable `RETRY_SEND_CRON` from `0 0 * * * 1,2,3` to `0 0 * * * 1,2,3`

### apps/civil/civil-sdt/aat-image-policy.yaml
- Added a filter for image tags matching the pattern '^pr-620-[a-f0-9]+-(?P<ts>[0-9]+)' with an ascending alphabetical order.