### PR TITLE
Remove old ecm/ethos  aad identity nonprod

### DIFF
--- a/apps/et/preview/base/kustomization.yaml
+++ b/apps/et/preview/base/kustomization.yaml
@@ -14,7 +14,6 @@ resources:
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
-  - ../../../ethos/identity/identity.yaml
   - ../aso/et-postgres-config.yaml
   - ../sops-secrets
 namespace: et
@@ -26,7 +25,6 @@ patches:
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml
   - path: ../../../hmc/identity/aat.yaml
-  - path: ../../../ethos/identity/aat.yaml
   - path: ../aso/et-servicebus.yaml
   - path: ../aso/et-postgres.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/ethos/aat/base/kustomization.yaml
+++ b/apps/ethos/aat/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../repl-docmosis-service/aat.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../../ecm-consumer/aat.yaml

--- a/apps/ethos/base/kustomization.yaml
+++ b/apps/ethos/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../ecm-consumer/ecm-consumer.yaml
   - ../repl-docmosis-service/repl-docmosis-service.yaml
   - ../../base/workload-identity

--- a/apps/ethos/demo/base/kustomization.yaml
+++ b/apps/ethos/demo/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: ethos
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../ecm-consumer/demo.yaml
   - path: ../../repl-docmosis-service/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/ethos/identity/aat.yaml
+++ b/apps/ethos/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ethos
-  namespace: ethos
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ethos-aat-mi"
-  clientID: "d4f08cdc-94a9-42a5-ac0c-9c55cbea57cb"

--- a/apps/ethos/identity/demo.yaml
+++ b/apps/ethos/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ethos
-  namespace: ethos
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ethos-demo-mi"
-  clientID: "be86f28f-eece-4ac1-aeb7-3df56749dc03"

--- a/apps/ethos/identity/ithc.yaml
+++ b/apps/ethos/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ethos
-  namespace: ethos
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ethos-ithc-mi"
-  clientID: "a7dd5a42-9d33-4fcf-8827-41e310ffa4c3"

--- a/apps/ethos/identity/perftest.yaml
+++ b/apps/ethos/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ethos
-  namespace: ethos
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ethos-perftest-mi"
-  clientID: "6807b8e6-3a5a-4cf7-8627-06600ff6e910"

--- a/apps/ethos/ithc/base/kustomization.yaml
+++ b/apps/ethos/ithc/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: ethos
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml
   - path: ../../repl-docmosis-service/ithc.yaml
   - path: ../../ecm-consumer/ithc.yaml

--- a/apps/ethos/perftest/base/kustomization.yaml
+++ b/apps/ethos/perftest/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: ethos
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml
   - path: ../../repl-docmosis-service/perftest.yaml
   - path: ../../ecm-consumer/perftest.yaml

--- a/apps/ethos/preview/base/kustomization.yaml
+++ b/apps/ethos/preview/base/kustomization.yaml
@@ -3,10 +3,8 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
 namespace: ethos
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo

--- a/apps/ethos/prod/base/kustomization.yaml
+++ b/apps/ethos/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: ethos
 patches:
   - path: ../../identity/prod.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/28706/files
https://github.com/hmcts/cnp-flux-config/pull/28682

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happy





## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Removed references to \"identity\" files in several kustomization.yaml files.
- Deleted \"aat.yaml\", \"demo.yaml\", \"ithc.yaml\", and \"perftest.yaml\" identity files.
- Updated \"kustomization.yaml\" files to remove references to deleted \"identity\" files.