### PR TITLE
[ADOP-2408] increased adoption-web AAT cpuLimits

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "500m"
+      cpuLimits: "600m"
       cpuRequests: "50m"
       memoryLimits: "1536Mi"
       memoryRequests: "512Mi"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Increased adoption-web AAT cpuLimits to prevent extra pods from being spun up when pipelines run



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-web/aat.yaml
- Increased the CPU limits for the nodejs container from \"500m\" to \"600m\".