### PR TITLE
Add infrastructure repos to dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -260,7 +260,7 @@ spec:
                     title: RSE
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(em-ccd-orchestrator|em-native-pdf-annotator-app|em-annotation-api|em-stitching-api|document-management-store-app|dg-docassembly-api|em-hrs-api|em-hrs-ingestor)\/master
+                      ^HMCTS.*\/(em-ccd-orchestrator|em-native-pdf-annotator-app|em-annotation-api|em-stitching-api|document-management-store-app|dg-docassembly-api|em-hrs-api|em-hrs-ingestor|em-shared-infrastructure|dm-shared-infrastructure)\/master
                     name: Evidence
                     recurse: true
                     title: Evidence Management


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EM-6271

### Change description
Add infrastructure repos to dashboard


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml` 📝
  - Changed the `buildMonitor` regex pattern to include `em-shared-infrastructure` and `dm-shared-infrastructure` in the path.