### PR TITLE
Adding oci repo for pact broker

### DIFF
--- a/apps/flux-system/base/hmctspublic-oci.yaml
+++ b/apps/flux-system/base/hmctspublic-oci.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hmctspublicoci
+  namespace: flux-system
+spec:
+  url: oci://hmctspublic.azurecr.io/helm/v1/repo/
+  interval: 10m

--- a/apps/flux-system/base/hmctspublic-oci.yaml
+++ b/apps/flux-system/base/hmctspublic-oci.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1
+apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: OCIRepository
 metadata:
   name: hmctspublicoci

--- a/apps/flux-system/base/kustomization.yaml
+++ b/apps/flux-system/base/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - jenkins-webhook-relay-gitrepo.yaml
 - chart-job-gitrepo.yaml
 - chart-neuvector-gitrepo.yaml
+- hmctspublic-oci.yaml

--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -11,8 +11,8 @@ spec:
   chart:
     spec:
       chart: pact-broker
-      version: 0.10.0
+      version: 0.11.0
       sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
+        kind: OCIRepository
+        name: hmctspublicoci
         namespace: flux-system


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-22281

### Change description
Adding OCI repo for pact broker helm chart.

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/base/hmctspublic-oci.yaml
- 📄 Created new file `hmctspublic-oci.yaml` with OCIRepository configuration for hmctspublic.
- Configured OCI URL: oci://hmctspublic.azurecr.io/helm/v1/repo/
- Set interval for 10 minutes.

### apps/flux-system/base/kustomization.yaml
- Removed `chart-neuvector-gitrepo.yaml` and `hmctspublic-oci.yaml`.
- Added `chart-neuvector-gitrepo.yaml` and `hmctspublic-oci.yaml`.

### apps/pact-broker/pact-broker/sbox-intsvc.yaml
- Updated chart version from 0.10.0 to 0.11.0.
- Changed chart source reference from HelmRepository to OCIRepository for `hmctspublicoci`.