### PR TITLE
CME-75 match perf testing env to prod for ExUI

### DIFF
--- a/apps/xui/xui-webapp/perftest.yaml
+++ b/apps/xui/xui-webapp/perftest.yaml
@@ -5,16 +5,9 @@ metadata:
 spec:
   values:
     nodejs:
-      replicas: 14
-      memoryLimits: "3Gi"
-      memoryRequests: "1.5Gi"
-      autoscaling:
-        enabled: true
-        maxReplicas: 24
-        cpu:
-          averageUtilization: 70
-        memory:
-          averageUtilization: 70
+      replicas: 24
+      memoryLimits: "4Gi"
+      memoryRequests: "3Gi"
       ingressHost: manage-case.perftest.platform.hmcts.net
       environment:
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CME-75

### Change description
Match ExUI perf environment to Prod so baseline performance can be measured.


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/xui/xui-webapp/perftest.yaml
- Changed the `replicas` value from 14 to 24
- Changed the `memoryLimits` value from \"3Gi\" to \"4Gi\"
- Changed the `memoryRequests` value from \"1.5Gi\" to \"3Gi\"
- Removed the `autoscaling` configuration, including `enabled`, `maxReplicas`, `cpu` and `memory` values