### PR TITLE
DFPL: Reset perftest to be inline with prod

### DIFF
--- a/apps/family-public-law/fpl-case-service/perftest-image-policy.yaml
+++ b/apps/family-public-law/fpl-case-service/perftest-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: perftest-fpl-case-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-5657-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: fpl-case-service


### PR DESCRIPTION
Resetting perftest image of fpl-case-service to be inline with master/prod

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/family-public-law/fpl-case-service/perftest-image-policy.yaml
- Removed annotations and filterTags from the ImagePolicy.
- Removed the extract and policy fields.
- Removed the alphabetical and order fields.