### PR TITLE
SDT-231: Enable new queue process

### DIFF
--- a/apps/civil/civil-sdt/prod-00.yaml
+++ b/apps/civil/civil-sdt/prod-00.yaml
@@ -12,5 +12,5 @@ spec:
         REQUEUE_SCHEDULE_CRON: 0 0,10,20,30,40,50 * * * *
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         LOGGING_LEVEL_UK_GOV_MOJ_SDT: DEBUG
-        ENABLE_QUEUE_RESET: true
+        ENABLE_NEW_QUEUE_PROCESS: true
         DUMMY_RESTART_VAR: 68

--- a/apps/civil/civil-sdt/prod-01.yaml
+++ b/apps/civil/civil-sdt/prod-01.yaml
@@ -12,5 +12,5 @@ spec:
         REQUEUE_SCHEDULE_CRON: 0 5,15,25,35,45,55 * * * *
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         LOGGING_LEVEL_UK_GOV_MOJ_SDT: DEBUG
-        ENABLE_QUEUE_RESET: true
+        ENABLE_NEW_QUEUE_PROCESS: true
         DUMMY_RESTART_VAR: 68


### PR DESCRIPTION
Update civil-sdt production configuration to enable new queue process.

### Jira link

See [SDT-231](https://tools.hmcts.net/jira/browse/SDT-231)

### Change description

Update civil-sdt production configuration to set ENABLE_NEW_QUEUE_PROCESS flag to true.  This will enable the new queue process code within the civil-sdt application.

### Testing done

Testing has been completed successfully in both development and AAT environments.  QA sign-off has been obtained.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `prod-00.yaml` 🔄
  - Changed `ENABLE_QUEUE_RESET` to `ENABLE_NEW_QUEUE_PROCESS`

- `prod-01.yaml` 🔄
  - Changed `ENABLE_QUEUE_RESET` to `ENABLE_NEW_QUEUE_PROCESS`