### PR TITLE
Remove old aad identity fpl nonprod

### DIFF
--- a/apps/family-public-law/aat/base/kustomization.yaml
+++ b/apps/family-public-law/aat/base/kustomization.yaml
@@ -5,6 +5,5 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../fpl-case-service/aat.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/family-public-law/base/kustomization.yaml
+++ b/apps/family-public-law/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../fpl-case-service/fpl-case-service.yaml
   - ../fpl-cron-ccd-data-migration-tool/fpl-cron-ccd-data-migration-tool.yaml
   - ../../base/workload-identity

--- a/apps/family-public-law/demo/base/kustomization.yaml
+++ b/apps/family-public-law/demo/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: family-public-law
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../fpl-case-service/demo.yaml
   - path: ../../fpl-cron-ccd-data-migration-tool/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/family-public-law/identity/aat.yaml
+++ b/apps/family-public-law/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: family-public-law
-  namespace: family-public-law
-spec:
-  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-aat-mi
-  clientID: 84e843a3-53f4-4862-a842-81a2bf56dafe

--- a/apps/family-public-law/identity/demo.yaml
+++ b/apps/family-public-law/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: family-public-law
-  namespace: family-public-law
-spec:
-  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-demo-mi
-  clientID: bb3c54a7-5340-441a-9a78-929c47ff52c3

--- a/apps/family-public-law/identity/ithc.yaml
+++ b/apps/family-public-law/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: family-public-law
-  namespace: family-public-law
-spec:
-  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-ithc-mi
-  clientID: ef35d4fa-2d3c-46d4-9208-034a5f2f8cc5

--- a/apps/family-public-law/identity/perftest.yaml
+++ b/apps/family-public-law/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: family-public-law
-  namespace: family-public-law
-spec:
-  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fpl-perftest-mi
-  clientID: 86afcbe0-2992-42c9-800d-641ccb437008

--- a/apps/family-public-law/ithc/base/kustomization.yaml
+++ b/apps/family-public-law/ithc/base/kustomization.yaml
@@ -6,6 +6,5 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: family-public-law
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../fpl-case-service/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml

--- a/apps/family-public-law/perftest/base/kustomization.yaml
+++ b/apps/family-public-law/perftest/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: family-public-law
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../fpl-case-service/perftest.yaml
   - path: ../../fpl-cron-ccd-data-migration-tool/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml

--- a/apps/family-public-law/preview/base/kustomization.yaml
+++ b/apps/family-public-law/preview/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
@@ -15,7 +14,6 @@ resources:
   - ../sops-secrets
 namespace: family-public-law
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml

--- a/apps/family-public-law/prod/base/kustomization.yaml
+++ b/apps/family-public-law/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: family-public-law
 patches:
   - path: ../../identity/prod.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/35848

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happy

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Improved file `apps/family-public-law/aat/base/kustomization.yaml` by removing references to `identity/aat.yaml` and `identity/demo.yaml`.
- Removed files `apps/family-public-law/identity/aat.yaml`, `apps/family-public-law/identity/demo.yaml`, `apps/family-public-law/identity/ithc.yaml`, `apps/family-public-law/identity/perftest.yaml`.
- Updated file `apps/family-public-law/base/kustomization.yaml` by removing reference to `identity/identity.yaml`.
- Updated file `apps/family-public-law/ithc/base/kustomization.yaml` and `apps/family-public-law/perftest/base/kustomization.yaml` by removing references to `identity/ithc.yaml` and `identity/perftest.yaml`.
- Updated file `apps/family-public-law/prod/base/kustomization.yaml` by removing reference to `identity/identity.yaml` and adding `identity/prod.yaml`.
- Updated file `apps/family-public-law/preview/base/kustomization.yaml` by removing reference to `identity/aat.yaml` and `identity/identity.yaml` and updating other `identity` references.