### PR TITLE
reverting deployed https://tools.hmcts.net/jira/browse/CCD-5521 to Pr…

### DIFF
--- a/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
@@ -2,5 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ccd-data-store-api
+  annotations:
+    hmcts.github.com/prod-automated: enabled
 spec:
-  name: ccd-data-store-api
+  filterTags:
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
@@ -2,14 +2,5 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ccd-data-store-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-2433-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
-  imageRepositoryRef:
-    name: ccd-data-store-api
+  name: ccd-data-store-api

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2433-67f383f-20241127094123 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-dd4a665-20241111095936 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
       replicas: 4
       autoscaling:
         enabled: true


### PR DESCRIPTION
reverting deployed https://tools.hmcts.net/jira/browse/CCD-5521 to prod image




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


#### apps/ccd/ccd-data-store-api/demo-image-policy.yaml
- Updated the `demo-image-policy.yaml` file to change the annotation `hmcts.github.com/prod-automated` from \"disabled\" to \"enabled\".
- Modified the `filterTags` pattern from '^pr-2433-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'.

#### apps/ccd/ccd-data-store-api/demo.yaml
- In the `demo.yaml` file, changed the image tag from `hmctspublic.azurecr.io/ccd/data-store-api:pr-2433-67f383f-20241127094123` to `hmctspublic.azurecr.io/ccd/data-store-api:prod-dd4a665-20241111095936`.
- Updated the number of replicas from 4 to 5.