### PR TITLE
Remove aad identity nonprod for; fis, finrem, fees-pay

### DIFF
--- a/apps/fees-pay/aat/base/kustomization.yaml
+++ b/apps/fees-pay/aat/base/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - ../../../base/slack-provider/aat
 namespace: fees-pay
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../ccpay-refunds-api/aat.yaml
   - path: ../../ccpay-cpo-callback-function/aat.yaml
   - path: ../../ccpay-cpo-update-service/aat.yaml

--- a/apps/fees-pay/base/kustomization.yaml
+++ b/apps/fees-pay/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../ccpay-paymentoutcome-web/ccpay-paymentoutcome-web.yaml
   - ../ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
   - ../ccpay-cpo-update-service/ccpay-cpo-update-service.yaml

--- a/apps/fees-pay/demo/base/kustomization.yaml
+++ b/apps/fees-pay/demo/base/kustomization.yaml
@@ -30,7 +30,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: fees-pay
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../fees-register-api/demo.yaml
   - path: ../../ccpay-bubble-frontend-int/demo.yaml
   - path: ../../ccpay-payment-api-int/demo.yaml

--- a/apps/fees-pay/identity/aat.yaml
+++ b/apps/fees-pay/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ccpay
-  namespace: fees-pay
-spec:
-  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ccpay-aat-mi
-  clientID: a8aac5ca-d33b-4f13-84cb-ec3d1fa25666

--- a/apps/fees-pay/identity/demo.yaml
+++ b/apps/fees-pay/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ccpay
-  namespace: fees-pay
-spec:
-  resourceID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ccpay-demo-mi
-  clientID: c73f34d3-240e-4c2b-9bc6-7847b5a83193

--- a/apps/fees-pay/identity/ithc.yaml
+++ b/apps/fees-pay/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ccpay
-  namespace: fees-pay
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ccpay-ithc-mi"
-  clientID: "3b246d97-b0ca-4816-8626-2fa99eee465e"

--- a/apps/fees-pay/identity/perftest.yaml
+++ b/apps/fees-pay/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: ccpay
-  namespace: fees-pay
-spec:
-  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ccpay-perftest-mi
-  clientID: b4140930-43d5-4cea-a835-2b7b6701de9a

--- a/apps/fees-pay/ithc/base/kustomization.yaml
+++ b/apps/fees-pay/ithc/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: fees-pay
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../ccpay-callback-function/ithc.yaml
   - path: ../../ccpay-refunds-api/ithc.yaml
   - path: ../../ccpay-cpo-update-service/ithc.yaml

--- a/apps/fees-pay/perftest/base/kustomization.yaml
+++ b/apps/fees-pay/perftest/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: fees-pay
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../ccpay-refunds-api/perftest.yaml
   - path: ../../ccpay-cpo-update-service/perftest.yaml
   - path: ../../ccpay-notifications-service/perftest.yaml

--- a/apps/fees-pay/preview/base/kustomization.yaml
+++ b/apps/fees-pay/preview/base/kustomization.yaml
@@ -3,13 +3,11 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
 namespace: fees-pay
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../aso/fees-pay-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:

--- a/apps/fees-pay/prod/base/kustomization.yaml
+++ b/apps/fees-pay/prod/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../unprocessed-payment-update/unprocessed-payment-update.yaml
   - ../../ccpay-notifications-service/ccpay-notifications-service.yaml
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: fees-pay
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/financial-remedy/aat/base/kustomization.yaml
+++ b/apps/financial-remedy/aat/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
 namespace: financial-remedy
 patches:
   - path: ../../finrem-cos/aat.yaml
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../../finrem-cron-one-off-task/aat/aat.yaml
   - path: ../../finrem-cron-draft-order-review-overdue/aat/aat.yaml

--- a/apps/financial-remedy/base/kustomization.yaml
+++ b/apps/financial-remedy/base/kustomization.yaml
@@ -3,6 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
   - ../finrem-cos/finrem-cos.yaml
-  - ../identity/identity.yaml
   - ../../base/workload-identity
 namespace: financial-remedy

--- a/apps/financial-remedy/demo/base/kustomization.yaml
+++ b/apps/financial-remedy/demo/base/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 namespace: financial-remedy
 patches:
   - path: ../../finrem-cos/demo.yaml
-  - path: ../../identity/demo.yaml
   - path: ../../serviceaccount/demo.yaml
   - path: ../../finrem-cron-one-off-task/demo/demo.yaml
   - path: ../../finrem-cron-remove-solicitor-from-case/demo/demo.yaml

--- a/apps/financial-remedy/identity/aat.yaml
+++ b/apps/financial-remedy/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: finrem
-  namespace: financial-remedy
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/finrem-aat-mi"
-  clientID: "f26e3f17-f671-4c79-8622-3d17b16707da"

--- a/apps/financial-remedy/identity/demo.yaml
+++ b/apps/financial-remedy/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: finrem
-  namespace: financial-remedy
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/finrem-demo-mi"
-  clientID: "10c7ad2b-364a-4877-a447-e040c8e25988"

