### PR TITLE
Revert "CME-68 deploy pr job image on demo"

### DIFF
--- a/apps/fees-pay/card-payment-job/demo-00.yaml
+++ b/apps/fees-pay/card-payment-job/demo-00.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: card-payment-job
   values:
     job:
-      image: "hmctspublic.azurecr.io/payment/jobs:pr-150"
+      image: "hmctspublic.azurecr.io/payment/jobs:prod-5ee51a8-20241128071353" #{"$imagepolicy": "flux-system:card-csv-report"}
       schedule: "30 2 * * *"
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/fees-pay/pba-payment-job/demo.yaml
+++ b/apps/fees-pay/pba-payment-job/demo.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: pba-payment-job
   values:
     job:
-      image: "hmctspublic.azurecr.io/payment/jobs:pr-150"
+      image: "hmctspublic.azurecr.io/payment/jobs:prod-5ee51a8-20241128071353" #{"$imagepolicy": "flux-system:pba-csv-report"}
       schedule: "*/30 * * * *"
       environment:
         DUMMY_RESTART_VAR: true

--- a/apps/fees-pay/refund-notifications-job/demo-image-policy.yaml
+++ b/apps/fees-pay/refund-notifications-job/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-refund-notifications-job
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-150-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: refund-notifications-job

--- a/apps/fees-pay/status-payment-job/demo-00.yaml
+++ b/apps/fees-pay/status-payment-job/demo-00.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: status-payment-job
   values:
     job:
-      image: "hmctspublic.azurecr.io/payment/jobs:pr-150"
+      image: "hmctspublic.azurecr.io/payment/jobs:prod-5ee51a8-20241128071353" #{"$imagepolicy": "flux-system:status-update"}
       schedule: "*/30 * * * *"
       environment:
         DUMMY_RESTART_VAR: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#35589

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/fees-pay/card-payment-job/demo-00.yaml` 🔄 Updated image tag from \"hmctspublic.azurecr.io/payment/jobs:pr-150\" to \"hmctspublic.azurecr.io/payment/jobs:prod-5ee51a8-20241128071353\" and updated schedule to \"30 2 * * *\"
- `apps/fees-pay/pba-payment-job/demo.yaml` 🔄 Updated image tag from \"hmctspublic.azurecr.io/payment/jobs:pr-150\" to \"hmctspublic.azurecr.io/payment/jobs:prod-5ee51a8-20241128071353\" and updated schedule to \"*/30 * * * *\"
- `apps/fees-pay/refund-notifications-job/demo-image-policy.yaml` 🔄 Removed annotations and updated image policy
- `apps/fees-pay/status-payment-job/demo-00.yaml` 🔄 Updated image tag from \"hmctspublic.azurecr.io/payment/jobs:pr-150\" to \"hmctspublic.azurecr.io/payment/jobs:prod-5ee51a8-20241128071353\" and updated schedule to \"*/30 * * * *\"