### PR TITLE
Restoring ITHC policy to use default Prod image

### DIFF
--- a/apps/financial-remedy/finrem-cos/ithc-image-policy.yaml
+++ b/apps/financial-remedy/finrem-cos/ithc-image-policy.yaml
@@ -3,13 +3,6 @@ kind: ImagePolicy
 metadata:
   name: ithc-finrem-cos
   annotations:
-    hmcts.github.com/prod-automated: disabled
-spec:
-  filterTags:
-    pattern: '^pr-1953-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
+    hmcts.github.com/prod-automated: enabled
   imageRepositoryRef:
     name: finrem-cos


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3411

### Change description

Image was locked to a Preview Image for 1 week for  ITHC testing.  Testing now complete.

PR looks slightly odd because the image isn't showing.  This is because when I deleted the branch, the platform removed the image from the policy, but didn't update the annotation or correct the ithc.yaml.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/financial-remedy/finrem-cos/ithc-image-policy.yaml
- Added annotation `hmcts.github.com/prod-automated: enabled` to enable prod automated process.