### PR TITLE
Sbox - IDAM: disable pdb for idam-api

### DIFF
--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -15,6 +15,8 @@ spec:
       cpuLimits: '1500m'
       memoryRequests: '1536Mi'
       memoryLimits: '2048Mi'
+      pdb:
+        enabled: false
       environment:
         LOG_AND_AUDIT_IDAM_ENABLED: false
         MANAGEMENT_HEALTH_IDAMSERVICEAUTH_ENABLED: false


### PR DESCRIPTION
### Change description

- idam-api deployment is broken
- pod disruption budget is stopping the auto-shutdown/auto-startup scripting functioning correctly
- confusion of starts/stops lead cft sbox-00 into perpetual "Running" status and causing pipeline failure in prechecks for some core repos (azure-platform-terraform)


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- sbox.yaml
  - Added a new field 'pdb' with 'enabled' set to 'false' under the 'spec' section.