### PR TITLE
Enable ST_CIC and criminalinjuriescompensation in perftest and ithc envs - Task Management config

### DIFF
--- a/apps/wa/wa-task-management-api/ithc.yaml
+++ b/apps/wa/wa-task-management-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
       image: hmctspublic.azurecr.io/wa/task-management-api:prod-ca121b9-20240916144849 #{"$imagepolicy": "flux-system:ithc-wa-task-management-api"}
       environment:
         REFRESH_FLAG: "3"
-        ALLOWED_JURISDICTIONS: wa,ia,sscs,civil,publiclaw,privatelaw
-        ALLOWED_CASE_TYPES: asylum,wacasetype,sscs,civil,generalapplication,care_supervision_epo,prlapps,privatelaw_exceptionrecord,benefit
+        ALLOWED_JURISDICTIONS: wa,ia,sscs,civil,publiclaw,privatelaw,st_cic
+        ALLOWED_CASE_TYPES: asylum,wacasetype,sscs,civil,generalapplication,care_supervision_epo,prlapps,privatelaw_exceptionrecord,benefit,criminalinjuriescompensation
       spotInstances:
         enabled: false

--- a/apps/wa/wa-task-management-api/perftest.yaml
+++ b/apps/wa/wa-task-management-api/perftest.yaml
@@ -16,7 +16,7 @@ spec:
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS: INFO
         REFRESH_FLAG: "2"
-        ALLOWED_JURISDICTIONS: wa,ia,sscs,civil,publiclaw,privatelaw,publiclaw,sscs,divorce,employment
-        ALLOWED_CASE_TYPES: asylum,wacasetype,sscs,civil,generalapplication,care_supervision_epo,prlapps,care_supervision_epo,benefit,financialremedycontested,financialremedymvp2,finrem_exceptionrecord,privatelaw_exceptionrecord,et_englandwales,et_scotland
+        ALLOWED_JURISDICTIONS: wa,ia,sscs,civil,publiclaw,privatelaw,publiclaw,sscs,divorce,employment,st_cic
+        ALLOWED_CASE_TYPES: asylum,wacasetype,sscs,civil,generalapplication,care_supervision_epo,prlapps,care_supervision_epo,benefit,financialremedycontested,financialremedymvp2,finrem_exceptionrecord,privatelaw_exceptionrecord,et_englandwales,et_scotland,criminalinjuriescompensation
         RESTART: true
         SPRING_PROFILES_ACTIVE: "replica"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/wa/wa-task-management-api/ithc.yaml
- Updated the `ALLOWED_JURISDICTIONS` and `ALLOWED_CASE_TYPES` fields by adding `st_cic` and `criminalinjuriescompensation`.

### apps/wa/wa-task-management-api/perftest.yaml
- Updated the `ALLOWED_JURISDICTIONS` and `ALLOWED_CASE_TYPES` fields by adding `st_cic` and `criminalinjuriescompensation`.