### PR TITLE
Revert "DTSPO-18903 - Add virtual repo"

### DIFF
--- a/apps/artifactory/sbox-intsvc/artifactory-configmap.yaml
+++ b/apps/artifactory/sbox-intsvc/artifactory-configmap.yaml
@@ -260,58 +260,6 @@ spec:
                         <propagateQueryParams>false</propagateQueryParams>
                     </remoteRepository>
                     <remoteRepository>
-                        <key>maven-remotes</key>
-                        <type>maven</type>
-                        <includesPattern>**/*</includesPattern>
-                        <repoLayoutRef>maven-2-default</repoLayoutRef>
-                        <dockerApiVersion>V2</dockerApiVersion>
-                        <forceNugetAuthentication>false</forceNugetAuthentication>
-                        <blackedOut>false</blackedOut>
-                        <handleReleases>true</handleReleases>
-                        <handleSnapshots>true</handleSnapshots>
-                        <maxUniqueSnapshots>0</maxUniqueSnapshots>
-                        <maxUniqueTags>0</maxUniqueTags>
-                        <suppressPomConsistencyChecks>false</suppressPomConsistencyChecks>
-                        <propertySets/>
-                        <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-                        <url>https://plugins.gradle.org/m2/</url>
-                        <offline>false</offline>
-                        <hardFail>false</hardFail>
-                        <storeArtifactsLocally>true</storeArtifactsLocally>
-                        <fetchJarsEagerly>false</fetchJarsEagerly>
-                        <fetchSourcesEagerly>false</fetchSourcesEagerly>
-                        <retrievalCachePeriodSecs>600</retrievalCachePeriodSecs>
-                        <assumedOfflinePeriodSecs>300</assumedOfflinePeriodSecs>
-                        <missedRetrievalCachePeriodSecs>1800</missedRetrievalCachePeriodSecs>
-                        <remoteRepoChecksumPolicyType>generate-if-absent</remoteRepoChecksumPolicyType>
-                        <unusedArtifactsCleanupPeriodHours>0</unusedArtifactsCleanupPeriodHours>
-                        <shareConfiguration>false</shareConfiguration>
-                        <synchronizeProperties>false</synchronizeProperties>
-                        <listRemoteFolderItems>true</listRemoteFolderItems>
-                        <rejectInvalidJars>false</rejectInvalidJars>
-                        <p2OriginalUrl>https://plugins.gradle.org/m2/</p2OriginalUrl>
-                        <contentSynchronisation>
-                            <enabled>false</enabled>
-                            <statistics>
-                                <enabled>false</enabled>
-                            </statistics>
-                            <properties>
-                                <enabled>false</enabled>
-                            </properties>
-                            <source>
-                                <originAbsenceDetection>false</originAbsenceDetection>
-                            </source>
-                        </contentSynchronisation>
-                        <blockMismatchingMimeTypes>true</blockMismatchingMimeTypes>
-                        <mismatchingMimeTypesOverrideList></mismatchingMimeTypesOverrideList>
-                        <bypassHeadRequests>false</bypassHeadRequests>
-                        <allowAnyHostAuth>false</allowAnyHostAuth>
-                        <socketTimeoutMillis>15000</socketTimeoutMillis>
-                        <enableCookieManagement>false</enableCookieManagement>
-                        <enableTokenAuthentication>false</enableTokenAuthentication>
-                        <propagateQueryParams>false</propagateQueryParams>
-                    </remoteRepository>
-                    <remoteRepository>
                         <key>jenkins</key>
                         <type>maven</type>
                         <includesPattern>**/*</includesPattern>
@@ -468,6 +416,30 @@ spec:
                         <propagateQueryParams>false</propagateQueryParams>
                     </remoteRepository>
                 </remoteRepositories>
+                <virtualRepositories>
+                    <virtualRepository>
+                        <key>maven-remotes</key>
+                        <type>maven</type>
+                        <includesPattern>**/*</includesPattern>
+                        <repoLayoutRef>maven-2-default</repoLayoutRef>
+                        <dockerApiVersion>V2</dockerApiVersion>
+                        <forceNugetAuthentication>false</forceNugetAuthentication>
+                        <artifactoryRequestsCanRetrieveRemoteArtifacts>false</artifactoryRequestsCanRetrieveRemoteArtifacts>
+                        <repositories>
+                            <repositoryRef>gradle-plugins</repositoryRef>
+                            <repositoryRef>hmcts</repositoryRef>
+                            <repositoryRef>jcenter</repositoryRef>
+                            <repositoryRef>jenkins</repositoryRef>
+                            <repositoryRef>maven-central</repositoryRef>
+                            <repositoryRef>jitpack</repositoryRef>
+                        </repositories>
+                        <pomRepositoryReferencesCleanupPolicy>discard_active_reference</pomRepositoryReferencesCleanupPolicy>
+                        <virtualCacheConfig>
+                            <virtualRetrievalCachePeriodSecs>600</virtualRetrievalCachePeriodSecs>
+                        </virtualCacheConfig>
+                        <forceMavenAuthentication>false</forceMavenAuthentication>
+                    </virtualRepository>
+                </virtualRepositories>
                 <distributionRepositories/>
                 <releaseBundlesRepositories/>
                 <proxies/>

--- a/apps/artifactory/sbox-intsvc/base/kustomization.yaml
+++ b/apps/artifactory/sbox-intsvc/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 
 patches:
   - path: ../ingress-patch.yaml
+  - path: ../artifactory-configmap.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34659

Trying to resolve https://tools.hmcts.net/jira/browse/DTSPO-19241

Darts-API and some others are having issues with jknack specifically as the pipeline is looking for those packages in `https://repo.maven.apache.org/maven2/com/github/jknack/handlebars/java/handlebars-springmvc/4.3.1/handlebars-springmvc-4.3.1.pom` instead of `https://repo.maven.apache.org/maven2/com/github/jknack/handlebars-springmvc/4.3.1/`.

Don't think it's to do with artifactory as it seems to be an issue upstream but would like to rule it out.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **artifactory-configmap.yaml**
  - Added a new remote repository configuration for \"maven-remotes\" including various settings like URL, cache configuration, and authentication settings.
  - Updated the existing configurations for \"gradle-plugins\" and \"jenkins\" remote repositories.
  - Added new configurations for \"hmcts\", \"jcenter\", \"maven-central\", and \"jitpack\" remote repositories.
  - Added virtual repository configurations including references to the remote repositories.
  - Updated layout patterns for various repository types.
  - Added security settings in the form of XML data.

- **base/kustomization.yaml**
  - Added a new reference to the `artifactory-configmap.yaml` file.