### PR TITLE
Add bypass flag for tya default

### DIFF
--- a/apps/sscs/sscs-tya-notif/demo.yaml
+++ b/apps/sscs/sscs-tya-notif/demo.yaml
@@ -30,6 +30,7 @@ spec:
         TEST_RECIPIENTS_POSTCODE: "*"
         POST_HEARINGS_FEATURE: true
         POST_HEARINGS_B_FEATURE: true
+        BYPASS_NOTIFICATIONS_SERVICE: false
     global:
       environment: demo
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SSCSSI-147

### Change description

- Disabling upfront with default

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/sscs/sscs-tya-notif/demo.yaml
- Added a new configuration BYPASS_NOTIFICATIONS_SERVICE with the value false.