### PR TITLE
Replace hmctssandbox ACR name in my nodeJS app chart with hmctspublic

### DIFF
--- a/apps/labs/labs-dawidstrozak-nodejs/image-repo.yaml
+++ b/apps/labs/labs-dawidstrozak-nodejs/image-repo.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     hmcts.github.com/image-registry: hmctssandbox
 spec:
-  image: hmctssandbox.azurecr.io/labs/dawidstrozak-nodejs
+  image: hmctspublic.azurecr.io/labs/dawidstrozak-nodejs

--- a/apps/labs/labs-dawidstrozak-nodejs/labs-dawidstrozak-nodejs.yaml
+++ b/apps/labs/labs-dawidstrozak-nodejs/labs-dawidstrozak-nodejs.yaml
@@ -16,5 +16,5 @@ spec:
       interval: 1m
   values:
     nodejs:
-      image: hmctssandbox.azurecr.io/labs/dawidstrozak-nodejs:prod-75071c6-20241220151505 # {"$imagepolicy": "flux-system:labs-dawidstrozak-nodejs"}
+      image: hmctspublic.azurecr.io/labs/dawidstrozak-nodejs:prod-75071c6-20241220151505 # {"$imagepolicy": "flux-system:labs-dawidstrozak-nodejs"}
       disableTraefikTls: true

--- a/labs/create-lab-flux-config.sh
+++ b/labs/create-lab-flux-config.sh
@@ -23,7 +23,7 @@ set -ex
 NAMESPACE=labs
 PRODUCT=labs
 COMPONENT=$1
-ACR=hmctssandbox
+ACR=hmctspublic
 NAMESPACE_DIR="../apps/${NAMESPACE}"
 COMPONENT_DIR="${NAMESPACE_DIR}/${PRODUCT}-${COMPONENT}"
 ENVIRONMENT="sbox"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23140

### Change description

It looks like flux generation script generates lab exercise charts with "**hmctssandbox**" registry name.
But this registry is not where the common pipeline actually uploads the images, it uploads them to "**hmctspublic**" instead, I can see that in pipeline log output and the Azure portal.

- Replace sandbox registry in my NodeJS app with the public one to fix image pull error I am seeing on my container
- Replace sandbox registry in the lab chart generation script so public one is used instead so that this does not happen any more when following the Golden Path.

### Testing done
I can see that my and other lab app images live within hmctspublic

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/labs/labs-dawidstrozak-nodejs/image-repo.yaml
- Changed the image registry for the `dawidstrozak-nodejs` application to use `hmctspublic.azurecr.io` instead of `hmctssandbox.azurecr.io`.

### apps/labs/labs-dawidstrozak-nodejs/labs-dawidstrozak-nodejs.yaml
- Updated the image reference for the `dawidstrozak-nodejs` application to use `hmctspublic.azurecr.io` instead of `hmctssandbox.azurecr.io`.

### labs/create-lab-flux-config.sh
- Updated the ACR (Azure Container Registry) from `hmctssandbox` to `hmctspublic`.