### PR TITLE
Include media view and toolkit in ExUI dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -116,7 +116,7 @@ spec:
                     title: BSP
                 - buildMonitor:
                     includeRegex: >-
-                      .+\/(rpx-.*)\/(master)
+                      (^rpx-.+\/master)|(em-media-viewer)|(em-showcase)|(ccd-case-ui-toolkit)
                     name: XUI
                     recurse: true
                     title: XUI


### PR DESCRIPTION
### Jira link

See https://tools.hmcts.net/jira/browse/EXUI-2404

### Change description
Include em media viewer repos in ExUI dashboard, because they are managed by the ExUI team now

### Testing done
->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
- Updated the includeRegex in the buildMonitor to include the branches `(^rpx-.+\/master)|(em-media-viewer)|(em-showcase)|(ccd-case-ui-toolkit)`.