### PR TITLE
Update aat.yaml

### DIFF
--- a/apps/ccd/ccd-definition-store-api/aat.yaml
+++ b/apps/ccd/ccd-definition-store-api/aat.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-definition-store-api
   values:
     java:
-      replicas: 1
+      replicas: 2
       memoryRequests: "3072Mi"
       memoryLimits: "4096Mi"
       cpuRequests: "1"


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/ccd/ccd-definition-store-api/aat.yaml`
  - Changed the number of replicas from 1 to 2 for the `java` component.
  - Updated memory requests to \"3072Mi\".
  - Updated memory limits to \"4096Mi\".
  - Updated CPU requests to \"1\".