### PR TITLE
Defaulting sandbox env to use latest base helm chart for testing-support

### DIFF
--- a/apps/idam/idam-testing-support-api/sbox.yaml
+++ b/apps/idam/idam-testing-support-api/sbox.yaml
@@ -5,15 +5,6 @@ metadata:
   namespace: idam
 spec:
   releaseName: idam-testing-support-api
-  chart:
-    spec:
-      chart: idam-testing-support-api
-      version: 0.0.33
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic-oci
-        namespace: flux-system
-      interval: 1m
   values:
     java:
       ingressHost: idam-testing-support-api.sandbox.platform.hmcts.net


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SIDM-9496

### Change description
Removing the old helm chart overwrite for sandbox environment which is currently pointed to the older use of idam-testing-support-api's secrets 

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/idam-testing-support-api/sbox.yaml
- Removed the `chart` section and its specifications.
- Updated the `ingressHost` value to `idam-testing-support-api.sandbox.platform.hmcts.net`.