### PR TITLE
DTSPO-18669 Upgrade CFT NonProd AKS Clusters to Kubernetes 1.30 - point to image that do not exist

### DIFF
--- a/apps/fact/fact-frontend/demo.yaml
+++ b/apps/fact/fact-frontend/demo.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/fact/frontend:pr-766-48f8771-20240524104238 #{"$imagepolicy": "flux-system:demo-fact-frontend"}
+      image: hmctspublic.azurecr.io/fact/frontend:pr-784-b9699e2-20240820055029 #{"$imagepolicy": "flux-system:demo-fact-frontend"}
       autoscaling:
         enabled: false

--- a/apps/fact/fact-frontend/demo.yaml
+++ b/apps/fact/fact-frontend/demo.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/fact/frontend:pr-784-b9699e2-20240820055029 #{"$imagepolicy": "flux-system:demo-fact-frontend"}
+      image: hmctspublic.azurecr.io/fact/frontend:pr-784-b9699e2-20240820055029 #{"$imagepolicy": "flux-system:fact-frontend"}
       autoscaling:
         enabled: false


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-18668](https://tools.hmcts.net/jira/browse/DTSPO-18669)

updated image that do not exist

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fact/fact-frontend/demo.yaml
- Updated the image tag for the `hmctspublic.azurecr.io/fact/frontend` container to `pr-784-b9699e2-20240820055029`.