### PR TITLE
remove fact frontend pr from demo

### DIFF
--- a/apps/fact/fact-frontend/demo.yaml
+++ b/apps/fact/fact-frontend/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/fact/frontend:pr-807-3ba0d06-20241122132304
       autoscaling:
         enabled: false


### PR DESCRIPTION
Remove PR from fact frontend demo.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fact/fact-frontend/demo.yaml
- Removed the `nodejs` image reference `hmctspublic.azurecr.io/fact/frontend:pr-807-3ba0d06-20241122132304`
- Disabled autoscaling by setting `enabled` to `false`