### PR TITLE
Remove em aad identity nonprod

### DIFF
--- a/apps/em/aat/base/kustomization.yaml
+++ b/apps/em/aat/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../em-ccd-orchestrator/aat.yaml
   - path: ../../em-anno/aat.yaml
   - path: ../../em-npa/aat.yaml

--- a/apps/em/base/kustomization.yaml
+++ b/apps/em/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../em-ccd-orchestrator/em-ccd-orchestrator.yaml
   - ../em-anno/em-anno.yaml
   - ../em-hrs-ingestor/em-hrs-ingestor.yaml

--- a/apps/em/demo/base/kustomization.yaml
+++ b/apps/em/demo/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: em
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../em-ccd-orchestrator/demo.yaml
   - path: ../../em-anno/demo.yaml
   - path: ../../em-hrs-ingestor/demo.yaml

--- a/apps/em/identity/aat.yaml
+++ b/apps/em/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: em
-  namespace: em
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpa-aat-mi"
-  clientID: "0e33ddce-95a4-45ff-99d1-c3cde6567049"

--- a/apps/em/identity/demo.yaml
+++ b/apps/em/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: em
-  namespace: em
-spec:
-  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpa-demo-mi
-  clientID: caa51f17-ea43-48a3-8034-8d29f38d685a

--- a/apps/em/identity/ithc.yaml
+++ b/apps/em/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: em
-  namespace: em
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpa-ithc-mi"
-  clientID: "28d10158-19aa-4cbc-9a3c-e6673f965493"

--- a/apps/em/identity/perftest.yaml
+++ b/apps/em/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: em
-  namespace: em
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/rpa-perftest-mi"
-  clientID: "1b0c1360-59eb-4ebb-8c07-bc3155bd5877"

--- a/apps/em/ithc/base/kustomization.yaml
+++ b/apps/em/ithc/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: em
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../em-ccd-orchestrator/ithc.yaml
   - path: ../../em-anno/ithc.yaml
   - path: ../../em-hrs-ingestor/ithc.yaml

--- a/apps/em/perftest/base/kustomization.yaml
+++ b/apps/em/perftest/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: em
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../em-ccd-orchestrator/perftest.yaml
   - path: ../../em-anno/perftest.yaml
   - path: ../../em-hrs-ingestor/schedule-off.yaml

--- a/apps/em/preview/base/kustomization.yaml
+++ b/apps/em/preview/base/kustomization.yaml
@@ -3,14 +3,12 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../ia/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
 namespace: em
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../ia/identity/aat.yaml

--- a/apps/em/prod/base/kustomization.yaml
+++ b/apps/em/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: em
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/et/preview/base/kustomization.yaml
+++ b/apps/et/preview/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../../em/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
   - ../../../rd/identity/identity.yaml
   - ../../../hmc/identity/identity.yaml
@@ -23,7 +22,6 @@ patches:
   - path: ../../identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
-  - path: ../../../em/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml

--- a/apps/ia/preview/base/kustomization.yaml
+++ b/apps/ia/preview/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../rpe/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../../em/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../ia-aip-frontend/ia-aip-frontend.yaml
   - ../../../wa/identity/identity.yaml
@@ -25,7 +24,6 @@ patches:
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../rpe/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
-  - path: ../../../em/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml

--- a/apps/private-law/preview/base/kustomization.yaml
+++ b/apps/private-law/preview/base/kustomization.yaml
@@ -7,14 +7,12 @@ resources:
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../em/identity/identity.yaml
 namespace: private-law
 patches:
   - path: ../../identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
-  - path: ../../../em/identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo

--- a/apps/sptribs/preview/base/kustomization.yaml
+++ b/apps/sptribs/preview/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
-  - ../../../em/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
   - ../../../rd/identity/identity.yaml
   - ../../../hmc/identity/identity.yaml
@@ -23,7 +22,6 @@ patches:
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
-  - path: ../../../em/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml
   - path: ../../../hmc/identity/aat.yaml

--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../rpe/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
-  - ../../../em/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../hmc/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
@@ -24,7 +23,6 @@ patches:
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../rpe/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
-  - path: ../../../em/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../../hmc/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/28706/files
https://github.com/hmcts/cnp-flux-config/pull/28682

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happy

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Summary of Changes
- `kustomization.yaml` (apps/em/aat/base, apps/em/base, apps/em/demo/base, apps/em/ithc/base, apps/em/perftest/base, apps/em/preview/base, apps/em/prod/base, apps/et/preview/base, apps/ia/preview/base, apps/private-law/preview/base, apps/sptribs/preview/base, apps/sscs/preview/base): 
  - Removed references to identity files in various environments.
  - Removed and updated patches for different environments.