### PR TITLE
Revert "DTSPO-23036: test bugfix for azure-vm-agents jenkins plugin ptlsbox"

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.491-830
+      tag: 2.491-829


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#35899

- new plugin version works correctly, will rollback for now but new Jenkins controller version will be picked up and propagated to clusters post change freeze when renovate auto-merge is re-enabled

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- File: `apps/jenkins/jenkins/sbox-intsvc/jenkins-controller-version.yaml`
  - Updated the Jenkins controller tag from `2.491-830` to `2.491-829` 🔄