### PR TITLE
Upgrade traefik in nonprod

### DIFF
--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/aat/01.yaml
+++ b/apps/admin/traefik2/aat/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/preview/01.yaml
+++ b/apps/admin/traefik2/preview/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/sbox-intsvc/00.yaml
+++ b/apps/admin/traefik2/sbox-intsvc/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/aat/base/kustomization.yaml
+++ b/clusters/aat/base/kustomization.yaml
@@ -64,3 +64,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/aat/base/kustomize.yaml
   - path: ../../../apps/admin/aat/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -59,3 +59,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -63,3 +63,4 @@ patches:
   - path: ../../../apps/tax-tribunals/ithc/base/kustomize.yaml
   - path: ../../../apps/neuvector/ithc/base/kustomize.yaml
   - path: ../../../apps/admin/ithc/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -57,3 +57,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/perftest/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -62,3 +62,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/preview/base/kustomize.yaml
   - path: ../../../apps/admin/preview/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/sbox-intsvc/base/kustomization.yaml
+++ b/clusters/sbox-intsvc/base/kustomization.yaml
@@ -19,3 +19,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/sbox-intsvc/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml


### PR DESCRIPTION
All went through ok in sbox
Went through in sds nonprod with no issues https://github.com/hmcts/sds-flux-config/pull/5733/files

upgrading traefik for all nonprod in cft

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/admin/traefik2/aat/00.yaml, apps/admin/traefik2/aat/01.yaml, apps/admin/traefik2/demo/00.yaml, apps/admin/traefik2/demo/01.yaml, apps/admin/traefik2/ithc/00.yaml, apps/admin/traefik2/ithc/01.yaml, apps/admin/traefik2/perftest/00.yaml, apps/admin/traefik2/perftest/01.yaml, apps/admin/traefik2/preview/00.yaml, apps/admin/traefik2/preview/01.yaml, apps/admin/traefik2/sbox-intsvc/00.yaml
- Added a new chart with its version and source reference for Traefik.

### clusters/aat/base/kustomization.yaml, clusters/demo/base/kustomization.yaml, clusters/ithc/base/kustomization.yaml, clusters/perftest/base/kustomization.yaml, clusters/preview/base/kustomization.yaml, clusters/sbox-intsvc/base/kustomization.yaml
- Added path for the Traefik v33 CRDs to the kustomization files.