### PR TITLE
Revert "disabled  pdb on apps for perftest"

### DIFF
--- a/apps/fact/aat/base/kustomization.yaml
+++ b/apps/fact/aat/base/kustomization.yaml
@@ -9,5 +9,4 @@ patches:
   - path: ../../serviceaccount/aat.yaml
   - path: ../../fact-frontend/aat.yaml
   - path: ../../fact-api/aat.yaml
-  - path: ../../fact-api/perftest.yaml
   - path: ../../fact-admin/aat.yaml

--- a/apps/fact/fact-api/perftest.yaml
+++ b/apps/fact/fact-api/perftest.yaml
@@ -1,4 +1,0 @@
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
-metadata:
-  name: fact-api

--- a/apps/fis/fis-bulk-scan-api/perftest.yaml
+++ b/apps/fis/fis-bulk-scan-api/perftest.yaml
@@ -7,5 +7,3 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/fis/bulk-scan-api:prod-3c28dd7-20240910093549 #{"$imagepolicy": "flux-system:perftest-fis-bulk-scan-api"}
-      pdb:
-        enabled: false

--- a/apps/fis/fis-cos-api/perftest.yaml
+++ b/apps/fis/fis-cos-api/perftest.yaml
@@ -8,8 +8,6 @@ spec:
       image: hmctspublic.azurecr.io/fis/cos-api:prod-342554d-20240906100534 #{"$imagepolicy": "flux-system:perftest-fis-cos-api"}
       environment:
         FEATURE_EXAMPLE: false
-      pdb:
-        enabled: false
     global:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/apps/fis/fis-ds-update-web/perftest.yaml
+++ b/apps/fis/fis-ds-update-web/perftest.yaml
@@ -7,8 +7,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/fis/ds-update-web:pr-89-d75dc14-20230317141052 #{"$imagepolicy": "flux-system:perftest-fis-ds-update-web"}
-      pdb:
-        enabled: false
       keyVaults:
         fis-kv:
           secrets:

--- a/apps/fis/fis-ds-web/perftest.yaml
+++ b/apps/fis/fis-ds-web/perftest.yaml
@@ -7,8 +7,6 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/fis/ds-web:pr-89-d75dc14-20230317141052 #{"$imagepolicy": "flux-system:perftest-fis-ds-web"}
-      pdb:
-        enabled: false
       environment:
         FEATURE_EXAMPLE: false
     global:

--- a/apps/reform-scan/reform-scan-notification-service/perftest.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/perftest.yaml
@@ -8,5 +8,3 @@ spec:
       environment:
         PENDING_NOTIFICATIONS_TASK_DELAY_IN_MS: 600000
         PENDING_NOTIFICATIONS_SEND_DELAY_IN_MINUTE: 0
-    pdb:
-      enabled: false


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34388

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **apps/fact/aat/base/kustomization.yaml**
  - Removed path to `././fact-api/perftest.yaml`.

- **apps/fact/fact-api/perftest.yaml**
  - This file was deleted.

- **apps/fis/fis-bulk-scan-api/perftest.yaml**
  - Removed the \"pdb\" section.

- **apps/fis/fis-cos-api/perftest.yaml**
  - Removed the \"pdb\" section.

- **apps/fis/fis-ds-update-web/perftest.yaml**
  - Removed the \"pdb\" section.

- **apps/fis/fis-ds-web/perftest.yaml**
  - Removed the \"pdb\" section.

- **apps/reform-scan/reform-scan-notification-service/perftest.yaml**
  - Removed the \"pdb\" section.