### PR TITLE
Remove old aad identity fact nonprod

### DIFF
--- a/apps/fact/aat/base/kustomization.yaml
+++ b/apps/fact/aat/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../../fact-frontend/aat.yaml
   - path: ../../fact-api/aat.yaml

--- a/apps/fact/base/kustomization.yaml
+++ b/apps/fact/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../fact-api/fact-api.yaml
   - ../fact-frontend/fact-frontend.yaml
   - ../fact-admin/fact-admin.yaml

--- a/apps/fact/demo/base/kustomization.yaml
+++ b/apps/fact/demo/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: fact
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../fact-api/demo.yaml
   - path: ../../fact-frontend/demo.yaml
   - path: ../../fact-admin/demo.yaml

--- a/apps/fact/identity/aat.yaml
+++ b/apps/fact/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fact
-  namespace: fact
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fact-aat-mi"
-  clientID: "938971dc-1926-4aa3-b85c-0e857b61ea60"

--- a/apps/fact/identity/demo.yaml
+++ b/apps/fact/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fact
-  namespace: fact
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fact-demo-mi"
-  clientID: 8eb2231b-d461-447b-9fd5-798f6c25aada

--- a/apps/fact/identity/ithc.yaml
+++ b/apps/fact/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fact
-  namespace: fact
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fact-ithc-mi"
-  clientID: "0172b223-af5e-4507-9043-20016ca8a59a"

--- a/apps/fact/identity/perftest.yaml
+++ b/apps/fact/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fact
-  namespace: fact
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fact-perftest-mi"
-  clientID: "5237d5f6-b271-47af-b59f-2564efaafb03"

--- a/apps/fact/ithc/base/kustomization.yaml
+++ b/apps/fact/ithc/base/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: fact
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml

--- a/apps/fact/perftest/base/kustomization.yaml
+++ b/apps/fact/perftest/base/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: fact
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml

--- a/apps/fact/preview/base/kustomization.yaml
+++ b/apps/fact/preview/base/kustomization.yaml
@@ -3,10 +3,8 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
 namespace: fact
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo

--- a/apps/fact/prod/base/kustomization.yaml
+++ b/apps/fact/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - fact-redirect.yaml
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: fact
 patches:
   - path: ../../identity/prod.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/35848

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happy

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


ℹ️  `apps/fact/aat/base/kustomization.yaml`:
- Removed paths to `identity/aat.yaml` and `serviceaccount/aat.yaml`.
- Removed `fact-frontend/aat.yaml` and `fact-api/aat.yaml`.

ℹ️  `apps/fact/base/kustomization.yaml`:
- Removed `./identity/identity.yaml`.

ℹ️  `apps/fact/demo/base/kustomization.yaml`:
- Removed `identity/demo.yaml`, `fact-api/demo.yaml`, `fact-frontend/demo.yaml`, and `fact-admin/demo.yaml`.

🔴 `apps/fact/identity/aat.yaml`:
- File deleted.

🔴 `apps/fact/identity/demo.yaml`:
- File deleted.

🔴 `apps/fact/identity/ithc.yaml`:
- File deleted.

🔴 `apps/fact/identity/perftest.yaml`:
- File deleted.

ℹ️  `apps/fact/ithc/base/kustomization.yaml`:
- Removed `identity/ithc.yaml`.

ℹ️  `apps/fact/perftest/base/kustomization.yaml`:
- Removed `identity/perftest.yaml`.

ℹ️  `apps/fact/preview/base/kustomization.yaml`:
- Removed `identity/aat.yaml`.

ℹ️  `apps/fact/prod/base/kustomization.yaml`:
- Added path to `identity/identity.yaml`.