### PR TITLE
DTSPO-22647 - Use https for repo

### DIFF
--- a/apps/flux-system/base/hmctspublic-ocirepo.yaml
+++ b/apps/flux-system/base/hmctspublic-ocirepo.yaml
@@ -4,6 +4,6 @@ metadata:
   name: hmctspublic-oci
   namespace: flux-system
 spec:
-  url: oci://hmctspublic.azurecr.io/helm/v1/repo/
+  url: https://hmctspublic.azurecr.io/helm/v1/repo/
   interval: 10m
   type: oci

--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -10,7 +10,7 @@ spec:
     vaultName: cftsbox-intsvc
   chart:
     spec:
-      chart: pact-broker/pact-broker
+      chart: pact-broker
       version: 0.11.0
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
### Jira link

See [DTSPO-22647](https://tools.hmcts.net/jira/browse/DTSPO-22647)

### Change description

Updating the oci repo to use https
Reverting previous change to pact-broker

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/base/hmctspublic-ocirepo.yaml
- Changed URL from `oci://hmctspublic.azurecr.io/helm/v1/repo/` to `https://hmctspublic.azurecr.io/helm/v1/repo/`
- Updated interval to 10m
- Type changed to oci

### apps/pact-broker/pact-broker/sbox-intsvc.yaml
- Updated chart to `pact-broker/pact-broker` version 0.11.0