### PR TITLE
Adding recipes-shared-infrastructure to platform dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -92,7 +92,7 @@ spec:
                     name: all
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|recipes-backend|camunda-.*)\/master
+                      ^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|recipes-backend|recipes-shared-infrastructure|camunda-.*)\/master
                     name: Platform
                     recurse: true
                     title: Platform


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-14632

### Change description
Adding recipes-shared-infrastructure to platform dashboard

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed file: jenkins.yaml
- Updated the `buildMonitor` includeRegex from `^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|recipes-backend|camunda-.*)\/master` to `^HMCTS.*\/(draft-store|rpe-pdf-service|service-auth-provider-app|spring-boot-template|cnp-plum-recipes-service|cnp-plum-frontend|cnp-plum-shared-infrastructure|recipes-backend|recipes-shared-infrastructure|camunda-.*)\/master` to include `recipes-shared-infrastructure` in the regex.