### PR TITLE
[ADOP-2408] reducing CPU and memory for AAT containers

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "1000m"
-      cpuRequests: "500m"
-      memoryLimits: "2Gi"
+      cpuLimits: "500m"
+      cpuRequests: "100m"
+      memoryLimits: "1536Mi"
       memoryRequests: "512Mi"
       autoscaling:
         enabled: true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
 reducing CPU and memory for AAT containers


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-web/aat.yaml
- Updated CPU and memory limits and requests for the `nodejs` container in the `aat` environment.
- CPU limits changed from \"1000m\" to \"500m\".
- CPU requests changed from \"500m\" to \"100m\".
- Memory limits changed from \"2Gi\" to \"1536Mi\".
- Memory requests unchanged.