### PR TITLE
DTSRD-3646 - Scheduling full data load in PROD at 8 PM

### DIFF
--- a/apps/rd/rd-judicial-api/prod.yaml
+++ b/apps/rd/rd-judicial-api/prod.yaml
@@ -17,7 +17,7 @@ spec:
         ELINKS_URL: https://gateway.prod.elinks.judiciary.uk/elinks/api/v5
         LAST_UPDATED: 1900-01-01
         SCHEDULER_ENABLED: true
-        CRON_EXPRESSION: "0 00 19 24 10 ?"
+        CRON_EXPRESSION: "0 00 19 25 10 ?"
         PER_PAGE: 50
         INCLUDE_PREVIOUS_APPOINTMENT: true
         THREAD_PAUSE_TIME: 2000


### PR DESCRIPTION
### Jira link https://tools.hmcts.net/jira/browse/DTSRD-3646

#### Scheduling elinks full load job in PROD today at 8 PM.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/rd/rd-judicial-api/prod.yaml
- Updated the `CRON_EXPRESSION` from \"0 00 19 24 10 ?\" to \"0 00 19 25 10 ?\" to change the schedule time for the job. 🔄