### PR TITLE
CCD-4262 update data store in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: perftest-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2448-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       replicas: 8
-      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-17d07ce-20241106110028 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2448-a32aa38-20241112123336 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
         enabled: false
         minReplicas: 4


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### perftest-image-policy.yaml
- Changes the `perftest-ccd-data-store-api` image policy to disable the `hmcts.github.com/prod-automated` annotation.
- Updates the `filterTags` pattern to `'pr-2448-[a-f0-9]+-(?P<ts>[0-9]+)'`.

### perftest.yaml
- Updates the `replicas` value of the `java` container to 8.
- Changes the `image` version to `pr-2448-a32aa38-20241112123336` for the `hmctspublic.azurecr.io/ccd/data-store-api` container.