### PR TITLE
DTSRD-3646 - Scheduling full data load in PROD today at 4 PM

### DIFF
--- a/apps/rd/rd-judicial-api/prod.yaml
+++ b/apps/rd/rd-judicial-api/prod.yaml
@@ -17,7 +17,7 @@ spec:
         ELINKS_URL: https://gateway.prod.elinks.judiciary.uk/elinks/api/v5
         LAST_UPDATED: 1900-01-01
         SCHEDULER_ENABLED: true
-        CRON_EXPRESSION: "0 00 15 28 10 ?"
+        CRON_EXPRESSION: "0 00 16 29 10 ?"
         PER_PAGE: 50
         INCLUDE_PREVIOUS_APPOINTMENT: true
         THREAD_PAUSE_TIME: 2000


### PR DESCRIPTION
### Jira link https://tools.hmcts.net/jira/browse/DTSRD-3646

#### DTSRD-3646 - Scheduling full data load in PROD today at 4 PM

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### File changed: prod.yaml
- Updated the `CRON_EXPRESSION` from \"0 00 15 28 10 ?\" to \"0 00 16 29 10 ?\"
- Changed the scheduler time for the judicial API in the production environment to run at 16:00 on the 29th of October.