### PR TITLE
Revert "CMC Prod DB migration enabled"

### DIFF
--- a/apps/civil/civil-service/prod.yaml
+++ b/apps/civil/civil-service/prod.yaml
@@ -20,9 +20,6 @@ spec:
         DOCMOSIS_TORNADO_URL: https://docmosis.platform.hmcts.net
         TESTING_SUPPORT_ENABLED: false
         DOCUMENT_MANAGEMENT_SECURED: true
-        REFERENCE_DATABASE_MIGRATION: true
-        SPRING_FLYWAY_TABLE: schema_version
-        SPRING_FLYWAY_BASELINE_ON_MIGRATE: true
         CUI_URL: https://www.moneyclaims.service.gov.uk
         CUI_URL_RESPOND_TO_CLAIM: https://www.moneyclaims.service.gov.uk/first-contact/start
         OCMC_CLIENT_URL: https://www1.moneyclaims.service.gov.uk


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34256

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **prod.yaml**
  - Removed `REFERENCE_DATABASE_MIGRATION`, `SPRING_FLYWAY_TABLE`, and `SPRING_FLYWAY_BASELINE_ON_MIGRATE` properties.
  - Updated `DOCMOSIS_TORNADO_URL` to `https://docmosis.platform.hmcts.net`.
  - Set `TESTING_SUPPORT_ENABLED` to `false`.
  - Set `DOCUMENT_MANAGEMENT_SECURED` to `true`.
  - Updated `CUI_URL` to `https://www.moneyclaims.service.gov.uk`.
  - Updated `CUI_URL_RESPOND_TO_CLAIM` to `https://www.moneyclaims.service.gov.uk/first-contact/start`.
  - Updated `OCMC_CLIENT_URL` to `https://www1.moneyclaims.service.gov.uk`.