### PR TITLE
DTSPO-18332 - Simplify onboarding to persistent preview databases

### DIFF
--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -28,7 +28,7 @@ if [ ! -f "apps/$NAMESPACE_NAME/preview/aso" ]; then
 
   (
     cat <<EOF
-apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+apiVersion: dbforpostgresql.azure.com/v1api20210601
 kind: FlexibleServer
 metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -34,7 +34,7 @@ metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
-  version: "16"
+  version: "14"
   sku:
     name: Standard_D2ds_v5
     tier: GeneralPurpose

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -109,6 +109,7 @@ patches:
 EOF
   ) >"apps/$NAMESPACE_NAME/preview/base/kustomization.yaml"
 else
+echo "Updating kustomization in preview/base"
 (
     cat <<EOF
   - ../../../azureserviceoperator-system/resources/resource-group.yaml\\
@@ -146,16 +147,17 @@ sed -i.bak "/namespace:/i\\
 $FILE_RESOURCES_CONTENTS
 " "$KUSTOMIZATION_FILE"
 
-echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_TO_RESOURCES_INCLUDE"
+echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_RESOURCES_TO_INCLUDE"
 
 # Update the kustomization.yaml file
 sed -i.bak "/patches:/a\\
 $FILE_PATCHES_CONTENTS
 " "$KUSTOMIZATION_FILE"
 
-echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_TO_PATCHES_INCLUDE"
+echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_PATCHES_TO_INCLUDE"
 
 # deleting the temp file
 rm "./apps/$NAMESPACE_NAME/preview/base/kustomization_resources_temp.yaml"
 rm "./apps/$NAMESPACE_NAME/preview/base/kustomization_patches_temp.yaml"
+rm "./apps/cnp/preview/base/kustomization.yaml.bak"
 fi

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -51,12 +51,7 @@ metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
-  version: "14"
-  network:
-    delegatedSubnetResourceReference:
-      armId: /subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/cft-preview-network-rg/providers/Microsoft.Network/virtualNetworks/cft-preview-vnet/subnets/postgresql
-    privateDnsZoneArmResourceReference:
-      armId: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.azure.com
+  version: "16"
 EOF
   ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres.yaml"
 fi

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # set -ex
 
+NAMESPACE='${NAMESPACE}'
+ENVIRONMENT='${ENVIRONMENT}'
 NAMESPACE_NAME="$1"
 APP_NAME="$2"
 APPS_DIR="../../apps/"
@@ -29,12 +31,12 @@ apiVersion: dbforpostgresql.azure.com/v1api20210601
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions
-  namespace: '${NAMESPACE}'
+  namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: detach-on-delete
 spec:
   owner:
-    name: '${NAMESPACE}'-preview
+    name: ${NAMESPACE}-${ENVIRONMENT}
   azureName: azure.extensions
   source: user-override
   value: "btree_gin"
@@ -46,8 +48,8 @@ EOF
 apiVersion: dbforpostgresql.azure.com/v1api20210601
 kind: FlexibleServer
 metadata:
-  name: '${NAMESPACE}'-preview
-  namespace: "${NAMESPACE}"
+  name: ${NAMESPACE}-${ENVIRONMENT}
+  namespace: ${NAMESPACE}
 spec:
   version: "14"
   network:

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -75,7 +75,7 @@ metadata:
     namespace: $NAMESPACE_NAME
 type: Opaque
 EOF
-) >"apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml"
+) >"apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc_temp.yaml"
 
 if ! [ -f /usr/local/bin/sops ]; then
   echo "Sops is not installed... installing..."
@@ -84,7 +84,13 @@ if ! [ -f /usr/local/bin/sops ]; then
   chmod +x /usr/local/bin/sops
 fi
 
