### PR TITLE
Remove old AAD identity nonprod hmc, hwf, lau

### DIFF
--- a/apps/et/preview/base/kustomization.yaml
+++ b/apps/et/preview/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../ccd/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
   - ../../../rd/identity/identity.yaml
-  - ../../../hmc/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
@@ -24,7 +23,6 @@ patches:
   - path: ../../../wa/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml
-  - path: ../../../hmc/identity/aat.yaml
   - path: ../aso/et-servicebus.yaml
   - path: ../aso/et-postgres.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/help-with-fees/aat/base/kustomization.yaml
+++ b/apps/help-with-fees/aat/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/aat
 namespace: help-with-fees
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../help-with-fees-publicapp/aat.yaml
   - path: ../../help-with-fees-staffapp/aat.yaml
   - path: ../../help-with-fees-benefit-checker-api/aat.yaml

--- a/apps/help-with-fees/base/kustomization.yaml
+++ b/apps/help-with-fees/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../help-with-fees-publicapp/help-with-fees-publicapp.yaml
   - ../help-with-fees-staffapp/help-with-fees-staffapp.yaml
   - ../help-with-fees-benefit-checker-api/help-with-fees-benefit-checker-api.yaml

--- a/apps/help-with-fees/demo/base/kustomization.yaml
+++ b/apps/help-with-fees/demo/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: help-with-fees
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../help-with-fees-publicapp/demo.yaml
   - path: ../../help-with-fees-staffapp/demo.yaml
   - path: ../../help-with-fees-benefit-checker-api/demo.yaml

--- a/apps/help-with-fees/identity/aat.yaml
+++ b/apps/help-with-fees/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: help-with-fees
-  namespace: help-with-fees
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/help-with-fees-aat-mi"
-  clientID: "7f2f5641-218e-46b6-8f84-9521cde32478"

--- a/apps/help-with-fees/identity/demo.yaml
+++ b/apps/help-with-fees/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: help-with-fees
-  namespace: help-with-fees
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/help-with-fees-demo-mi"
-  clientID: "28ed2152-2d4f-4f6f-b961-fc75ad9e2c81"

--- a/apps/help-with-fees/preview/base/kustomization.yaml
+++ b/apps/help-with-fees/preview/base/kustomization.yaml
@@ -3,10 +3,8 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
 namespace: help-with-fees
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo

--- a/apps/help-with-fees/prod/base/kustomization.yaml
+++ b/apps/help-with-fees/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/exec-prod-role.yaml
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: help-with-fees
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/hmc/aat/base/kustomization.yaml
+++ b/apps/hmc/aat/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/aat
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../hmc-cft-hearing-service/aat.yaml
   - path: ../../hmc-hmi-outbound-adapter/aat.yaml
   - path: ../../hmc-hmi-inbound-adapter/aat.yaml

--- a/apps/hmc/base/kustomization.yaml
+++ b/apps/hmc/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../hmc-cft-hearing-service/hmc-cft-hearing-service.yaml
   - ../hmc-hmi-outbound-adapter/hmc-hmi-outbound-adapter.yaml
   - ../hmc-hmi-inbound-adapter/hmc-hmi-inbound-adapter.yaml

--- a/apps/hmc/demo/base/kustomization.yaml
+++ b/apps/hmc/demo/base/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/demo
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../hmc-cft-hearing-service-int/demo.yaml
   - path: ../../hmc-hmi-outbound-adapter-int/demo.yaml
   - path: ../../hmc-hmi-inbound-adapter-int/demo.yaml

--- a/apps/hmc/identity/aat.yaml
+++ b/apps/hmc/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: hmc
-  namespace: hmc
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/hmc-aat-mi"
-  clientID: "1907a367-6f62-4523-9cef-07777327a355"

--- a/apps/hmc/identity/demo.yaml
+++ b/apps/hmc/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: hmc
-  namespace: hmc
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/hmc-demo-mi"
-  clientID: "261a1e07-6883-4e61-a730-7748d2589991"

--- a/apps/hmc/identity/ithc.yaml
+++ b/apps/hmc/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: hmc
-  namespace: hmc
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/hmc-ithc-mi"
-  clientID: "6f01c8cf-811e-439b-be35-dc4028a5c74c"

