### PR TITLE
[ADOP-2408] increased AAT cpuLimit to 500m

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "100m"
+      cpuLimits: "500m"
       cpuRequests: "50m"
       memoryLimits: "1536Mi"
       memoryRequests: "512Mi"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Increased AAT cpuLimit to 500m to prevent pods being starved on start up

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `apps/adoption/adoption-web/aat.yaml` has been modified to increase the CPU limits from \"100m\" to \"500m\".