### PR TITLE
Fix appinsights for HMC

### DIFF
--- a/apps/hmc/hmc-hmi-outbound-adapter/aat.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/aat.yaml
@@ -16,8 +16,8 @@ spec:
       keyVaults:
         hmc:
           secrets:
-            - name: AppInsightsInstrumentationKey
-              alias: azure.application-insights.instrumentation-key
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
             - name: cft-hearing-service-POSTGRES-USER-V15
               alias: CFT_HEARING_SERVICE_DB_USERNAME
             - name: cft-hearing-service-POSTGRES-PASS-V15

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -9,8 +9,8 @@ spec:
       keyVaults:
         hmc:
           secrets:
-            - name: AppInsightsInstrumentationKey
-              alias: azure.application-insights.instrumentation-key
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
             - name: cft-hearing-service-POSTGRES-USER-V15
               alias: CFT_HEARING_SERVICE_DB_USERNAME
             - name: cft-hearing-service-POSTGRES-PASS-V15

--- a/apps/hmc/hmc-hmi-outbound-adapter/ithc.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/ithc.yaml
@@ -8,8 +8,8 @@ spec:
       keyVaults:
         hmc:
           secrets:
-            - name: AppInsightsInstrumentationKey
-              alias: azure.application-insights.instrumentation-key
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
             - name: cft-hearing-service-POSTGRES-USER-V15
               alias: CFT_HEARING_SERVICE_DB_USERNAME
             - name: cft-hearing-service-POSTGRES-PASS-V15

--- a/apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml
@@ -22,8 +22,8 @@ spec:
       keyVaults:
         hmc:
           secrets:
-            - name: AppInsightsInstrumentationKey
-              alias: azure.application-insights.instrumentation-key
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
             - name: cft-hearing-service-POSTGRES-USER-V15
               alias: CFT_HEARING_SERVICE_DB_USERNAME
             - name: cft-hearing-service-POSTGRES-PASS-V15

--- a/apps/hmc/hmc-hmi-outbound-adapter/prod.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/prod.yaml
@@ -8,8 +8,8 @@ spec:
       keyVaults:
         hmc:
           secrets:
-            - name: AppInsightsInstrumentationKey
-              alias: azure.application-insights.instrumentation-key
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
             - name: cft-hearing-service-POSTGRES-USER-V15
               alias: CFT_HEARING_SERVICE_DB_USERNAME
             - name: cft-hearing-service-POSTGRES-PASS-V15


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/hmc/hmc-hmi-outbound-adapter/aat.yaml`:
  - Changed secrets aliases to use `app-insights-connection-string` instead of `azure.application-insights.instrumentation-key`.
- `apps/hmc/hmc-hmi-outbound-adapter/demo.yaml`:
  - Changed secrets aliases to use `app-insights-connection-string` instead of `azure.application-insights.instrumentation-key`.
- `apps/hmc/hmc-hmi-outbound-adapter/ithc.yaml`:
  - Changed secrets aliases to use `app-insights-connection-string` instead of `azure.application-insights.instrumentation-key`.
- `apps/hmc/hmc-hmi-outbound-adapter/perftest.yaml`:
  - Changed secrets aliases to use `app-insights-connection-string` instead of `azure.application-insights.instrumentation-key`.
- `apps/hmc/hmc-hmi-outbound-adapter/prod.yaml`:
  - Changed secrets aliases to use `app-insights-connection-string` instead of `azure.application-insights.instrumentation-key`.
  - Updated the environment HMI_BASE_URL to use a different endpoint.