### PR TITLE
[ADOP-2408] bump up AAT adoption-web cpuLimits 

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "600m"
+      cpuLimits: "700m"
       cpuRequests: "50m"
       memoryLimits: "1536Mi"
       memoryRequests: "512Mi"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
bump up AAT adoption-web cpuLimits  to prevent extra pods spinning up when pipeline run



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


yaml
aat.yaml
- Increased CPU limits from \"600m\" to \"700m\" for the nodejs container
```