### PR TITLE
DTSPO-19241 - Update virtual repo name

### DIFF
--- a/apps/artifactory/artifactory/artifactory-configmap.yaml
+++ b/apps/artifactory/artifactory/artifactory-configmap.yaml
@@ -260,58 +260,6 @@ spec:
                         <propagateQueryParams>false</propagateQueryParams>
                     </remoteRepository>
                     <remoteRepository>
-                        <key>maven-remotes</key>
-                        <type>maven</type>
-                        <includesPattern>**/*</includesPattern>
-                        <repoLayoutRef>maven-2-default</repoLayoutRef>
-                        <dockerApiVersion>V2</dockerApiVersion>
-                        <forceNugetAuthentication>false</forceNugetAuthentication>
-                        <blackedOut>false</blackedOut>
-                        <handleReleases>true</handleReleases>
-                        <handleSnapshots>true</handleSnapshots>
-                        <maxUniqueSnapshots>0</maxUniqueSnapshots>
-                        <maxUniqueTags>0</maxUniqueTags>
-                        <suppressPomConsistencyChecks>false</suppressPomConsistencyChecks>
-                        <propertySets/>
-                        <archiveBrowsingEnabled>false</archiveBrowsingEnabled>
-                        <url>https://plugins.gradle.org/m2/</url>
-                        <offline>false</offline>
-                        <hardFail>false</hardFail>
-                        <storeArtifactsLocally>true</storeArtifactsLocally>
-                        <fetchJarsEagerly>false</fetchJarsEagerly>
-                        <fetchSourcesEagerly>false</fetchSourcesEagerly>
-                        <retrievalCachePeriodSecs>600</retrievalCachePeriodSecs>
-                        <assumedOfflinePeriodSecs>300</assumedOfflinePeriodSecs>
-                        <missedRetrievalCachePeriodSecs>1800</missedRetrievalCachePeriodSecs>
-                        <remoteRepoChecksumPolicyType>generate-if-absent</remoteRepoChecksumPolicyType>
-                        <unusedArtifactsCleanupPeriodHours>0</unusedArtifactsCleanupPeriodHours>
-                        <shareConfiguration>false</shareConfiguration>
-                        <synchronizeProperties>false</synchronizeProperties>
-                        <listRemoteFolderItems>true</listRemoteFolderItems>
-                        <rejectInvalidJars>false</rejectInvalidJars>
-                        <p2OriginalUrl>https://plugins.gradle.org/m2/</p2OriginalUrl>
-                        <contentSynchronisation>
-                            <enabled>false</enabled>
-                            <statistics>
-                                <enabled>false</enabled>
-                            </statistics>
-                            <properties>
-                                <enabled>false</enabled>
-                            </properties>
-                            <source>
-                                <originAbsenceDetection>false</originAbsenceDetection>
-                            </source>
-                        </contentSynchronisation>
-                        <blockMismatchingMimeTypes>true</blockMismatchingMimeTypes>
-                        <mismatchingMimeTypesOverrideList></mismatchingMimeTypesOverrideList>
-                        <bypassHeadRequests>false</bypassHeadRequests>
-                        <allowAnyHostAuth>false</allowAnyHostAuth>
-                        <socketTimeoutMillis>15000</socketTimeoutMillis>
-                        <enableCookieManagement>false</enableCookieManagement>
-                        <enableTokenAuthentication>false</enableTokenAuthentication>
-                        <propagateQueryParams>false</propagateQueryParams>
-                    </remoteRepository>
-                    <remoteRepository>
                         <key>jenkins</key>
                         <type>maven</type>
                         <includesPattern>**/*</includesPattern>
@@ -470,7 +418,7 @@ spec:
                 </remoteRepositories>
                 <virtualRepositories>
                     <virtualRepository>
-                        <key>maven-virtual</key>
+                        <key>maven-remotes</key>
                         <type>maven</type>
                         <includesPattern>**/*</includesPattern>
                         <excludesPattern>com/github/jknack**</excludesPattern>


### PR DESCRIPTION
### Jira link

See [DTSPO-19241](https://tools.hmcts.net/jira/browse/DTSPO-19241)

### Change description

Updating `maven-virtual` to `maven-remotes` and deleting the remoteRepository `maven-remotes`.
Tested `maven-virtual` on civil-sdt nightly and darts-api and both are now working

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Mentioned changes in `artifactory-configmap.yaml`:
  - Removed a `<remoteRepository>` block with several configuration settings.
  - Updated the `<virtualRepository>` key from `maven-virtual` to `maven-remotes`.