### PR TITLE
ADOP-2408 Part 2: Add HPA to Adoption Production

### DIFF
--- a/apps/adoption/adoption-cos-api/aat.yaml
+++ b/apps/adoption/adoption-cos-api/aat.yaml
@@ -7,16 +7,6 @@ spec:
   interval: 1m
   values:
     java:
-      cpuLimits: "1500m"
-      cpuRequests: "250m"
-      memoryLimits: "2048Mi"
-      memoryRequests: "1536Mi"
-      autoscaling:
-        enabled: true
-        minReplicas: 2
-        maxReplicas: 4
-        memory:
-          averageUtilization: 120
       environment:
         RELEASE: NOW
         APP_INSIGHTS_KEY: '273cc8cd-c511-49ae-9988-9debe01d54d5'

--- a/apps/adoption/adoption-cos-api/adoption-cos-api.yaml
+++ b/apps/adoption/adoption-cos-api/adoption-cos-api.yaml
@@ -7,11 +7,17 @@ spec:
   interval: 1m
   values:
     java:
-      cpuLimits: "1000m"
-      cpuRequests: "500m"
-      memoryLimits: "1.5Gi"
-      memoryRequests: "1Gi"
+      cpuLimits: "1500m"
+      cpuRequests: "250m"
+      memoryLimits: "2048Mi"
+      memoryRequests: "1536Mi"
       replicas: 2
+      autoscaling:
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 4
+        memory:
+          averageUtilization: 120
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15

--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -6,13 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      cpuLimits: "500m"
-      cpuRequests: "50m"
-      memoryLimits: "1536Mi"
-      memoryRequests: "512Mi"
       autoscaling:
-        enabled: true
-        maxReplicas: 4
         cpu:
           averageUtilization: 300 #AAT only: To prevent pods scaling when pipelines run
       environment:

--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -7,11 +7,14 @@ spec:
   interval: 1m
   values:
     nodejs:
-      cpuLimits: "1000m"
-      cpuRequests: "500m"
-      memoryLimits: "2048Mi"
+      cpuLimits: "500m"
+      cpuRequests: "50m"
+      memoryLimits: "1536Mi"
       memoryRequests: "512Mi"
       replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Move HPA settings from AAT to Production (with exception of web cpu averageUtilization which remains in AAT to prevent scaling when the pipelines are run).

### Testing done
Monitored in AAT to ensure required behaviour of HPA.