### PR TITLE
Whitelist Civil to call HMC API in AAT

### DIFF
--- a/apps/civil/civil-service/aat-image-policy.yaml
+++ b/apps/civil/civil-service/aat-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: aat-civil-service
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-5420-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+    policy:
+      alphabetical:
+        order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctspublic.azurecr.io/civil/service:pr-5420-4e84d81-20240912091415 #{"$imagepolicy": "flux-system:aat-civil-service"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/apps/hmc/hmc-cft-hearing-service/aat.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/aat.yaml
@@ -44,5 +44,5 @@ spec:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_REPOSITORY: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG
-        CFT_HEARING_SERVICE_S2S_AUTHORISED_SERVICES: xui_webapp,hmc_hmi_inbound_adapter,sscs,fis_hmc_api,et-hearings-api,iac
+        CFT_HEARING_SERVICE_S2S_AUTHORISED_SERVICES: xui_webapp,hmc_hmi_inbound_adapter,sscs,fis_hmc_api,et-hearings-api,iac,civil_service
         HMCTS_DEPLOYMENT_ID_ENABLED: true


### PR DESCRIPTION
### Change description
Whitelist civil_service to call HMC API in AAT

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/aat-image-policy.yaml
- Added annotations for disabling prod-automated
- Added spec for filterTags and policy

### apps/civil/civil-service/aat.yaml
- Updated java image to hmctspublic.azurecr.io/civil/service:pr-5420-4e84d81-20240912091415

### apps/hmc/hmc-cft-hearing-service/aat.yaml
- Updated CFT_HEARING_SERVICE_S2S_AUTHORISED_SERVICES to include civil_service