### PR TITLE
Add admin pw to artifactory

### DIFF
--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -18,6 +18,9 @@ spec:
   values:
     artifactory:
       artifactory:
+        admin:
+          secret: admin-pw
+          dataKey: password
         consoleLog: true
         joinKeySecretName: join-key
         masterKeySecretName: master-key

--- a/apps/artifactory/artifactory-helm/artifactory.yaml
+++ b/apps/artifactory/artifactory-helm/artifactory.yaml
@@ -20,7 +20,7 @@ spec:
       artifactory:
         admin:
           secret: admin-pw
-          dataKey: password
+          dataKey: bootstrap.creds
         consoleLog: true
         joinKeySecretName: join-key
         masterKeySecretName: master-key


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34280

let's try again

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- File: artifactory.yaml
- Added an `admin` section with `secret` and `dataKey` fields under the `artifactory` values.