### PR TITLE
Revert "Update hmctspublic.azurecr.io/jenkins/jenkins Docker tag to v2.481-783 in jenkins"

### DIFF
--- a/apps/jenkins/jenkins/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/jenkins-controller-version.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.481-783
+      tag: 2.481-782


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34933

^ github-scm-filter-aged-refs was upgraded to v55 which is breaking PR runs in Jenkins, reverting to old image pre plugin upgrade

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


**apps/jenkins/jenkins/jenkins-controller-version.yaml**
- In the `controller` section, the tag has been changed from `2.481-783` to `2.481-782`. 🔄