### PR TITLE
FACT-2040 undo prod image lat lon update into demo for normal release DO NOT MERGE

### DIFF
--- a/apps/fact/fact-api/demo.yaml
+++ b/apps/fact/fact-api/demo.yaml
@@ -5,4 +5,3 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/fact/api:pr-846-656d844-20241218143422


### PR DESCRIPTION
This reverts commit d5816a1618df4d76556d59234e1f9ccd5f6b1510.

### Jira link
https://tools.hmcts.net/jira/browse/FACT-2040

### Change description

undo demo release for normal release

### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `demo.yaml` in `fact-api` app.
- Removed a specific image reference for Java.