### PR TITLE
Pointing ITHC at a PR Image for the duration of ITHC testing.  Image …

### DIFF
--- a/apps/financial-remedy/finrem-cos/ithc-image-policy.yaml
+++ b/apps/financial-remedy/finrem-cos/ithc-image-policy.yaml
@@ -3,7 +3,13 @@ kind: ImagePolicy
 metadata:
   name: ithc-finrem-cos
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-1953-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: finrem-cos

--- a/apps/financial-remedy/finrem-cos/ithc.yaml
+++ b/apps/financial-remedy/finrem-cos/ithc.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctspublic.azurecr.io/finrem/cos:pr-1953-6f00e04-20241107122335 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
       environment:
         SECURE_DOC_ENABLED: false
         FEATURE_PBA_CASE_TYPE: true


### PR DESCRIPTION
…based on master from 7/11/2024

### Jira link

https://tools.hmcts.net/jira/browse/DFR-3411

### Change description

Points ITHC at an image for the duration of pen testing.   The image was just created from master.
This is so that the pen testers are working from a consistent image beginning Monday 11th.


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


yaml
- apps/financial-remedy/finrem-cos/ithc-image-policy.yaml
- Disabled prod-automated annotation
- Added filterTags and policy for image policy

- apps/financial-remedy/finrem-cos/ithc.yaml
- Updated Java image version to 'pr-1953-6f00e04-20241107122335'
```