### PR TITLE
Lowering pod replication back to 1 after re indexing

### DIFF
--- a/apps/ccd/ccd-logstash/prod.yaml
+++ b/apps/ccd/ccd-logstash/prod.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   releaseName: ccd-logstash
   values:
-    replicas: 2
+    replicas: 1


### PR DESCRIPTION
### Jira link
https://mojcppprod.service-now.com/nav_to.do?uri=%2Fchange_request.do%3Fsys_id%3D2ed77ec247ad5614dffff0eb736d43da%26sysparm_stack%3D%26sysparm_view%3D

### Change description

Lowering the number of replicated pods for logstash from 2 to 1 after CHG5018722

### Testing done

This was done for the Civil re-indexing on October 3rd.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


#### apps/ccd/ccd-logstash/prod.yaml
- Changed replicas from 2 to 1. 🔧