### PR TITLE
Adding remission fix to pull in missing net_amount.

### DIFF
--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -6,10 +6,10 @@ spec:
   releaseName: ccpay-payment-api
   values:
     java:
-      image: hmctspublic.azurecr.io/payment/api:pr-1683-c5fd04d-20240910104304 #{"$imagepolicy": "flux-system:demo-ccpay-payment-app"}
+      image: hmctspublic.azurecr.io/payment/api:pr-1683-c5fd04d-20240910104304
       imagePullPolicy: Always
       environment:
-        DUMMY_RESTART_VAR: false
+        DUMMY_RESTART_VAR: true
         TRUSTED_S2S_SERVICE_NAMES: "refunds_api,cmc,cmc_claim_store,probate_frontend,divorce_frontend,ccd_gw,bar_api,api_gw,finrem_payment_service,finrem_case_orchestration,ccpay_bubble,jui_webapp,xui_webapp,fpl_case_service,probate_backend,iac,nfdiv_case_api,civil_service,paymentoutcome_web,prl_cos_api,adoption_web,civil_general_applications"
         RETURNURL_ALLOWED_HOSTNAMES: hmcts.net,gov.uk
         RD_LOCATION_BASE_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PAY-7311

### Change description

This fix addresses an issue of missing net_amount when adding remissions for telephony payments made using a Service Request created through the POST /service-request endpoint which typically happens when performing a Ways2Pay service request creation from CCD.

The net_amount on first creation of the Service Request should equal the calculcatd amount, but will change in it's lifecycle depending on payments, remissions and refunds. The behaviour exactly matches the POST /payment-groups which is the endpoint Paybubble uses to create Service Requests.

### Testing done

Updated Unit Tests, testing will be performed in the DEMO environment prior to pushing into Production.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
