### PR TITLE
Disable rate limiter in demo env - sptribs fe apps

### DIFF
--- a/apps/sptribs/sptribs-dss-update-case-web/demo.yaml
+++ b/apps/sptribs/sptribs-dss-update-case-web/demo.yaml
@@ -8,6 +8,8 @@ spec:
     nodejs:
       spotInstances:
         enabled: false
+      environment:
+        RATE_LIMITER_DISABLED: true
       ingressSessionAffinity:
         enabled: true
         sessionCookieName: sticky

--- a/apps/sptribs/sptribs-frontend/demo.yaml
+++ b/apps/sptribs/sptribs-frontend/demo.yaml
@@ -9,3 +9,4 @@ spec:
         enabled: false
       environment:
         PCQ_ENABLED: false
+        RATE_LIMITER_DISABLED: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


-  `demo.yaml`:
   - Added `RATE_LIMITER_DISABLED: true` to the environment in both `sptribs-dss-update-case-web` and `sptribs-frontend` apps.
   - Updated the configuration to disable rate limiter in the apps.