### PR TITLE
Point demo at probate-back-office#2918 image.

### DIFF
--- a/apps/probate/probate-back-office/demo-image-policy.yaml
+++ b/apps/probate/probate-back-office/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2896-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2918-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link
See [DTSPB-4450](https://tools.hmcts.net/jira/browse/DTSPB-4450)

### Change description
Redirect demo to use latest image from hmcts/probate-back-office#2918

### Testing done
This is for testing.

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `demo-image-policy.yaml` in the `probate-back-office` app has been modified to update the pattern for filterTags from `^pr-2896-[a-f0-9]+-(?P<ts>[0-9]+)` to `^pr-2918-[a-f0-9]+-(?P<ts>[0-9]+)`. This change updates the pattern for filterTags in the demo-image-policy.