### PR TITLE
[ADOP-2408] increased adoption-web AAT CPU averageUtilization for autoscaling

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,13 +6,15 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "750m"
+      cpuLimits: "500m"
       cpuRequests: "50m"
       memoryLimits: "1536Mi"
       memoryRequests: "512Mi"
       autoscaling:
         enabled: true
         maxReplicas: 4
+        cpu:
+          averageUtilization: 300 #AAT only: To prevent pods scaling when pipelines run
       environment:
         PCQ_ENABLED: "true"
         #Pilot local-court email-Ids


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Increased CPU averageUtilization to 300% to prevent additional pods being spun up during pipeline runs in AAT


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-web/aat.yaml
- Decreased CPU limits from \"750m\" to \"500m\" and updated autoscaling configuration to have an average CPU utilization of 300.