### PR TITLE
Revert "Add admin pwd to artifactory"

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -18,9 +18,6 @@ spec:
   values:
     artifactory:
       artifactory:
-        admin:
-          secret: admin-pw
-          dataKey: password
         consoleLog: true
         joinKeySecretName: join-key
         masterKeySecretName: master-key


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34273

Not happy for some reason

: Illegal credentials file - each line is expected to be in the format: user=pass

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/artifactory/artifactory-helm/artifactory.yaml
- Removed the `admin` section with `secret` and `dataKey` properties from the `artifactory` values.