### PR TITLE
ADOP Change FlexibleServer from Burstable

### DIFF
--- a/apps/adoption/preview/aso/adoption-postgres.yaml
+++ b/apps/adoption/preview/aso/adoption-postgres.yaml
@@ -4,4 +4,7 @@ metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
-  version: "14"
+  version: "16"
+  sku:
+    name: Standard_D2ds_v5
+    tier: GeneralPurpose


### PR DESCRIPTION
### Jira link
[DTSPO-22713](https://u17380493.ct.sendgrid.net/ls/click?upn=u001.-2BevxEqWRJPQyO7wloOhTl1KUar-2BGO-2B8Ol9Q0wfTRyY9dg5-2F2R9yQVdBBn8fL6TO1VcRv6hWBj2TLwubXsyyCCg-3D-3D1RHZ_Er47nCliRmhLogRBAyk41Fj0J7rsHWlesGUxuKn2CmwU1bJ-2FFmtNWkheav0PAElR-2BMYo5Cc1gKdmA13kPa14fMlijWOQfWpS2ywl3uyRxzCqO-2FhtMziCwxs6iBvGmJptY-2Fjpch1bZIffh9h6h2f17ykIle1V-2BSs62kkqxvdOuKjw7-2FasWQU2s-2BRivwYlmmGMZkAS3tplgP0uBbKi-2Bdh3-2BwDy2M-2FINufaT3u1mpeqtmE-3D)

### Change description
FlexibleServer didn't start up this morning.  Changing so it's no longer burstable.

