### PR TITLE
Update artifactory.yaml

### DIFF
--- a/apps/artifactory/artifactory/artifactory.yaml
+++ b/apps/artifactory/artifactory/artifactory.yaml
@@ -36,8 +36,7 @@ spec:
             [
               "sh",
               "-c",
-              "mkdir -p /var/opt/jfrog/artifactory/etc; cp artifactory.config.xml /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml; chown -R 1030:1030 /var/opt/jfrog/artifactory; chmod -R 0700 /var/opt/jfrog/artifactory;",
-              "sed -i -e 's/#allowNonPostgresql: false/allowNonPostgresql: true/' /opt/jfrog/artifactory/var/etc/system.yaml",
+              "mkdir -p /var/opt/jfrog/artifactory/etc; cp artifactory.config.xml /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml; chown -R 1030:1030 /var/opt/jfrog/artifactory; chmod -R 0700 /var/opt/jfrog/artifactory; sed -i -e 's/#allowNonPostgresql: false/allowNonPostgresql: true/' /opt/jfrog/artifactory/var/etc/system.yaml;",
             ]
           volumeMounts:
             - mountPath: "/var/opt/jfrog/artifactory"

--- a/apps/artifactory/artifactory/artifactory.yaml
+++ b/apps/artifactory/artifactory/artifactory.yaml
@@ -37,6 +37,7 @@ spec:
               "sh",
               "-c",
               "mkdir -p /var/opt/jfrog/artifactory/etc; cp artifactory.config.xml /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml; chown -R 1030:1030 /var/opt/jfrog/artifactory; chmod -R 0700 /var/opt/jfrog/artifactory;",
+              "sed -i -e 's/#allowNonPostgresql: false/allowNonPostgresql: true/' /opt/jfrog/artifactory/var/etc/system.yaml",
             ]
           volumeMounts:
             - mountPath: "/var/opt/jfrog/artifactory"


### PR DESCRIPTION
```
Caused by: org.jfrog.storage.dbtype.DbTypeNotAllowedException: DB Type derby is not allowed: Cannot start the application with a database other than PostgreSQL. For more information, see JFrog documentation.
```





## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Modified file: apps/artifactory/artifactory/artifactory.yaml
- Added a sed command to modify a file within the artifactory container