### PR TITLE
DTSSTCI-921

### DIFF
--- a/apps/sptribs/aat/00/kustomization.yaml
+++ b/apps/sptribs/aat/00/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: sptribs
 resources:
 - ../base
 patches:
+  - path: ../../sptribs-cron-clear-inactive-dss-draft-cases/aat/00.yaml

--- a/apps/sptribs/aat/00/kustomization.yaml
+++ b/apps/sptribs/aat/00/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: sptribs
 resources:
-- ../base
+  - ../base
 patches:
   - path: ../../sptribs-cron-clear-inactive-dss-draft-cases/aat/00.yaml

--- a/apps/sptribs/aat/base/kustomization.yaml
+++ b/apps/sptribs/aat/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
+  - ../../sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../sptribs-case-api/aat.yaml

--- a/apps/sptribs/demo/01/kustomization.yaml
+++ b/apps/sptribs/demo/01/kustomization.yaml
@@ -4,6 +4,5 @@ namespace: sptribs
 resources:
   - ../base
 patches:
-  - path: ../../sptribs-cron-clear-inactive-dss-draft-cases/demo/01.yaml
   - path: ../../sptribs-cron-trigger-stitch-hearing-bundle/demo/01.yaml
   - path: ../../sptribs-cron-trigger-complete-hearing-outcome/demo/01.yaml

--- a/apps/sptribs/ithc/00/kustomization.yaml
+++ b/apps/sptribs/ithc/00/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: sptribs
 resources:
-- ../base
+  - ../base
+patches:
+  - path: ../../sptribs-cron-clear-inactive-dss-draft-cases/ithc/00.yaml
 sortOptions:
   order: fifo

--- a/apps/sptribs/ithc/base/kustomization.yaml
+++ b/apps/sptribs/ithc/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/ithc
+  - ../../sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml
 namespace: sptribs
 patches:
   - path: ../../identity/ithc.yaml

--- a/apps/sptribs/perftest/00/kustomization.yaml
+++ b/apps/sptribs/perftest/00/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: sptribs
 resources:
   - ../base
 patches:
+  - path: ../../sptribs-cron-clear-inactive-dss-draft-cases/perftest/00.yaml

--- a/apps/sptribs/perftest/base/kustomization.yaml
+++ b/apps/sptribs/perftest/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/perftest
+  - ../../sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml
 patches:
   - path: ../../identity/perftest.yaml
   - path: ../../sptribs-case-api/perftest.yaml

--- a/apps/sptribs/prod/00/kustomization.yaml
+++ b/apps/sptribs/prod/00/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: sptribs
 resources:
-- ../base
+  - ../base
 patches:
-- path: ../../sptribs-cron-migrate-global-search-fields/prod/00.yaml
+  - path: ../../sptribs-cron-migrate-global-search-fields/prod/00.yaml
+  - path: ../../sptribs-cron-clear-inactive-dss-draft-cases/prod/00.yaml

--- a/apps/sptribs/prod/base/kustomization.yaml
+++ b/apps/sptribs/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: sptribs
 resources:
   - ../../base
   - ../../sptribs-cron-migrate-global-search-fields/sptribs-cron-migrate-global-search-fields.yaml
+  - ../../sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml
   - ../../../base/slack-provider/prod
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/aat/00.yaml
+++ b/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/aat/00.yaml
@@ -11,4 +11,4 @@ spec:
       jobKind: CronJob
       enableKeyVaults: true
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      environment: demo
+      environment: aat

--- a/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/ithc/00.yaml
+++ b/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/ithc/00.yaml
@@ -6,9 +6,9 @@ spec:
   releaseName: sptribs-cron-clear-inactive-dss-draft-cases
   values:
     job:
-      schedule: "0,5,15,25,35,45,55 8-17 * * *"
+      schedule: "0 9 * * *"
     global:
       jobKind: CronJob
       enableKeyVaults: true
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      environment: aat
+      environment: ithc

--- a/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/perftest/00.yaml
+++ b/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/perftest/00.yaml
@@ -11,4 +11,4 @@ spec:
       jobKind: CronJob
       enableKeyVaults: true
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      environment: demo
+      environment: perftest

--- a/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/prod/00.yaml
+++ b/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/prod/00.yaml
@@ -11,4 +11,4 @@ spec:
       jobKind: CronJob
       enableKeyVaults: true
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-      environment: demo
+      environment: prod


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSSTCI-921

### Change description
Switch on retire inactive cases cron in all envs after demo testing completed



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- apps/sptribs/aat/00/kustomization.yaml
  - Added a patch for sptribs-cron-clear-inactive-dss-draft-cases/aat/00.yaml.

- apps/sptribs/aat/base/kustomization.yaml
  - Added sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml to resources.

- apps/sptribs/demo/01/kustomization.yaml
  - Updated patches to include sptribs-cron-clear-inactive-dss-draft-cases/demo/01.yaml.

- apps/sptribs/ithc/00/kustomization.yaml
  - Added a patch for sptribs-cron-clear-inactive-dss-draft-cases/ithc/00.yaml.

- apps/sptribs/ithc/base/kustomization.yaml
  - Added sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml to resources.

- apps/sptribs/perftest/00/kustomization.yaml
  - Added a patch for sptribs-cron-clear-inactive-dss-draft-cases/perftest/00.yaml.

- apps/sptribs/perftest/base/kustomization.yaml
  - Added sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml to resources.

- apps/sptribs/prod/00/kustomization.yaml
  - Added patches for sptribs-cron-migrate-global-search-fields/prod/00.yaml and sptribs-cron-clear-inactive-dss-draft-cases/prod/00.yaml.

- apps/sptribs/prod/base/kustomization.yaml
  - Added sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml to resources.

- Renamed and added new files related to sptribs-cron-clear-inactive-dss-draft-cases for different environments. Updated schedule times for jobs in the renamed files.