### PR TITLE
DTSPO-18399 disable ssl mode on sandbox

### DIFF
--- a/apps/response/sbox-intsvc/base/patches/response-api.yaml
+++ b/apps/response/sbox-intsvc/base/patches/response-api.yaml
@@ -13,3 +13,4 @@ spec:
         INCIDENT_CHANNEL_NAME: incidents-sandbox
         INCIDENT_REPORT_CHANNEL_NAME: incidents-sandbox
         DB_HOST: postgres-postgresql
+        DB_SSL_MODE: disabled


### PR DESCRIPTION
### Jira link
DTSPO-18399

### Change description

Disabling ssl mode as bitnami postgres does not support ssl

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


yaml
response-api.yaml
- Added DB_SSL_MODE: disabled
```