### PR TITLE
Artifactory PTLSBOX: set persistence mountPath

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -31,6 +31,7 @@ spec:
           tag: 7.90.9
         persistence:
           enabled: false
+          mountPath: /temp/persistence-mount
         configMapName: artifactory-oss-configmaps
         configMaps: |
           artifactory.config.import.xml: |-


### PR DESCRIPTION
### Change description

- set the persistence mountPath to avoid clash with pvc


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/artifactory/artifactory-helm/artifactory.yaml
- Added a new `mountPath` under `persistence` with the value `/temp/persistence-mount`.