### PR TITLE
Upgrade traefik in sbox

### DIFF
--- a/apps/admin/traefik-v33-crds/kustomization.yaml
+++ b/apps/admin/traefik-v33-crds/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v33.0.0/traefik/crds/traefik.io_traefikservices.yaml

--- a/apps/admin/traefik-v33-crds/kustomize.yaml
+++ b/apps/admin/traefik-v33-crds/kustomize.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  path: ./apps/admin/traefik-v33-crds

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     deployment:
       additionalVolumes:

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -21,3 +21,4 @@ patches:
     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
     kind: Kustomization
 - path: ../../../apps/admin/sbox/base/kustomize.yaml
+- path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml


### PR DESCRIPTION
Upgrades traefik to latest in cft sbox

Same done in sds https://github.com/hmcts/sds-flux-config/pull/5732/files -- nonprod is all also done in sds

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Added `apps/admin/traefik-v33-crds/kustomization.yaml` which includes references to Traefik CRDs and custom resources.
- Added `apps/admin/traefik-v33-crds/kustomize.yaml` to apply customization for Traefik CRDs in the `flux-system` namespace.
- Updated `apps/admin/traefik2/sbox/00.yaml` and `apps/admin/traefik2/sbox/01.yaml` to specify Traefik version 33.0.0 and the Helm repository.
- Updated `clusters/sbox/base/kustomization.yaml` to include a new path for Traefik v33 CRDs kustomization file.