### PR TITLE
Remove nonprod aad from bar

### DIFF
--- a/apps/bar/aat/base/kustomization.yaml
+++ b/apps/bar/aat/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../bar-web/aat.yaml
   - path: ../../bar-api/aat.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/bar/base/kustomization.yaml
+++ b/apps/bar/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../bar-web/bar-web.yaml
   - ../bar-api/bar-api.yaml
   - ../../base/workload-identity

--- a/apps/bar/demo/base/kustomization.yaml
+++ b/apps/bar/demo/base/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: bar
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../bar-web/demo.yaml
   - path: ../../bar-api-int/demo.yaml
   - path: ../../bar-api/demo.yaml

--- a/apps/bar/identity/aat.yaml
+++ b/apps/bar/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: bar
-  namespace: bar
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-aat-mi"
-  clientID: "a8689343-209e-47d0-8016-97ff046cc215"

--- a/apps/bar/identity/demo.yaml
+++ b/apps/bar/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: bar
-  namespace: bar
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-demo-mi"
-  clientID: "ed70a92c-eece-43e2-a0ef-8f70e0e35b0e"

--- a/apps/bar/identity/ithc.yaml
+++ b/apps/bar/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: bar
-  namespace: bar
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-ithc-mi"
-  clientID: "335e0c82-9191-4c24-8d6a-bed01994e222"

--- a/apps/bar/identity/perftest.yaml
+++ b/apps/bar/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: bar
-  namespace: bar
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/bar-perftest-mi"
-  clientID: "38d25177-5b36-4a48-a2f4-f07748f462b4"

--- a/apps/bar/ithc/base/kustomization.yaml
+++ b/apps/bar/ithc/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: bar
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../bar-web/ithc.yaml
   - path: ../../bar-api/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml

--- a/apps/bar/perftest/base/kustomization.yaml
+++ b/apps/bar/perftest/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: bar
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../bar-web/perftest.yaml
   - path: ../../bar-api/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml

--- a/apps/bar/preview/base/kustomization.yaml
+++ b/apps/bar/preview/base/kustomization.yaml
@@ -3,10 +3,8 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
 namespace: bar
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo

--- a/apps/bar/prod/base/kustomization.yaml
+++ b/apps/bar/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: bar
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/bar/prod/base/kustomization.yaml
+++ b/apps/bar/prod/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
-  - ../../identity/identity.yaml
 namespace: bar
 patches:
   - path: ../../identity/prod.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/28706/files
https://github.com/hmcts/cnp-flux-config/pull/28682

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happy

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed `apps/bar/aat/base/kustomization.yaml`
  - Removed a path to `identity/aat.yaml` and added paths to other YAML files.
- Changed `apps/bar/demo/base/kustomization.yaml`
  - Removed a path to `identity/demo.yaml` and added paths to other YAML files.
- Deleted `apps/bar/identity/aat.yaml`, `apps/bar/identity/demo.yaml`, `apps/bar/identity/ithc.yaml`, `apps/bar/identity/perftest.yaml`
- Changed `apps/bar/ithc/base/kustomization.yaml`
  - Removed a path to `identity/ithc.yaml` and added paths to other YAML files.
- Changed `apps/bar/perftest/base/kustomization.yaml`
  - Removed a path to `identity/perftest.yaml` and added paths to other YAML files.
- Changed `apps/bar/preview/base/kustomization.yaml`
  - Removed paths to `identity/aat.yaml` and `serviceaccount/aat.yaml`.
- Changed `apps/bar/prod/base/kustomization.yaml`
  - Added a path to `identity/identity.yaml` and removed a path to `identity/prod.yaml`.