### PR TITLE
PAY-7452 reverting back to prod in Demo

### DIFF
--- a/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ccpay-payment-app
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1697-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: ccpay-payment-app


### PR DESCRIPTION
### Jira link
See [PAY-7452](https://tools.hmcts.net/jira/browse/PAY-7452)

### Change description

Reverting payments in demo back to prod image

### Testing done
N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
- Removed annotations and image filter tags from the ImagePolicy.
- Removed the automated production deployment for the demo-ccpay-payment-app.
- Updated the image policy to remove the filter for specific pattern and tag extraction.