### PR TITLE
[ADOP-2408] reducing livelinessDelay for adoption-web

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -15,7 +15,7 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      livenessDelay: 135
+      livenessDelay: 130
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2408

### Change description
Reducing livelinessDelay for adoption-web

### Testing done
Confirmed pods started with 135.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `adoption-web.yaml` in the `adoption` app has been modified.
- The `livenessDelay` has been updated from 135 to 130.
- No other changes were made in this file.