### PR TITLE
Revert "artifactory/remove-unused-code"

### DIFF
--- a/apps/artifactory/artifactory/artifactory.yaml
+++ b/apps/artifactory/artifactory/artifactory.yaml
@@ -29,6 +29,10 @@ spec:
           size: 128Gi
         database:
           allowNonPostgresql: true
+        systemYaml: |
+          shared:
+            database:
+              allowNonPostgresql: true
         configMapName: artifactory-oss-configmaps
       ingress:
         annotations:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34296

Apparently need this in the code

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/artifactory/artifactory/artifactory.yaml
- Added a `systemYaml` section with the `shared` configuration for the database to allow non-PostgreSQL usage.