### PR TITLE
Make 01 active preview cluster

### DIFF
--- a/apps/admin/external-dns-2/preview/00-external-dns-private.yaml
+++ b/apps/admin/external-dns-2/preview/00-external-dns-private.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   releaseName: external-dns-private
   values:
-    txtOwnerId: preview-active
+    txtOwnerId: preview-inactive

--- a/apps/admin/external-dns-2/preview/01-external-dns-private.yaml
+++ b/apps/admin/external-dns-2/preview/01-external-dns-private.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   releaseName: external-dns-private
   values:
-    txtOwnerId: preview-inactive
+    txtOwnerId: preview-active


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#19889

In line with https://github.com/hmcts/aks-cft-deploy/pull/678 

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/admin/external-dns-2/preview/00-external-dns-private.yaml
- Changed `txtOwnerId` value from `preview-active` to `preview-inactive`.

### apps/admin/external-dns-2/preview/01-external-dns-private.yaml
- Changed `txtOwnerId` value from `preview-inactive` to `preview-active`.