### PR TITLE
Lowering pods after re indexing

### DIFF
--- a/apps/ccd/ccd-logstash/prod.yaml
+++ b/apps/ccd/ccd-logstash/prod.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   releaseName: ccd-logstash
   values:
-    replicas: 2
+    replicas: 1


### PR DESCRIPTION
### Jira link
https://mojcppprod.service-now.com/nav_to.do?uri=%2Fchange_request.do%3Fsys_id%3D6c5ac2b61b025a506226da88b04bcb91%26sysparm_record_target%3Dchange_request%26sysparm_record_row%3D1%26sysparm_record_rows%3D105%26sysparm_record_list%3Drequested_by.departmentDYNAMIC08c5d81edb2a4700edfc7cbdae96193d%5Eassignment_group%3Da573ec80dbd7af440346f68dae961990%5EORDERBYDESCnumber

### Change description
Lowering logstash pods back down to 1 after re-indexing.

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `prod.yaml` 🛠️
  - Reduced the number of replicas from 2 to 1.