### PR TITLE
[ADOP-2408] added minReplicas to override chart values

### DIFF
--- a/apps/adoption/adoption-cos-api/aat.yaml
+++ b/apps/adoption/adoption-cos-api/aat.yaml
@@ -13,6 +13,7 @@ spec:
       memoryRequests: "1536Mi"
       autoscaling:
         enabled: true
+        minReplicas: 2
         maxReplicas: 4
         memory:
           averageUtilization: 120


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Setting AAT minReplicas to override chart values


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


md
- `aat.yaml`
    - Added `minReplicas` as 2 under the `autoscaling` section
```