### PR TITLE
[ADOP-2408] move adoption-web liveness delay from charts

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -15,6 +15,7 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
+      livenessDelay: 135
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Housekeeping: move adoption-web liveness delay from charts to be in alignment with readiness configuration.


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-web/adoption-web.yaml
- Added livenessDelay of 135
- Updated readinessDelay to 45