### PR TITLE
DFPL-2164: Add Pod auto scaling to FPL service

### DIFF
--- a/apps/family-public-law/fpl-case-service/demo.yaml
+++ b/apps/family-public-law/fpl-case-service/demo.yaml
@@ -5,19 +5,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 4
-      memoryRequests: '1536Mi'
-      cpuRequests: '250m'
-      memoryLimits: '2048Mi'
-      cpuLimits: '2000m'
-      readinessDelay: 45
-      readinessTimeout: 5
-      readinessPeriod: 15
-      autoscaling:
-        enabled: true
-        maxReplicas: 6
-        memory:
-          averageUtilization: 120
       ingressHost: fpl-case-service-demo.service.core-compute-demo.internal
       image: hmctspublic.azurecr.io/fpl/case-service:pr-5570-1819859-20240925134209 #{"$imagepolicy": "flux-system:demo-fpl-case-service"}
       environment:

--- a/apps/family-public-law/fpl-case-service/fpl-case-service.yaml
+++ b/apps/family-public-law/fpl-case-service/fpl-case-service.yaml
@@ -8,12 +8,19 @@ spec:
   releaseName: fpl-case-service
   values:
     java:
-      replicas: 2
+      replicas: 4
+      memoryRequests: '1536Mi'
+      cpuRequests: '250m'
+      memoryLimits: '2048Mi'
+      cpuLimits: '2000m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
       autoscaling:
-        enabled: false
+        enabled: true
+        maxReplicas: 6
+        memory:
+          averageUtilization: 120
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/fpl/case-service:prod-43eb141-20240925133748 #{"$imagepolicy": "flux-system:fpl-case-service"}
   chart:

--- a/apps/family-public-law/fpl-case-service/fpl-case-service.yaml
+++ b/apps/family-public-law/fpl-case-service/fpl-case-service.yaml
@@ -8,17 +8,17 @@ spec:
   releaseName: fpl-case-service
   values:
     java:
-      replicas: 4
+      replicas: 2
       memoryRequests: '1536Mi'
       cpuRequests: '250m'
       memoryLimits: '2048Mi'
-      cpuLimits: '2000m'
+      cpuLimits: '1500m'
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15
       autoscaling:
         enabled: true
-        maxReplicas: 6
+        maxReplicas: 4
         memory:
           averageUtilization: 120
       useInterpodAntiAffinity: true


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-2164

Add HPA to FPL service, remove from demo as testing showed little impact but best to keep an eye on memory/amount of pods span up once cafcass API is deployed

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Changes to `demo.yaml`
- Removed `replicas: 4` under `java`
- Removed `memoryRequests: '1536Mi'`
- Removed `cpuRequests: '250m'`
- Removed `memoryLimits: '2048Mi'`
- Removed `cpuLimits: '2000m`
- Removed `readinessDelay: 45`
- Removed `readinessTimeout: 5`
- Removed `readinessPeriod: 15`
- Removed `autoscaling` configuration

### Changes to `fpl-case-service.yaml`
- Added `replicas: 2` under `java`
- Updated `memoryRequests: '1536Mi'`
- Updated `cpuRequests: '250m'`
- Updated `memoryLimits: '2048Mi'`
- Updated `cpuLimits: '1500m`
- Changed `autoscaling` configuration from `enabled: false` to `enabled: true`
- Updated `maxReplicas: 4` under `autoscaling`
- Added `memory: averageUtilization: 120` under `autoscaling`