### PR TITLE
Artifactory PTLSBOX: default replicaCount of 1

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -21,7 +21,6 @@ spec:
         #speicifes the artifactory-oss container image version
         image:
           tag: 7.90.9
-        replicaCount: 2
         customPersistentVolumeClaim:
           name: artifactory-data
           mountPath: "/var/opt/jfrog/artifactory"


### PR DESCRIPTION
### Change description

- using Derby DB doesn't allow a replica count higher than 1
- drop replicaCount: 2


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed file: artifactory.yaml
- Updated image tag to 7.90.9
- Reduced replicaCount from 2 to 1