### PR TITLE
Em-6284-increse-interval

### DIFF
--- a/apps/em/em-stitching/prod.yaml
+++ b/apps/em/em-stitching/prod.yaml
@@ -17,7 +17,7 @@ spec:
         memory:
           averageUtilization: 85
       environment:
-        DOCUMENT_TASK_MILLISECONDS: 6000   Leave this to default of 2 seconds
+        DOCUMENT_TASK_MILLISECONDS: 6000
         DOCMOSIS_ENDPOINT: https://docmosis.platform.hmcts.net/rs/convert
         DOCMOSIS_RENDER_ENDPOINT: https://docmosis.platform.hmcts.net/rs/render
         IDAM_API_BASE_URI: https://idam-api.platform.hmcts.net


### PR DESCRIPTION
### Jira link

Em-6284(https://tools.hmcts.net/jira/browse/EM-6284)
increase cron job interval

### Change description

>Currently, the task can only run at intervals longer than 5 seconds because the minimum lock duration is 5 seconds. Setting the scheduler to 6 seconds won't have any significant impact, but it will ease the scheduler's polling.

