### PR TITLE
add version of artifactory and chart version

### DIFF
--- a/apps/artifactory/artifactory/artifactory-sbox.yaml
+++ b/apps/artifactory/artifactory/artifactory-sbox.yaml
@@ -7,4 +7,10 @@ spec:
   chart:
     spec:
       chart: artifactory-oss
-      version: 7.98.9
+      version: 107.90.9
+  values:
+    artifactory:
+      image:
+        registry: releases-docker.jfrog.io
+        repository: jfrog/artifactory-oss
+        tag: "7.98.9"


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-22631](https://tools.hmcts.net/jira/browse/DTSPO-22631)

## Description

add tag value under image to test new image version 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not yet 

### Issues Found

Please list any issues found during testing and how they were resolved:

artifactory-oss   85d   False   HelmChart 'artifactory/artifactory-artifactory-oss' is not ready: invalid chart reference: failed to get chart version for remote reference: no 'artifactory-oss' chart with version matching '7.98.9' found

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

## Deployment Steps

None

## Additional Information

Please add any other information that is important to this PR, such as screenshots, logs, or links to other related PRs.

See this for reference how to add it https://github.com/jfrog/charts/blob/387d7a1aa890bb65fb42a7d5b2c65cae0b7dded1/stable/artifactory-oss/values.yaml#L72



























