### PR TITLE
Remove ADOP-2305 from demo-image-policy.yaml

### DIFF
--- a/apps/adoption/adoption-cos-api/demo-image-policy.yaml
+++ b/apps/adoption/adoption-cos-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-adoption-cos-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-917-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: adoption-cos-api


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
ADOP-2305 is not currently being worked on.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **demo-image-policy.yaml**
  - Removed the `annotations` section and `filterTags`, `pattern`, `extract`, and `policy` fields from the `spec` section.