### PR TITLE
DTSSTCI-1080: Moved ITHC cron job to peftest to migrate cases to support GlobalSearch

### DIFF
--- a/apps/sptribs/ithc/base/kustomization.yaml
+++ b/apps/sptribs/ithc/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
-  - ../../sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml
   - ../../../base/slack-provider/ithc
 namespace: sptribs
 patches:
@@ -12,4 +11,3 @@ patches:
   - path: ../../sptribs-dss-update-case-web/ithc.yaml
   - path: ../../sptribs-frontend/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml
-  - path: ../../sptribs-cron-migrate-global-search-fields/ithc/00.yaml

--- a/apps/sptribs/perftest/base/kustomization.yaml
+++ b/apps/sptribs/perftest/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../sptribs-cron-migrate-case-flags/sptribs-cron-migrate-case-flags.yaml
   - ../../sptribs-cron-migrate-case-links/sptribs-cron-migrate-case-links.yaml
+  - ../../sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml
   - ../../../base/slack-provider/perftest
 patches:
   - path: ../../identity/perftest.yaml
@@ -13,3 +14,4 @@ patches:
   - path: ../../sptribs-dss-update-case-web/perftest.yaml
   - path: ../../sptribs-frontend/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml
+  - path: ../../sptribs-cron-migrate-global-search-fields/perftest/00.yaml

--- a/apps/sptribs/sptribs-cron-migrate-global-search-fields/perftest/00.yaml
+++ b/apps/sptribs/sptribs-cron-migrate-global-search-fields/perftest/00.yaml
@@ -10,9 +10,9 @@ spec:
       schedule: "0/5 * * * *"
       environment:
         GLOBAL_SEARCH_MIGRATION_ENABLED: true
-        GLOBAL_SEARCH_MIGRATION_TEST_CASE_REF:
+        GLOBAL_SEARCH_MIGRATION_TEST_CASE_REF: "1679067992876711"
     global:
       jobKind: CronJob
       enableKeyVaults: true
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      environment: ithc
+      environment: perftest


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSSTCI-1080

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `kustomization.yaml` file in `apps/sptribs/ithc/base` has had the path `./sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml` removed, and a patch path `./sptribs-cron-migrate-global-search-fields/ithc/00.yaml` removed.
- The `kustomization.yaml` file in `apps/sptribs/perftest/base` has had the path `./sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml` added, and a patch path `./sptribs-cron-migrate-global-search-fields/perftest/00.yaml` added.
- The `00.yaml` file in `/apps/sptribs/sptribs-cron-migrate-global-search-fields` has been renamed from `ithc` to `perftest`, and the environment variable `environment` value has been changed from `ithc` to `perftest`. Additionally, the `GLOBAL_SEARCH_MIGRATION_TEST_CASE_REF` value has been added as `1679067992876711`.