### PR TITLE
CIV-00000 Disable database migration in claim store

### DIFF
--- a/apps/money-claims/cmc-claim-store/prod.yaml
+++ b/apps/money-claims/cmc-claim-store/prod.yaml
@@ -42,5 +42,6 @@ spec:
         DOC_ASSEMBLY_URL: http://dg-docassembly-prod.service.core-compute-prod.internal
         DOCUMENT_MANAGEMENT_URL: http://ccd-case-document-am-api-prod.service.core-compute-prod.internal
         FEATURE_TOGGLES_SECURE_DOC_STORE_ENABLED: true
+        REFERENCE_DATABASE_MIGRATION: false
       spotInstances:
         enabled: false


### PR DESCRIPTION
Disable database migration in claim store

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/money-claims/cmc-claim-store/prod.yaml
- Added a new feature toggle: `REFERENCE_DATABASE_MIGRATION` set to `false` 🚀