### PR TITLE
Revert "Update artifactory.yaml"

### DIFF
--- a/apps/artifactory/artifactory/artifactory.yaml
+++ b/apps/artifactory/artifactory/artifactory.yaml
@@ -36,7 +36,7 @@ spec:
             [
               "sh",
               "-c",
-              "mkdir -p /var/opt/jfrog/artifactory/etc; cp artifactory.config.xml /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml; chown -R 1030:1030 /var/opt/jfrog/artifactory; chmod -R 0700 /var/opt/jfrog/artifactory; sed -i -e 's/#allowNonPostgresql: false/allowNonPostgresql: true/' /opt/jfrog/artifactory/var/etc/system.yaml;",
+              "mkdir -p /var/opt/jfrog/artifactory/etc; cp artifactory.config.xml /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml; chown -R 1030:1030 /var/opt/jfrog/artifactory; chmod -R 0700 /var/opt/jfrog/artifactory;",
             ]
           volumeMounts:
             - mountPath: "/var/opt/jfrog/artifactory"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34081 - file doesn't seem to exist yet at startup, blocks the pods instead

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `artifactory.yaml` has been updated.
- In the `spec` section, a command to make a directory, copy a configuration file, change ownership, set permissions, and perform a sed command has been modified.