### PR TITLE
DTSPO-22647 - Add oci repo

### DIFF
--- a/apps/flux-system/base/hmctspublic-ocirepo.yaml
+++ b/apps/flux-system/base/hmctspublic-ocirepo.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: hmctspublic-oci
+  namespace: flux-system
+spec:
+  url: oci://hmctspublic.azurecr.io/helm/v1/repo/
+  interval: 10m
+  type: oci

--- a/apps/flux-system/base/kustomization.yaml
+++ b/apps/flux-system/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - flux-config-gitrepo.yaml
 - hmcts-charts-gitrepo.yaml
 - hmctspublic-helmrepo.yaml
+- hmctspublic-ocirepo.yaml
 - hmcts-stable-charts-gitrepo.yaml
 - incident-response-api-gitrepo.yaml
 - plum-recipe-receiver-gitrepo.yaml

--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: pact-broker

--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pact-broker
@@ -11,8 +11,8 @@ spec:
   chart:
     spec:
       chart: pact-broker
-      version: 0.10.0
+      version: 0.11.0
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system


### PR DESCRIPTION
### Jira link

See [DTSPO-22647](https://tools.hmcts.net/jira/browse/DTSPO-22647)

### Change description

Add hmctspublic as an oci helm repo
This is required as we have moved to using helm3 to publish packages and these are stored as the oci type now
Updating pact-broker to 0.11.0 in sbox. This is the first of our apps to use the new oci format.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created the file `hmctspublic-ocirepo.yaml` with specifications for a Helm repository named `hmctspublic-oci` pointing to the specified URL with a 10-minute interval.
- Updated `kustomization.yaml` to include `hmctspublic-ocirepo.yaml` in the list of resources.
- Updated the version of the chart in `pact-broker/sbox-intsvc.yaml` from 0.10.0 to 0.11.0.