### PR TITLE
Revert "patch artifactory 7.84.12 -> 7.90.9"

### DIFF
--- a/apps/artifactory/artifactory/artifactory-sbox.yaml
+++ b/apps/artifactory/artifactory/artifactory-sbox.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: artifactory-oss
+  namespace: artifactory
+spec:
+  serviceName: "artifactory"
+  replicas: 2
+  selector:
+    matchLabels:
+      app: artifactory-oss
+  template:
+    metadata:
+      labels:
+        app: artifactory-oss
+    spec:
+      containers:
+        - image: docker.bintray.io/jfrog/artifactory-oss:7.90.9
+          name: artifactory-oss

--- a/apps/artifactory/artifactory/artifactory.yaml
+++ b/apps/artifactory/artifactory/artifactory.yaml
@@ -42,7 +42,7 @@ spec:
             - mountPath: "/var/opt/jfrog/artifactory"
               name: artifactory-data
       containers:
-        - image: docker.bintray.io/jfrog/artifactory-oss:7.90.9
+        - image: docker.bintray.io/jfrog/artifactory-oss:7.84.12
           name: artifactory-oss
           env:
             - name: EXTRA_JAVA_OPTIONS

--- a/apps/artifactory/sbox-intsvc/base/kustomization.yaml
+++ b/apps/artifactory/sbox-intsvc/base/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../artifactory/sbox-intsvc-ingress.yaml
+
+patchesStrategicMerge:
+  - ../../artifactory/artifactory-sbox.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34058

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Added
- `artifactory-sbox.yaml`
  - Added a new file defining the StatefulSet for Artifactory OSS with specific configurations and replicas.

### Updated
- `artifactory.yaml`
  - Updated the image version for Artifactory OSS from 7.90.9 to 7.84.12.

### Modified
- `kustomization.yaml`
  - Added a patch to the Kustomization resources for Artifactory Sbox.