### PR TITLE
DFR-3329: Enable draft orders overdue notifications cron job in demo

### DIFF
--- a/apps/financial-remedy/finrem-cron-draft-order-review-overdue/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-draft-order-review-overdue/demo/demo.yaml
@@ -7,9 +7,9 @@ spec:
   values:
     job:
       image: hmctspublic.azurecr.io/finrem/cos:pr-1949-9c51c52-20241121081611 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
-      schedule: "0 * 20 11 *"
+      schedule: "*/15 * * * *"
       environment:
-        CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_ENABLED: false
+        CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_ENABLED: true
         CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_BATCH_SIZE: 2000
         CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_DAYS_SINCE_ORDER_UPLOAD: 1
         FEATURE_PBA_CASE_TYPE: true


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3329

### Change description

Enable draft order overdue notifications task to run every 15 minutes in demo



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated demo.yaml``` in ```finrem-cron-draft-order-review-overdue```:
  - Updated the schedule to run every 15 minutes.
  - Enabled the feature for draft order review overdue notification.