### PR TITLE
Upping pods from 1 to 2 for re-indexing

### DIFF
--- a/apps/ccd/ccd-logstash/prod.yaml
+++ b/apps/ccd/ccd-logstash/prod.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   releaseName: ccd-logstash
   values:
-    replicas: 1
+    replicas: 2


### PR DESCRIPTION
### Jira link
https://mojcppprod.service-now.com/nav_to.do?uri=%2Fchange_request.do%3Fsys_id%3Ddfff68f1479e52502f5ffa7c736d43dc%26sysparm_stack%3D%26sysparm_view%3D

### Change description
Increasing count of logstash pods from 1 to 2 for re-indexing ET.

### Testing done
This has been done before for several re-indexes.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-logstash/prod.yaml
- Changed the number of replicas from 1 to 2. 🔄