### PR TITLE
Update aat.yaml

### DIFF
--- a/apps/em/em-stitching/aat.yaml
+++ b/apps/em/em-stitching/aat.yaml
@@ -11,5 +11,6 @@ spec:
       cpuLimits: "3000m"
       environment:
         TEST_VAR: refresh3
-        HISTORIC_DOCUMENT_TASKS_NO_OF_RECORDS: 200
-        HISTORIC_DOCUMENT_TASKS_CRONJOB_SCHEDULE: "0 */10 * * * *"
+        HISTORIC_DOCUMENT_TASKS_NO_OF_RECORDS: 300
+        HISTORIC_DOCUMENT_TASKS_CRONJOB_SCHEDULE: "0 */5 * * * *"
+        DOCUMENT_TASK_MILLISECONDS: 3600000 # every hour


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EM-6304
### Change description
Need to delete old DocumentTask rows from AAT DB which has reached 90% storage space.
Delay BatchExecution to resolve DB errror.
### Testing done
N/A
### Checklist
- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- File: aat.yaml
- Updated HISTORIC_DOCUMENT_TASKS_NO_OF_RECORDS from 200 to 300
- Updated HISTORIC_DOCUMENT_TASKS_CRONJOB_SCHEDULE from \"0 */10 * * * *\" to \"0 */5 * * * *\"
- Added DOCUMENT_TASK_MILLISECONDS with value 3600000