### PR TITLE
DTSAM-537 enable `sscs_wa_1_5` on ORM Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: civil_wa_1_9
+        DB_FEATURE_FLAG_ENABLE: sscs_wa_1_5
         REFRESH_JOB: LEGAL_OPERATIONS-CIVIL-NEW-0-48
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-537](https://tools.hmcts.net/jira/browse/DTSAM-537) _"Enable 'sscs_wa_1_5' ORM flag in lower environment ready for SSCS to test"_

### Change description

Enable 'sscs_wa_1_5' ORM flag in Demo environment ready for SSCS to test


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


## apps/am/am-org-role-mapping-service/demo.yaml
- Updated the value of DB_FEATURE_FLAG_ENABLE from \"civil_wa_1_9\" to \"sscs_wa_1_5\" 🔄