### PR TITLE
Update SSCS build radiator(remove ccd def and e2e tests)

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -146,7 +146,7 @@ spec:
                     title: CDM Develop Builds Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(sscs-bulk-scan|sscs-case-loader|sscs-cor-frontend|sscs-shared-infrastructure|sscs-submit-your-appeal|sscs-track-your-appeal-notifications|sscs-tribunals-case-api|sscs-ccd-definitions|sscs-hearings-api|sscs-ccd-e2e-tests)\/master
+                      ^HMCTS.*\/(sscs-bulk-scan|sscs-case-loader|sscs-cor-frontend|sscs-shared-infrastructure|sscs-submit-your-appeal|sscs-track-your-appeal-notifications|sscs-tribunals-case-api|sscs-hearings-api)\/master
                     name: SSCS
                     recurse: true
                     title: SSCS Dashboard


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
- Changed the includeRegex pattern for buildMonitor to exclude sscs-ccd-definitions and sscs-ccd-e2e-tests from the dashboard.