### PR TITLE
Revert "Add deployment id for aat hearings topic filter"

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -62,4 +62,3 @@ spec:
         AMQP_RECONNECT_ON_EXCEPTION: true
         PROCESS_EVENT_MESSAGE_V2_ENABLED: true
         UPDATE_CASE_ONLY_HEARING_V2_ENABLED: true
-        HMC_DEPLOYMENT_ID: "deployment-sscs-tribunals-api-aat"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#35777

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file **aat.yaml** had the environment variable `HMC_DEPLOYMENT_ID` removed.