### PR TITLE
Revert "Swapping over jenkins preview cluster" - switch back to 01

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -57,9 +57,9 @@ spec:
                       - key: AAT_AKS_RESOURCE_GROUP
                         value: cft-aat-01-rg
                       - key: PREVIEW_AKS_CLUSTER_NAME
-                        value : cft-preview-00-aks
+                        value : cft-preview-01-aks
                       - key : PREVIEW_AKS_RESOURCE_GROUP
-                        value: cft-preview-00-rg
+                        value: cft-preview-01-rg
                       - key: AKS_PTL_SUBSCRIPTION_NAME
                         value: DTS-CFTPTL-INTSVC
                       - key: AKS_PREVIEW_SUBSCRIPTION_NAME


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#34920

In line with https://github.com/hmcts/cnp-flux-config/pull/35032

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
- Updated the value for PREVIEW_AKS_CLUSTER_NAME from \"cft-preview-00-aks\" to \"cft-preview-01-aks\".
- Updated the value for PREVIEW_AKS_RESOURCE_GROUP from \"cft-preview-00-rg\" to \"cft-preview-01-rg\".