### PR TITLE
Artifactory PTLSBOX: extraSystemYaml to set system.yaml

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -17,8 +17,6 @@ spec:
   interval: 1m
   values:
     artifactory:
-      database:
-        allowNonPostgresql: true
       artifactory:
         customPersistentVolumeClaim:
           accessModes:
@@ -32,6 +30,12 @@ spec:
         persistence:
           enabled: false
           mountPath: /temp/persistence-mount
+        database:
+          allowNonPostgresql: true
+        extraSystemYaml:
+          shared:
+            database:
+              allowNonPostgresql: true   
         configMapName: artifactory-oss-configmaps
         configMaps: |
           artifactory.config.import.xml: |-


### PR DESCRIPTION
### Change description

- [docs](https://jfrog.com/help/r/jfrog-installation-setup-documentation/choose-the-right-database) say this needs setting to set db type to non-postgresql (despite also having a param for this?)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- File: artifactory.yaml
  - Removed configuration for non-Postgresql databases from the `values` section.
  - Added configuration for non-Postgresql databases in the `extraSystemYaml` section.