### PR TITLE
Revert "CCD-4262 update data-store ITHC"

### DIFF
--- a/apps/ccd/ccd-data-store-api/ithc-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/ithc-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2448-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/ithc.yaml
+++ b/apps/ccd/ccd-data-store-api/ithc.yaml
@@ -17,7 +17,7 @@ spec:
       memoryLimits: '5120Mi'
       cpuRequests: '1'
       cpuLimits: '3'
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2448-a32aa38-20241112123336 #{"$imagepolicy": "flux-system:ithc-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-17d07ce-20241106110028 #{"$imagepolicy": "flux-system:ithc-ccd-data-store-api"}
       environment:
         CCD_DOCUMENT_URL_PATTERN: ^https?://(((?:api-gateway\.preprod\.dm\.reform\.hmcts\.net|dm-store-ithc\.service\.core-compute-ithc\.internal(?::\d+)?)\/documents\/[A-Za-z0-9-]+(?:\/binary)?)|(em-hrs-api-ithc\.service\.core-compute-ithc\.internal(?::\d+)?\/hearing-recordings\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/((segments\/[0-9]+)|(file/\S+))))
         CCD_S2S_AUTHORISED_SERVICES_CASE_USER_ROLES: aac_manage_case_assignment,fpl_case_service,iac,finrem_case_orchestration,divorce_frontend,nfdiv_case_api,civil_service,adoption_cos_api,adoption_web,prl_cos_api,et_cos,civil_general_applications,et_sya_api


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#35327

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-data-store-api/ithc-image-policy.yaml
- Updated the `filterTags` pattern from `'^pr-2448-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`.

### apps/ccd/ccd-data-store-api/ithc.yaml
- Updated the `image` from `hmctspublic.azurecr.io/ccd/data-store-api:pr-2448-a32aa38-20241112123336` to `hmctspublic.azurecr.io/ccd/data-store-api:prod-17d07ce-20241106110028`.
- Updated the `CCD_DOCUMENT_URL_PATTERN` and `CCD_S2S_AUTHORISED_SERVICES_CASE_USER_ROLES` environment variables.