### PR TITLE
CIV-15700 - point to different PR

### DIFF
--- a/apps/civil/civil-service/demo-image-policy.yaml
+++ b/apps/civil/civil-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-5741-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-5754-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CIV-15700

### Change description
Pointing to a civil-service PR that will allow the testing of a cover letter appending service in demo


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/demo-image-policy.yaml
- Changed the pattern in the filterTags from `'pattern: '^pr-5741-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'pattern: '^pr-5754-[a-f0-9]+-(?P<ts>[0-9]+)'` for demo-image-policy.