### PR TITLE
SIDM-9563 Use Github charts

### DIFF
--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -60,4 +60,9 @@ spec:
       enableKeyVaults: true
   chart:
     spec:
-      version: 0.8.1
+      chart: ./stable/idam-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-api/ithc.yaml
+++ b/apps/idam/idam-api/ithc.yaml
@@ -60,4 +60,9 @@ spec:
       enableKeyVaults: true
   chart:
     spec:
-      version: 0.8.1
+      chart: ./stable/idam-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-api/perftest.yaml
+++ b/apps/idam/idam-api/perftest.yaml
@@ -61,3 +61,9 @@ spec:
   chart:
     spec:
       version: 0.8.1
+      chart: idam-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -41,4 +41,9 @@ spec:
         FEATUREFLAGS_EVENTPUBLISHINGENABLED: false
   chart:
     spec:
-      version: 0.8.1
+      chart: ./stable/idam-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -21,4 +21,9 @@ spec:
       enableKeyVaults: true
   chart:
     spec:
-      version: 0.4.1
+      chart: ./stable/idam-web-public
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -20,4 +20,9 @@ spec:
       enableKeyVaults: true
   chart:
     spec:
-      version: 0.4.1
+      chart: ./stable/idam-web-public
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -21,4 +21,9 @@ spec:
       enableKeyVaults: true
   chart:
     spec:
-      version: 0.4.1
+      chart: ./stable/idam-web-public
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/idam/idam-web-public/preview.yaml
+++ b/apps/idam/idam-web-public/preview.yaml
@@ -23,4 +23,9 @@ spec:
       enableKeyVaults: true
   chart:
     spec:
-      version: 0.4.0
+      chart: ./stable/idam-web-public
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SIDM-9563

### Change description

Use Github charts

### Testing done

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/idam-api/demo.yaml
- Updated the chart version to use the local path ./stable/idam-api``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-api/ithc.yaml
- Updated the chart version to use the local path ```./stable/idam-api``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-api/perftest.yaml
- Updated the chart version to use ```idam-api``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-api/sbox.yaml
- Updated the chart version to use the local path ```./stable/idam-api``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-web-public/demo.yaml
- Updated the chart version to use the local path ```./stable/idam-web-public``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-web-public/ithc.yaml
- Updated the chart version to use the local path ```./stable/idam-web-public``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-web-public/perftest.yaml
- Updated the chart version to use the local path ```./stable/idam-web-public``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.

### apps/idam/idam-web-public/preview.yaml
- Updated the chart version to use the local path ```./stable/idam-web-public``` with a source reference to ```hmcts-charts``` in the ```flux-system``` namespace with an interval of 1 minute.