### PR TITLE
[ADOP-2408] increasing AAT adoption-web memoryLimit

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -8,7 +8,7 @@ spec:
     nodejs:
       cpuLimits: "500m"
       cpuRequests: "50m"
-      memoryLimits: "512Mi"
+      memoryLimits: "1Gi"
       memoryRequests: "512Mi"
       autoscaling:
         enabled: true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
increasing AAT adoption-web memoryLimit


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated the `aat.yaml` file in `apps/adoption/adoption-web`:
  - Increased the memory limits from \"512Mi\" to \"1Gi\" for the Nodejs app.
  - The CPU limits and requests remain unchanged.