### PR TITLE
Cycle all adoption pods in lower envs to pickup new secret

### DIFF
--- a/apps/adoption/adoption-cos-api/demo.yaml
+++ b/apps/adoption/adoption-cos-api/demo.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       image: hmctspublic.azurecr.io/adoption/cos-api:prod-ba3c30a-20240703140916 #{"$imagepolicy": "flux-system:demo-adoption-cos-api"}
       environment:
-        RELEASE: AGAIN
+        RELEASE: NOW
         APP_INSIGHTS_KEY: '6c5278dd-ee76-4e7b-92f9-57b27ead382e'
         LA_PORTAL_BASEURL: https://adoption-web.{{ .Values.global.environment }}.platform.hmcts.net/la-portal/kba-case-ref
         MULTI_CHILDREN_CUI_URL: https://adoption-web.{{ .Values.global.environment }}.platform.hmcts.net/new-application-redirect

--- a/apps/adoption/adoption-cos-api/ithc.yaml
+++ b/apps/adoption/adoption-cos-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       environment:
-        RELEASE: AGAIN
+        RELEASE: NOW
         APP_INSIGHTS_KEY: '811b0b32-53bb-4c50-ae35-279b5cd91c40'
       keyVaults:
         adoption:

--- a/apps/adoption/adoption-cos-api/perftest.yaml
+++ b/apps/adoption/adoption-cos-api/perftest.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       environment:
-        RELEASE: AGAIN
+        RELEASE: NOW
         APP_INSIGHTS_KEY: '8007ea1d-b655-4399-9d4c-b6bc0a4728fb'
       keyVaults:
         adoption:


### PR DESCRIPTION
### Change description
Cycle all adoption-cos-api pods in lower envs (AAT done already) to pickup secret change in keyvault

### Checklist


- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/adoption/adoption-cos-api/demo.yaml`:
  - Updated the `RELEASE` environment variable from \"AGAIN\" to \"NOW\".

- `apps/adoption/adoption-cos-api/ithc.yaml`:
  - Updated the `RELEASE` environment variable from \"AGAIN\" to \"NOW\".

- `apps/adoption/adoption-cos-api/perftest.yaml`:
  - Updated the `RELEASE` environment variable from \"AGAIN\" to \"NOW\".