### PR TITLE
Add patch access to run helm upgrade command from locally

### DIFF
--- a/apps/rbac/edit-clusterrole.yaml
+++ b/apps/rbac/edit-clusterrole.yaml
@@ -40,7 +40,7 @@ rules:
   verbs: ['create', 'update', 'delete']
 - apiGroups: ['servicebus.azure.com']
   resources: ['namespaces', 'namespacesqueues', 'namespacestopics', 'namespacestopicssubscriptions']
-  verbs: ['create', 'update', 'delete']
+  verbs: ['create', 'update', 'delete', 'patch']
 - apiGroups: ['storage.azure.com']
   resources: ['StorageAccount', 'StorageAccountsBlobService', 'StorageAccountsBlobServicesContainer']
   verbs: ['create', 'update', 'delete']
@@ -55,7 +55,7 @@ rules:
   verbs: ['get', 'list', 'watch']
 - apiGroups: ['dbforpostgresql.azure.com']
   resources: ['flexibleserversdatabases']
-  verbs: ['create', 'update', 'delete']
+  verbs: ['create', 'update', 'delete', 'patch']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Jira link

UPGRADE FAILED: cannot patch "pr-xxxxxxx-dev-data-store" with kind FlexibleServersDatabase: flexibleserversdatabases.dbforpostgresql.azure.com "pr-xxxxxx-dev-data-store" is forbidden: User "xxxxx.xxxxx@HMCTS.NET" cannot patch resource "flexibleserversdatabases" in API group "dbforpostgresql.azure.com" in the namespace "sscs"

### Change description



### Testing done



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
