### PR TITLE
[ADOP-2408] increasing AAT adoption-web cpuLimits

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "700m"
+      cpuLimits: "750m"
       cpuRequests: "50m"
       memoryLimits: "1536Mi"
       memoryRequests: "512Mi"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
increasing AAT adoption-web cpuLimits so pods don't scale for pipeline runs



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `aat.yaml`
  - Increased CPU limits for `nodejs` from \"700m\" to \"750m\".