### PR TITLE
Artifactory PTLSBOX: switch pvc to persistent volume

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -21,16 +21,9 @@ spec:
         consoleLog: true
         joinKeySecretName: join-key
         masterKeySecretName: master-key
-        customPersistentVolumeClaim:
-          accessModes:
-          - ReadWriteOnce
-          mountPath: /var/opt/jfrog/artifactory
-          name: artifactory-data
-          size: 128Gi
-          storageClassName: managed
         persistence:
-          enabled: false
-          mountPath: /temp/persistence-mount
+          storageClassName: managed
+          size: 128Gi
         database:
           allowNonPostgresql: true
         systemYaml: |


### PR DESCRIPTION
### Change description

- switch from using custom pvc to persistence param in helm chart


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/artifactory/artifactory-helm/artifactory.yaml
- Removed the `customPersistentVolumeClaim` section.
- Updated the `storageClassName` to `managed` and `size` to `128Gi` under the `persistence` section.