-sops --encrypt --azure-kv https://dcdcftappsdevkv.vault.azure.net/keys/sops-key/aedb9ea38954430ca1d0a46ed589c049 --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml
+sops --encrypt --azure-kv https://dcdcftappsdevkv.vault.azure.net/keys/sops-key/aedb9ea38954430ca1d0a46ed589c049 --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc_temp.yaml
+
+# making sure the indentation is with 2 spaces
+yq eval --indent 2 -P "apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc_temp.yaml" > "apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml"
+
+# deleting the temp file
+rm "./apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc_temp.yaml"
 
 (
   cat <<EOF

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# set -ex
+
+NAMESPACE_NAME="$1"
+APP_NAME="$2"
+APPS_DIR="../../apps/"
+CLUSTERS_DIR="../../clusters"
+
+PASSWORD=$(openssl rand -base64 15)
+
+function usage() {
+  echo 'usage: ./postgres-setup.sh <namespace> <app_name>'
+}
+
+if [ -z "${NAMESPACE_NAME}" ] || [ -z "${APP_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+if [ ! -f "apps/$NAMESPACE_NAME/preview/aso" ]; then
+  echo "Creating aso"
+  mkdir -p apps/$NAMESPACE_NAME
+  mkdir -p apps/$NAMESPACE_NAME/preview
+  mkdir -p apps/$NAMESPACE_NAME/preview/aso
+
+  (
+    cat <<EOF
+apiVersion: dbforpostgresql.azure.com/v1api20210601
+kind: FlexibleServersConfiguration
+metadata:
+  name: extensions
+  namespace: '${NAMESPACE}'
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  owner:
+    name: '${NAMESPACE}'-preview
+  azureName: azure.extensions
+  source: user-override
+  value: "btree_gin"
+EOF
+  ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres-config.yaml"
+
+  (
+    cat <<EOF
+apiVersion: dbforpostgresql.azure.com/v1api20210601
+kind: FlexibleServer
+metadata:
+  name: '${NAMESPACE}'-preview
+  namespace: "${NAMESPACE}"
+spec:
+  version: "14"
+  network:
+    delegatedSubnetResourceReference:
+      armId: /subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/cft-preview-network-rg/providers/Microsoft.Network/virtualNetworks/cft-preview-vnet/subnets/postgresql
+    privateDnsZoneArmResourceReference:
+      armId: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.azure.com
+EOF
+  ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres.yaml"
+fi
+
+if [ ! -f "apps/$NAMESPACE_NAME/preview/sops-secrets" ]; then
+  echo "Creating sops-secrets"
+  mkdir -p apps/$NAMESPACE_NAME
+  mkdir -p apps/$NAMESPACE_NAME/preview
+  mkdir -p apps/$NAMESPACE_NAME/preview/sops-secrets
+fi
+
+(
+  cat <<EOF
+apiVersion: v1
+data:
+    PASSWORD: $PASSWORD
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: postgres
+    namespace: $NAMESPACE_NAME
+type: Opaque
+EOF
+) >"apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml"
+
+if ! [ -f /usr/local/bin/sops ]; then
+  echo "Sops is not installed... installing..."
+  curl -LO https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.darwin.amd64
+  mv sops-v3.9.1.darwin.amd64 /usr/local/bin/sops
+  chmod +x /usr/local/bin/sops
+fi
+
+sops --encrypt --azure-kv https://dcdcftappsdevkv.vault.azure.net/keys/sops-key/aedb9ea38954430ca1d0a46ed589c049 --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml
+
+(
+  cat <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - $APP_NAME-postgres.enc.yaml
+namespace: $NAMESPACE_NAME
+EOF
+) >"apps/$NAMESPACE_NAME/preview/sops-secrets/kustomization.yaml"


### PR DESCRIPTION
### Jira link
DTSPO-18332

### Change description
Create a script to automate and simplify onboarding to persistent preview databases

### Testing done
Tested when [PR-36038](https://github.com/hmcts/cnp-flux-config/pull/36083) merged.
Created flexible server and resource group containing it: [cnp-postgres flexible server](https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/cnp-aso-preview-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/cnp-preview/overview)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
















## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### bin/v2/postgres-setup.sh
- Added a new script `postgres-setup.sh` for setting up Postgres for a given namespace and app name.
- The script creates necessary directories and files for Postgres setup.
- Utilizes `sops` for encryption and `yq` for manipulation of YAML files.
- Handles creation and update of `kustomization.yaml` file for Preview base.