### PR TITLE
Artifactory PTLSBOX: use customInitContainerBegin, no configMap

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -30,16 +30,21 @@ spec:
           - "ReadWriteOnce"
         size: 128Gi
         storageClassName: "managed"
-      customVolumes:
-        - name: artifactory-startup-config
-          configMap:
-            name: artifactory-startup-config
-      customVolumeMounts: |
-        - name: artifactory-startup-config
-          mountPath: /tmp/artifactory-config-map
-      copyOnEveryStartup:
-        - source: /tmp/artifactory-config-map/artifactory.config.xml
-          target: /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml
+      customInitContainersBegin: |
+        - name: artifactory-init
+          image: hmctspublic.azurecr.io/artifactory-init:0.1.0
+          securityContext:
+            runAsNonRoot: false
+            allowPrivilegeEscalation: true
+          command:
+            [
+              "sh",
+              "-c",
+              "mkdir -p /var/opt/jfrog/artifactory/etc; cp artifactory.config.xml /var/opt/jfrog/artifactory/etc/artifactory.config.import.xml; chown -R 1030:1030 /var/opt/jfrog/artifactory; chmod -R 0700 /var/opt/jfrog/artifactory;",
+            ]
+          volumeMounts:
+            - mountPath: "var/opt/jfrog/artifactory"
+              name: artifactory-data
       persistence:
         enabled: false
       postgresql:


### PR DESCRIPTION
### Change description

- change approach to using customInitContainerBegin instead of using a configMap


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
