### PR TITLE
Em-6284 increase cron interval

### DIFF
--- a/apps/em/em-stitching/prod.yaml
+++ b/apps/em/em-stitching/prod.yaml
@@ -17,7 +17,7 @@ spec:
         memory:
           averageUtilization: 85
       environment:
-#        DOCUMENT_TASK_MILLISECONDS: 5000   Leave this to default of 2 seconds
+        DOCUMENT_TASK_MILLISECONDS: 6000   Leave this to default of 2 seconds
         DOCMOSIS_ENDPOINT: https://docmosis.platform.hmcts.net/rs/convert
         DOCMOSIS_RENDER_ENDPOINT: https://docmosis.platform.hmcts.net/rs/render
         IDAM_API_BASE_URI: https://idam-api.platform.hmcts.net


### PR DESCRIPTION
### Jira link

Em-6284(https://tools.hmcts.net/jira/browse/EM-6284)
increase cron job interval

### Change description

>Currently, the task can only run at intervals longer than 5 seconds because the minimum lock duration is 5 seconds. Setting the scheduler to 6 seconds won't have any significant impact, but it will ease the scheduler's polling.





## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/em/em-stitching/prod.yaml
- Added a new environment variable `DOCUMENT_TASK_MILLISECONDS` with a value of 6000.
- Updated the comment for `DOCUMENT_TASK_MILLISECONDS` to reflect its default value of 2 seconds.