### PR TITLE
Update URL

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -313,7 +313,8 @@ spec:
                         <synchronizeProperties>false</synchronizeProperties>
                         <listRemoteFolderItems>true</listRemoteFolderItems>
                         <rejectInvalidJars>false</rejectInvalidJars>
-                        <p2OriginalUrl>https://repo.maven.apache.org/maven2/</p2OriginalUrl>
+                        <p2OriginalUrl>https://plugins.gradle.org/m2/</p2OriginalUrl>
+                        <url>https://plugins.gradle.org/m2/</url>
                         <contentSynchronisation>
                             <enabled>false</enabled>
                             <statistics>


### PR DESCRIPTION
Fails to fetch spring dependencies without this change

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/artifactory/artifactory-helm/artifactory.yaml
- Updated the `p2OriginalUrl` and `url` properties to use `https://plugins.gradle.org/m2/` instead of `https://repo.maven.apache.org/maven2/`.