### PR TITLE
DTSPO-18669 - ITHC: temp remove erroring namespaces to allow AKS patch upgrade

### DIFF
--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ../../../apps/adoption/base/kustomize.yaml
   - ../../../apps/cnp/base/kustomize.yaml
   - ../../../apps/idam/base/kustomize.yaml
-  # - ../../../apps/financial-remedy/base/kustomize.yaml
+  - ../../../apps/financial-remedy/base/kustomize.yaml
   # div-pfe-nodejs: unknown redis_error Failed to connect to Redis connect ECONNREFUSED
   # - ../../../apps/divorce/base/kustomize.yaml
   - ../../../apps/wa/base/kustomize.yaml
@@ -17,7 +17,7 @@ resources:
   # - ../../../apps/nfdiv/base/kustomize.yaml
   - ../../../apps/hmc/base/kustomize.yaml
   - ../../../apps/et/base/kustomize.yaml
-  # - ../../../apps/civil/base/kustomize.yaml
+  - ../../../apps/civil/base/kustomize.yaml
   - ../../../apps/probate/base/kustomize.yaml
   - ../../../apps/ccd/base/kustomize.yaml
   - ../../../apps/xui/base/kustomize.yaml
@@ -33,8 +33,8 @@ resources:
   - ../../../apps/docmosis/base/kustomize.yaml
   - ../../../apps/em/base/kustomize.yaml
   - ../../../apps/fact/base/kustomize.yaml
-  # - ../../../apps/family-public-law/base/kustomize.yaml
-  # - ../../../apps/ia/base/kustomize.yaml
+  - ../../../apps/family-public-law/base/kustomize.yaml
+  - ../../../apps/ia/base/kustomize.yaml
   - ../../../apps/lau/base/kustomize.yaml
   # 2023-07-24 helmrelease/cmc-claim-store - reconciliation failed: previous release attempt remediation failed
   # - ../../../apps/money-claims/base/kustomize.yaml
@@ -44,7 +44,7 @@ resources:
   - ../../../apps/rpe/base/kustomize.yaml
   - ../../../apps/rpts/base/kustomize.yaml
   - ../../../apps/bsp/base/kustomize.yaml
-  - ../../../apps/sscs/base/kustomize.yaml
+  # - ../../../apps/sscs/base/kustomize.yaml
   - ../../../apps/ts/base/kustomize.yaml
   - ../../../apps/fis/base/kustomize.yaml
   - ../../../apps/sptribs/base/kustomize.yaml
@@ -52,8 +52,8 @@ resources:
   - ../../../apps/cui/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
   - ../../../apps/keda/base/kustomize.yaml
-  # - ../../../apps/et-pet/base/kustomize.yaml
-  # - ../../../apps/help-with-fees/base/kustomize.yaml
+  - ../../../apps/et-pet/base/kustomize.yaml
+  - ../../../apps/help-with-fees/base/kustomize.yaml
   - ../../../apps/disposer/base/kustomize.yaml
   - ../../../apps/ethos/base/kustomize.yaml
 patches:

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ../../../apps/adoption/base/kustomize.yaml
   - ../../../apps/cnp/base/kustomize.yaml
   - ../../../apps/idam/base/kustomize.yaml
-  - ../../../apps/financial-remedy/base/kustomize.yaml
+  # - ../../../apps/financial-remedy/base/kustomize.yaml
   # div-pfe-nodejs: unknown redis_error Failed to connect to Redis connect ECONNREFUSED
   # - ../../../apps/divorce/base/kustomize.yaml
   - ../../../apps/wa/base/kustomize.yaml
@@ -17,7 +17,7 @@ resources:
   # - ../../../apps/nfdiv/base/kustomize.yaml
   - ../../../apps/hmc/base/kustomize.yaml
   - ../../../apps/et/base/kustomize.yaml
-  - ../../../apps/civil/base/kustomize.yaml
+  # - ../../../apps/civil/base/kustomize.yaml
   - ../../../apps/probate/base/kustomize.yaml
   - ../../../apps/ccd/base/kustomize.yaml
   - ../../../apps/xui/base/kustomize.yaml
@@ -33,8 +33,8 @@ resources:
   - ../../../apps/docmosis/base/kustomize.yaml
   - ../../../apps/em/base/kustomize.yaml
   - ../../../apps/fact/base/kustomize.yaml
