### PR TITLE
HDPI-64-adding idenity for perfTest key vault

### DIFF
--- a/apps/pcs/perftest/base/kustomization.yaml
+++ b/apps/pcs/perftest/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../../base
   - ../../../rbac/nonprod-role.yaml
 namespace: pcs
+patches:
+  - path: ../../serviceaccount/perftest.yaml

--- a/apps/pcs/serviceaccount/perftest.yaml
+++ b/apps/pcs/serviceaccount/perftest.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "cdb62a73-dade-490c-853b-880c51e719fb"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `apps/pcs/perftest/base/kustomization.yaml` has been modified to add a new namespace 'pcs' and a patch to the path './serviceaccount/perftest.yaml'.
- A new file `apps/pcs/serviceaccount/perftest.yaml` has been added, creating a service account 'perftest' with annotations related to azure workload identity.