### PR TITLE
EM-6284 remove default value

### DIFF
--- a/apps/em/em-stitching/prod.yaml
+++ b/apps/em/em-stitching/prod.yaml
@@ -17,7 +17,7 @@ spec:
         memory:
           averageUtilization: 85
       environment:
-        DOCUMENT_TASK_MILLISECONDS: 6000
+        #DOCUMENT_TASK_MILLISECONDS: 5000   Leave this to default of 2 seconds
         DOCMOSIS_ENDPOINT: https://docmosis.platform.hmcts.net/rs/convert
         DOCMOSIS_RENDER_ENDPOINT: https://docmosis.platform.hmcts.net/rs/render
         IDAM_API_BASE_URI: https://idam-api.platform.hmcts.net

--- a/apps/em/em-stitching/prod.yaml
+++ b/apps/em/em-stitching/prod.yaml
@@ -17,7 +17,7 @@ spec:
         memory:
           averageUtilization: 85
       environment:
-        #DOCUMENT_TASK_MILLISECONDS: 5000   Leave this to default of 2 seconds
+        #DOCUMENT_TASK_MILLISECONDS: 5000
         DOCMOSIS_ENDPOINT: https://docmosis.platform.hmcts.net/rs/convert
         DOCMOSIS_RENDER_ENDPOINT: https://docmosis.platform.hmcts.net/rs/render
         IDAM_API_BASE_URI: https://idam-api.platform.hmcts.net


### PR DESCRIPTION
### Jira link
EM-6284 remove default value
Now it is 6000 in the chart



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/em/em-stitching/prod.yaml
- Updated the `DOCMOSIS_ENDPOINT` environment variable from `DOCUMENT_TASK_MILLISECONDS: 6000` to `DOCMOSIS_ENDPOINT: https://docmosis.platform.hmcts.net/rs/convert`
- Added `DOCMOSIS_RENDER_ENDPOINT` and `IDAM_API_BASE_URI` environment variables.