### PR TITLE
Add recipe backend to platforms dashboard on CFT Jenkins

### DIFF
--- a/apps/flux-system/base/plum-recipe-receiver-gitrepo.yaml
+++ b/apps/flux-system/base/plum-recipe-receiver-gitrepo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m
-  url: ssh://github.com/hmcts/sds-recipe-receiver
+  url: ssh://github.com/hmcts/recipe-receiver
   ref:
     branch: master
   secretRef:

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -92,7 +92,7 @@ spec:
                     name: all
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|camunda-.*)\/master
+                      ^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|recipes-backend|camunda-.*)\/master
                     name: Platform
                     recurse: true
                     title: Platform


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-14631

### Change description
Update recipe receiver to use latest repo name
Add recipes-backend to platform dashboard on Jenkins dashboards.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **plum-recipe-receiver-gitrepo.yaml**
  - Changed the URL from \"ssh://github.com/hmcts/sds-recipe-receiver\" to \"ssh://github.com/hmcts/recipe-receiver\".

- **jenkins.yaml**
  - Updated the includeRegex pattern for buildMonitor``` to include \"recipes-backend\" in the regular expression.