--- a/apps/financial-remedy/identity/ithc.yaml
+++ b/apps/financial-remedy/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: finrem
-  namespace: financial-remedy
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/finrem-ithc-mi"
-  clientID: "87ca8d4c-0fe5-499c-b20f-6976b40d191d"

--- a/apps/financial-remedy/identity/perftest.yaml
+++ b/apps/financial-remedy/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: finrem
-  namespace: financial-remedy
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/finrem-perftest-mi"
-  clientID: "1d7f0767-27e0-4e12-8a0d-d94e65473536"

--- a/apps/financial-remedy/ithc/base/kustomization.yaml
+++ b/apps/financial-remedy/ithc/base/kustomization.yaml
@@ -7,5 +7,4 @@ resources:
 namespace: financial-remedy
 patches:
   - path: ../../finrem-cos/ithc.yaml
-  - path: ../../identity/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml

--- a/apps/financial-remedy/perftest/base/kustomization.yaml
+++ b/apps/financial-remedy/perftest/base/kustomization.yaml
@@ -7,5 +7,4 @@ resources:
 namespace: financial-remedy
 patches:
   - path: ../../finrem-cos/perftest.yaml
-  - path: ../../identity/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml

--- a/apps/financial-remedy/preview/base/kustomization.yaml
+++ b/apps/financial-remedy/preview/base/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
@@ -13,7 +12,6 @@ resources:
   - ../sops-secrets
 namespace: financial-remedy
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml

--- a/apps/financial-remedy/prod/base/kustomization.yaml
+++ b/apps/financial-remedy/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../finrem-cron-one-off-task/finrem-cron-one-off-task.yaml
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: financial-remedy
 patches:
   - path: ../../finrem-cos/prod.yaml

--- a/apps/fis/aat/base/kustomization.yaml
+++ b/apps/fis/aat/base/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - ../../../base/slack-provider/aat
 namespace: fis
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../fis-cos-api/aat.yaml
   - path: ../../fis-ds-update-web/aat.yaml

--- a/apps/fis/base/kustomization.yaml
+++ b/apps/fis/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../fis-hmc-api/fis-hmc-api.yaml
   - ../fis-ds-web/fis-ds-web.yaml
   - ../fis-ds-update-web/fis-ds-update-web.yaml

--- a/apps/fis/demo/base/kustomization.yaml
+++ b/apps/fis/demo/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: fis
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../fis-hmc-api/demo.yaml
   - path: ../../fis-cos-api/demo.yaml
   - path: ../../fis-ds-update-web/demo.yaml

--- a/apps/fis/identity/aat.yaml
+++ b/apps/fis/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fis
-  namespace: fis
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fis-aat-mi"
-  clientID: "2fcfe646-5dfb-48fa-9fa4-0c933f3454da"

--- a/apps/fis/identity/demo.yaml
+++ b/apps/fis/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fis
-  namespace: fis
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fis-demo-mi"
-  clientID: "00077c73-5f6a-4a8f-acb6-3ae4e3903877"

--- a/apps/fis/identity/ithc.yaml
+++ b/apps/fis/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fis
-  namespace: fis
-spec:
-  resourceID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fis-ithc-mi
-  clientID: "32480cee-f784-4abc-bf9c-7f3475c4f160"

--- a/apps/fis/identity/perftest.yaml
+++ b/apps/fis/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: fis
-  namespace: fis
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/fis-perftest-mi"
-  clientID: "1e219761-5ec8-4b0c-9114-779307e1ef33"

--- a/apps/fis/ithc/base/kustomization.yaml
+++ b/apps/fis/ithc/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: fis
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../fis-hmc-api/ithc.yaml
   - path: ../../fis-cos-api/ithc.yaml
   - path: ../../fis-ds-update-web/ithc.yaml

--- a/apps/fis/perftest/base/kustomization.yaml
+++ b/apps/fis/perftest/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: fis
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../fis-hmc-api/perftest.yaml
   - path: ../../fis-cos-api/perftest.yaml
   - path: ../../fis-ds-update-web/perftest.yaml

--- a/apps/fis/preview/base/kustomization.yaml
+++ b/apps/fis/preview/base/kustomization.yaml
@@ -3,13 +3,11 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
 namespace: fis
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
   - path: ../../../xui/identity/aat.yaml

--- a/apps/fis/prod/base/kustomization.yaml
+++ b/apps/fis/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: fis
 patches:
   - path: ../../identity/prod.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

Removing for fis, finrem and fees-pay in one PR

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/35848

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happy

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Removed references to identity``` in aat, demo, ithc, perftest, and preview directories' kustomization.yaml files.
- Deleted ```identity``` YAML files in the aat, demo, ithc, perftest, and preview directories under apps/fees-pay and apps/financial-remedy.
- Removed references to ```identity``` in aat, demo, ithc, perftest, and preview directories' kustomization.yaml files in the apps/fis directory.