### PR TITLE
Add test stub perftest for HMC

### DIFF
--- a/apps/ccd/ccd-test-stubs-service/perftest.yaml
+++ b/apps/ccd/ccd-test-stubs-service/perftest.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ccd-test-stubs-service
+  namespace: ccd
+spec:
+  values:
+    java:
+      replicas: 1

--- a/apps/ccd/perftest/base/kustomization.yaml
+++ b/apps/ccd/perftest/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - probatemandb.yaml
   - ../../message-publisher/message-publisher.yaml
   - ../../ccd-case-disposer/ccd-case-disposer.yaml
+  - ../../ccd-test-stubs-service/ccd-test-stubs-service.yaml
   - ../../../base/slack-provider/perftest
 patches:
   - path: ../../identity/perftest.yaml
@@ -22,6 +23,7 @@ patches:
   - path: ../../serviceaccount/perftest.yaml
   - path: ../../ccd-case-disposer/perftest.yaml
   - path: ../../ccd-next-hearing-date-updater/perftest/perftest.yaml
+  - path: ../../ccd-test-stubs-service/aat.yaml
   - path: ../../ccd-logstash/perftest.yaml
   - path: ../../ccd-logstash-civil/perftest.yaml
   - path: ../../ccd-logstash-cmc/perftest.yaml

--- a/apps/ccd/perftest/base/kustomization.yaml
+++ b/apps/ccd/perftest/base/kustomization.yaml
@@ -23,7 +23,7 @@ patches:
   - path: ../../serviceaccount/perftest.yaml
   - path: ../../ccd-case-disposer/perftest.yaml
   - path: ../../ccd-next-hearing-date-updater/perftest/perftest.yaml
-  - path: ../../ccd-test-stubs-service/aat.yaml
+  - path: ../../ccd-test-stubs-service/perftest.yaml
   - path: ../../ccd-logstash/perftest.yaml
   - path: ../../ccd-logstash-civil/perftest.yaml
   - path: ../../ccd-logstash-cmc/perftest.yaml

--- a/apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml
@@ -14,7 +14,10 @@ spec:
       cpuRequests: '300m'
       cpuLimits: '1500m'
       environment:
-        HMI_BASE_URL: https://hmi-apim.demo.platform.hmcts.net/hmi
+        # HMI/LA integration
+        #HMI_BASE_URL: https://hmi-apim.demo.platform.hmcts.net/hmi
+        # Stubbing without using HMI/LA
+        HMI_BASE_URL: http://ccd-test-stubs-service-perftest.service.core-compute-perftest.internal/hmi
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CLIENT_FUTUREHEARING: DEBUG
       keyVaults:
         hmc:


### PR DESCRIPTION
### Jira link

### Change description
Add test stub service to perftest to create HMC test packs. Update outbound adapter to point to test stub instead of HMI as LA do not have an environment 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_



- perftest.yaml (new): Added perftest.yaml for ccd-test-stubs-service with HelmRelease configuration and Java replicas set to 1.
- kustomization.yaml: Added ccd-test-stubs-service to the list of resources and included perftest.yaml for the same service.
- hmc-hmi-outbound-adapter/perftest.yaml: Added HMI_BASE_URL for ccd-test-stubs-service-perftest.
