### PR TITLE
Fix issue with bad charts reference

### DIFF
--- a/apps/fees-pay/ccpay-callback-function/demo.yaml
+++ b/apps/fees-pay/ccpay-callback-function/demo.yaml
@@ -11,16 +11,8 @@ spec:
         S2S_URL: http://rpe-service-auth-provider-demo.service.core-compute-demo.internal
         MICROSERVICE_PAYMENT_APP: "payment_app"
         SERVICE_LOGGING_ENABLED: false
-        DUMMY_RESTART_VAR: false
+        DUMMY_RESTART_VAR: true
       keyVaults:
         "ccpay":
           secrets:
             - payment-s2s-secret
-  chart:
-    spec:
-      chart: ccpay-callback-function
-      version: 2.5.3
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system


### PR DESCRIPTION
### Jira link


### Testing done
This included a test to pull in a different chart version for a PR a while back, but the chart update was done through environment values/secret overrides instead. Chart versions can't be changed for environment updates done through a PR, so this code should have been removed.

The correct ccpay-callback-function chart version is 2.5.1 which is referenced in the master respository.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `demo.yaml` file in the `ccpay-callback-function` directory has been modified.
- The `DUMMY_RESTART_VAR` value has been changed from `false` to `true`.
- The Helm chart details have been removed from the file.