### PR TITLE
Patch prometheus to 66.2.1

### DIFF
--- a/apps/monitoring/kube-prometheus-stack-crds-patch/kustomization.yaml
+++ b/apps/monitoring/kube-prometheus-stack-crds-patch/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -178,7 +178,7 @@ spec:
     spec:
       chart: kube-prometheus-stack
       # Update kube-prometheus-stack-crds/kustomization.yaml when updating this
-      version: 61.9.0
+      version: 66.2.1
       sourceRef:
         kind: HelmRepository
         name: prometheus


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-22278

### Change description

Patch  prometheus to 66.2.1

### Testing done

All working on SDS

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/monitoring/kube-prometheus-stack-crds-patch/kustomization.yaml
- A new file `kustomization.yaml` has been added to patch CRDs for the kube-prometheus-stack.
- It includes configurations for various CRDs such as alertmanagerconfigs, alertmanagers, podmonitors, probes, prometheuses, prometheusrules, servicemonitors, and thanosrulers.

### apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
- In the `kube-prometheus-stack.yaml` file, the version has been updated from 61.9.0 to 66.2.1 for the chart kube-prometheus-stack.