### PR TITLE
Revert "CCD-4262 update data store in perftest"

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: perftest-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-2448-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       replicas: 8
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2448-a32aa38-20241112123336 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-17d07ce-20241106110028 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
         enabled: false
         minReplicas: 4


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#35352

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
- Changed annotation from `disabled` to `enabled` for `hmcts.github.com/prod-automated`
- Updated the filter tag pattern from `'pr-2448-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'prod-[a-f0-9]+-(?P<ts>[0-9]+)'`

### apps/ccd/ccd-data-store-api/perftest.yaml
- Updated the image tag from `pr-2448-a32aa38-20241112123336` to `prod-17d07ce-20241106110028`