### PR TITLE
Revert "Revert "Update perftest-image-policy.yaml""

### DIFF
--- a/apps/private-law/prl-cos/perftest-image-policy.yaml
+++ b/apps/private-law/prl-cos/perftest-image-policy.yaml
@@ -1,7 +1,14 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: perftest-prl-cos
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: prl-cos
+  filterTags:
+    pattern: '^pr-2544-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/private-law/prl-cos/perftest-image-policy.yaml
+++ b/apps/private-law/prl-cos/perftest-image-policy.yaml
@@ -7,7 +7,7 @@ spec:
   imageRepositoryRef:
     name: prl-cos
   filterTags:
-    pattern: '^pr-2544-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2821-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#33259

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/private-law/prl-cos/perftest-image-policy.yaml
- Updated the ImagePolicy with annotations and a new filterTags block to include a pattern, extract, and policy. The filterTags block is used to filter image tags based on the pattern defined.