### PR TITLE
DTSPO-23036: fix jenkins controller image - ptlsbox

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.491-828
+      tag: 2.491-829


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23036


### Change description

- new image without upgrade to azure-vm-agents plugin to fix jenkins agent pools


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `jenkins-controller-version.yaml`
  - The `tag` value for the Jenkins controller has been updated from `2.491-828` to `2.491-829`. 🚀