### PR TITLE
DTSAM-501 RABS Demo image policy reverted to use prod image regex, pr…

### DIFF
--- a/apps/am/am-role-assignment-batch-service/demo-image-policy.yaml
+++ b/apps/am/am-role-assignment-batch-service/demo-image-policy.yaml
@@ -2,6 +2,8 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-am-role-assignment-batch-service
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
     pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'

--- a/apps/am/am-role-assignment-batch-service/demo-image-policy.yaml
+++ b/apps/am/am-role-assignment-batch-service/demo-image-policy.yaml
@@ -2,11 +2,9 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-am-role-assignment-batch-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-966-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/am/am-role-assignment-batch-service/demo.yaml
+++ b/apps/am/am-role-assignment-batch-service/demo.yaml
@@ -13,6 +13,6 @@ spec:
         MIGRATION_MASTERFLAG: false
         MIGRATION_RENAMETABLES: false
         CCD_AM_MIGRATION_RENAME_TABLES_FLAG: false
-        EMAIL_ENABLED: true
+        EMAIL_ENABLED: false
         AM_SENDGRID_API_EMAIL_FROM: no-reply@mail-am-nonprod.platform.hmcts.net
         BATCH_ENV: demo


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSAM-501

### Change description
RABS Demo image policy reverted to use prod image regex, prod image syncing reenabled, email turned off in Demo

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/am/am-role-assignment-batch-service/demo-image-policy.yaml
- Updated the `filterTags` pattern from `'^pr-966-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`

### apps/am/am-role-assignment-batch-service/demo.yaml
- Changed the value of `EMAIL_ENABLED` from `true` to `false`