### PR TITLE
DTSPO-22647 - Update chart

### DIFF
--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -10,7 +10,7 @@ spec:
     vaultName: cftsbox-intsvc
   chart:
     spec:
-      chart: pact-broker
+      chart: pact-broker/pact-broker
       version: 0.11.0
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
### Jira link

See [DTSPO-22647](https://tools.hmcts.net/jira/browse/DTSPO-22647)

### Change description

Update chart from `pact-broker` to `pact-broker/pact-broker`
This may fix the error in the cluster as it's not trying to look for the chart in the right place
The controller is searching `oci://hmctspublic.azurecr.io/helm/pact-broker` when the url is `oci://hmctspublic.azurecr.io/helm/pact-broker/pact-broker`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