--- a/apps/hmc/identity/perftest.yaml
+++ b/apps/hmc/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: hmc
-  namespace: hmc
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/hmc-perftest-mi"
-  clientID: "f74a069a-33d6-486d-bc97-f5b20937ca17"

--- a/apps/hmc/ithc/base/kustomization.yaml
+++ b/apps/hmc/ithc/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/ithc
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../hmc-cft-hearing-service/ithc.yaml
   - path: ../../hmc-hmi-outbound-adapter/ithc.yaml
   - path: ../../hmc-hmi-inbound-adapter/ithc.yaml

--- a/apps/hmc/perftest/base/kustomization.yaml
+++ b/apps/hmc/perftest/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/perftest
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../hmc-cft-hearing-service/perftest.yaml
   - path: ../../hmc-hmi-outbound-adapter/perftest.yaml
   - path: ../../hmc-hmi-inbound-adapter/perftest.yaml

--- a/apps/hmc/preview/base/kustomization.yaml
+++ b/apps/hmc/preview/base/kustomization.yaml
@@ -3,13 +3,11 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets
 namespace: hmc
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../aso/hmc-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:

--- a/apps/hmc/prod/base/kustomization.yaml
+++ b/apps/hmc/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../hmc-operational-reports-runner/hmc-operational-reports-runner.yaml
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 patches:
   - path: ../../identity/prod.yaml
   - path: ../../hmc-cft-hearing-service/prod.yaml

--- a/apps/ia/preview/base/kustomization.yaml
+++ b/apps/ia/preview/base/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - ../../ia-aip-frontend/ia-aip-frontend.yaml
   - ../../../wa/identity/identity.yaml
   - ../../../rd/identity/identity.yaml
-  - ../../../hmc/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
@@ -27,7 +26,6 @@ patches:
   - path: ../../../am/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml
-  - path: ../../../hmc/identity/aat.yaml
   - path: ../aso/ia-servicebus.yaml
   - path: ../../serviceaccount/aat.yaml
   - path: ../aso/ia-postgres.yaml

--- a/apps/lau/aat/base/kustomization.yaml
+++ b/apps/lau/aat/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/aat
 namespace: lau
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../lau-idam-backend/aat.yaml
   - path: ../../lau-case-backend/aat.yaml
   - path: ../../lau-frontend/aat.yaml

--- a/apps/lau/base/kustomization.yaml
+++ b/apps/lau/base/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../identity/identity.yaml
   - ../lau-idam-backend/lau-idam-backend.yaml
   - ../lau-case-backend/lau-case-backend.yaml
   - ../lau-frontend/lau-frontend.yaml

--- a/apps/lau/demo/base/kustomization.yaml
+++ b/apps/lau/demo/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../base/slack-provider/demo
 namespace: lau
 patches:
-  - path: ../../identity/demo.yaml
   - path: ../../lau-idam-backend/demo.yaml
   - path: ../../lau-case-backend/demo.yaml
   - path: ../../lau-case-backend-int/demo.yaml

--- a/apps/lau/identity/aat.yaml
+++ b/apps/lau/identity/aat.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: lau
-  namespace: lau
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/lau-aat-mi"
-  clientID: "9d44984c-f2e4-4217-b76e-ff99e1a6abca"

--- a/apps/lau/identity/demo.yaml
+++ b/apps/lau/identity/demo.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: lau
-  namespace: lau
-spec:
-  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/lau-demo-mi"
-  clientID: "6d06a024-e88f-4b55-9da6-cb23a0f56182"

--- a/apps/lau/identity/ithc.yaml
+++ b/apps/lau/identity/ithc.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: lau
-  namespace: lau
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/lau-ithc-mi"
-  clientID: "694253f4-4729-4b39-bf1a-444fbe72c8fb"

--- a/apps/lau/identity/perftest.yaml
+++ b/apps/lau/identity/perftest.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: lau
-  namespace: lau
-spec:
-  resourceID: "/subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourcegroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/lau-perftest-mi"
-  clientID: "02759868-3aae-4ab4-bce3-a49d5d6b4273"

--- a/apps/lau/ithc/base/kustomization.yaml
+++ b/apps/lau/ithc/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/ithc
 namespace: lau
 patches:
-  - path: ../../identity/ithc.yaml
   - path: ../../lau-idam-backend/ithc.yaml
   - path: ../../lau-case-backend/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml

