### PR TITLE
DFR-3329: Disable draft orders notifications cron in demo

### DIFF
--- a/apps/financial-remedy/finrem-cron-draft-order-review-overdue/demo/demo.yaml
+++ b/apps/financial-remedy/finrem-cron-draft-order-review-overdue/demo/demo.yaml
@@ -6,10 +6,10 @@ spec:
   releaseName: finrem-cron-draft-order-review-overdue
   values:
     job:
-      image: hmctspublic.azurecr.io/finrem/cos:pr-1991-23ded79-20241126082002 #{"$imagepolicy": "flux-system:demo-finrem-cos"}
-      schedule: "*/15 * * * *"
+      image: hmctspublic.azurecr.io/finrem/cos:pr-1991-23ded79-20241126082002 #{"$imagepolicy": "flux-system:finrem-cos"}
+      schedule: "30 1 11 26 *"
       environment:
-        CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_ENABLED: true
+        CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_ENABLED: false
         CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_BATCH_SIZE: 2000
         CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_DAYS_SINCE_ORDER_UPLOAD: 1
         FEATURE_PBA_CASE_TYPE: true


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3329

### Change description

Disable draft orders notifications cron in demo


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/financial-remedy/finrem-cron-draft-order-review-overdue/demo/demo.yaml
- Updated the job schedule from \"*/15 * * * *\" to \"30 1 11 26 *\"
- Changed the value of CRON_DRAFT_ORDER_REVIEW_OVERDUE_NOTIFICATION_SENT_ENABLED from true to false