-  - ../../../apps/family-public-law/base/kustomize.yaml
-  - ../../../apps/ia/base/kustomize.yaml
+  # - ../../../apps/family-public-law/base/kustomize.yaml
+  # - ../../../apps/ia/base/kustomize.yaml
   - ../../../apps/lau/base/kustomize.yaml
   # 2023-07-24 helmrelease/cmc-claim-store - reconciliation failed: previous release attempt remediation failed
   # - ../../../apps/money-claims/base/kustomize.yaml
@@ -52,8 +52,8 @@ resources:
   - ../../../apps/cui/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
   - ../../../apps/keda/base/kustomize.yaml
-  - ../../../apps/et-pet/base/kustomize.yaml
-  - ../../../apps/help-with-fees/base/kustomize.yaml
+  # - ../../../apps/et-pet/base/kustomize.yaml
+  # - ../../../apps/help-with-fees/base/kustomize.yaml
   - ../../../apps/disposer/base/kustomize.yaml
   - ../../../apps/ethos/base/kustomize.yaml
 patches:

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -9,15 +9,15 @@ resources:
   - ../../../apps/adoption/base/kustomize.yaml
   - ../../../apps/cnp/base/kustomize.yaml
   - ../../../apps/idam/base/kustomize.yaml
-  - ../../../apps/financial-remedy/base/kustomize.yaml
+  # - ../../../apps/financial-remedy/base/kustomize.yaml
   # div-pfe-nodejs: unknown redis_error Failed to connect to Redis connect ECONNREFUSED
   # - ../../../apps/divorce/base/kustomize.yaml
   - ../../../apps/wa/base/kustomize.yaml
   # MountVolume.SetUp failed for volume "vault-nfdiv”. A secret with (name/id) redis-access-key was not found in this key vault.
   # - ../../../apps/nfdiv/base/kustomize.yaml
   - ../../../apps/hmc/base/kustomize.yaml
-  - ../../../apps/et/base/kustomize.yaml
-  - ../../../apps/civil/base/kustomize.yaml
+  # - ../../../apps/et/base/kustomize.yaml
+  # - ../../../apps/civil/base/kustomize.yaml
   - ../../../apps/probate/base/kustomize.yaml
   - ../../../apps/ccd/base/kustomize.yaml
   - ../../../apps/xui/base/kustomize.yaml
@@ -34,7 +34,7 @@ resources:
   - ../../../apps/em/base/kustomize.yaml
   - ../../../apps/fact/base/kustomize.yaml
   - ../../../apps/family-public-law/base/kustomize.yaml
-  - ../../../apps/ia/base/kustomize.yaml
+  # - ../../../apps/ia/base/kustomize.yaml
   - ../../../apps/lau/base/kustomize.yaml
   # 2023-07-24 helmrelease/cmc-claim-store - reconciliation failed: previous release attempt remediation failed
   # - ../../../apps/money-claims/base/kustomize.yaml
@@ -43,7 +43,7 @@ resources:
   - ../../../apps/rd/base/kustomize.yaml
   - ../../../apps/rpe/base/kustomize.yaml
   - ../../../apps/rpts/base/kustomize.yaml
-  - ../../../apps/bsp/base/kustomize.yaml
+  # - ../../../apps/bsp/base/kustomize.yaml
   # - ../../../apps/sscs/base/kustomize.yaml
   - ../../../apps/ts/base/kustomize.yaml
   - ../../../apps/fis/base/kustomize.yaml
@@ -53,7 +53,7 @@ resources:
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
   - ../../../apps/keda/base/kustomize.yaml
   - ../../../apps/et-pet/base/kustomize.yaml
-  - ../../../apps/help-with-fees/base/kustomize.yaml
+  # - ../../../apps/help-with-fees/base/kustomize.yaml
   - ../../../apps/disposer/base/kustomize.yaml
   - ../../../apps/ethos/base/kustomize.yaml
 patches:


### PR DESCRIPTION
### Jira link

See [DTSPO-18669](https://tools.hmcts.net/jira/browse/DTSPO-18669)


### Change description

- temporarily remove namespace from ITHC to allow patching
- these are namespaces with crashloops etc which are blocking AKS patching upgrade
- will be reinstated post-upgrade


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### clusters/ithc/base/kustomization.yaml
- Removed the `financial-remedy` and `ia` apps' kustomize.yaml references 🔄
- Added the `wa` and `probate` apps' kustomize.yaml references 🔄
- Replaced the `civil` app's kustomize.yaml reference with the `lau` app's 🔄
- Replaced the `bsp` and `sscs` apps' kustomize.yaml references with the `ts` app's 🔄
- Replaced the `help-with-fees` app's kustomize.yaml reference with the `disposer` app's 🔄