--- a/apps/lau/perftest/base/kustomization.yaml
+++ b/apps/lau/perftest/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - ../../../base/slack-provider/perftest
 namespace: lau
 patches:
-  - path: ../../identity/perftest.yaml
   - path: ../../lau-idam-backend/perftest.yaml
   - path: ../../lau-case-backend/perftest.yaml
   - path: ../../serviceaccount/perftest.yaml

--- a/apps/lau/preview/base/kustomization.yaml
+++ b/apps/lau/preview/base/kustomization.yaml
@@ -3,10 +3,8 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
-  - ../../identity/identity.yaml
 namespace: lau
 patches:
-  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
 sortOptions:
   order: fifo

--- a/apps/lau/prod/base/kustomization.yaml
+++ b/apps/lau/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../identity/identity.yaml
 namespace: lau
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/sptribs/preview/base/kustomization.yaml
+++ b/apps/sptribs/preview/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../../xui/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
   - ../../../rd/identity/identity.yaml
-  - ../../../hmc/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
@@ -24,7 +23,6 @@ patches:
   - path: ../../../xui/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../../../rd/identity/aat.yaml
-  - path: ../../../hmc/identity/aat.yaml
   - path: ../aso/sptribs-servicebus.yaml
   - path: ../aso/sptribs-postgres.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
   - ../../../rpe/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
-  - ../../../hmc/identity/identity.yaml
   - ../../../wa/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
@@ -24,7 +23,6 @@ patches:
   - path: ../../../rpe/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../am/identity/aat.yaml
-  - path: ../../../hmc/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml
   - path: ../aso/sscs-servicebus.yaml
   - path: ../aso/sscs-postgres.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15415
AAD already removed and we've been using workload identity for a long time
Cleanup was paused for reasons explained in JIRA ticket which are now resolved, picking this back up

Removing for fis, finrem and fees-pay in one PR

We don't use these identities at all now, we use workload identity through service account federation with MI

Similar PRs in the past:
https://github.com/hmcts/cnp-flux-config/pull/35881
https://github.com/hmcts/cnp-flux-config/pull/35848

This tests in nonprod first (expecting 0 issues but want to be fully safe) - keeping the identity there until happy that all nonprod is happ



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Removed references to `identity.yaml` in `apps/et/preview/base/kustomization.yaml`, `apps/help-with-fees/aat/base/kustomization.yaml`, `apps/help-with-fees/base/kustomization.yaml`, `apps/help-with-fees/demo/base/kustomization.yaml`, `apps/help-with-fees/identity/aat.yaml`, `apps/help-with-fees/identity/demo.yaml`, `apps/help-with-fees/preview/base/kustomization.yaml`, `apps/help-with-fees/prod/base/kustomization.yaml`, `apps/hmc/aat/base/kustomization.yaml`, `apps/hmc/base/kustomization.yaml`, `apps/hmc/demo/base/kustomization.yaml`, `apps/hmc/identity/aat.yaml`, `apps/hmc/identity/demo.yaml`, `apps/hmc/identity/ithc.yaml`, `apps/hmc/identity/perftest.yaml`, `apps/hmc/ithc/base/kustomization.yaml`, `apps/hmc/perftest/base/kustomization.yaml`, `apps/hmc/preview/base/kustomization.yaml`, `apps/hmc/prod/base/kustomization.yaml`, `apps/ia/preview/base/kustomization.yaml`, `apps/lau/aat/base/kustomization.yaml`, `apps/lau/base/kustomization.yaml`, `apps/lau/demo/base/kustomization.yaml`, `apps/lau/identity/aat.yaml`, `apps/lau/identity/demo.yaml`, `apps/lau/identity/ithc.yaml`, `apps/lau/identity/perftest.yaml`, `apps/lau/ithc/base/kustomization.yaml`, `apps/lau/perftest/base/kustomization.yaml`, `apps/lau/preview/base/kustomization.yaml`, `apps/lau/prod/base/kustomization.yaml`, `apps/sptribs/preview/base/kustomization.yaml`, `apps/sscs/preview/base/kustomization.yaml`
- Removed references to `hmc/identity/identity.yaml` in `apps/et/preview/base/kustomization.yaml`, `apps/help-with-fees/preview/base/kustomization.yaml`, `apps/sptribs/preview/base/kustomization.yaml`, `apps/sscs/preview/base/kustomization.yaml`