### PR TITLE
add divorce namespace back to ithc

### DIFF
--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -10,8 +10,7 @@ resources:
   - ../../../apps/cnp/base/kustomize.yaml
   - ../../../apps/idam/base/kustomize.yaml
   - ../../../apps/financial-remedy/base/kustomize.yaml
-  # div-pfe-nodejs: unknown redis_error Failed to connect to Redis connect ECONNREFUSED
-  # - ../../../apps/divorce/base/kustomize.yaml
+  - ../../../apps/divorce/base/kustomize.yaml
   - ../../../apps/wa/base/kustomize.yaml
   # MountVolume.SetUp failed for volume "vault-nfdiv”. A secret with (name/id) redis-access-key was not found in this key vault.
   # - ../../../apps/nfdiv/base/kustomize.yaml


### PR DESCRIPTION
### Change description
add divorce namespace back to ithc

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Modified `kustomization.yaml` in `clusters/ithc/base`:
  - Removed the path `./././apps/financial-remedy/base/kustomize.yaml`
  - Added the path `./././apps/divorce/base/kustomize.yaml`
  - Updated the paths in the `patches` section.