### PR TITLE
DTSPO-19360 - Increase daily agent limit

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -109,7 +109,7 @@ spec:
                       - templateName: "cnp-jenkins-ubuntu-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
                         labels: "daily"
-                        maxVirtualMachinesLimit: 20
+                        maxVirtualMachinesLimit: 40
                         retentionStrategy:
                           azureVMCloudRetentionStrategy:
                             idleTerminationMinutes: 5


### PR DESCRIPTION
### Jira link

See [DTSPO-19360](https://tools.hmcts.net/jira/browse/DTSPO-19360)

### Change description

There is a spike in nightly builds that is blocking other builds from running
Increasing until the queue clears

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- File: jenkins-azure-vm-agent.yaml
- Increased the maxVirtualMachinesLimit from 20 to 40.
- Updated the idleTerminationMinutes to 5.