### PR TITLE
Revert SSCS demo to prod

### DIFF
--- a/apps/sscs/sscs-tribunals-api/demo-image-policy.yaml
+++ b/apps/sscs/sscs-tribunals-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-sscs-tribunals-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-4194-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: sscs-tribunals-api

--- a/apps/sscs/sscs-tribunals-api/demo.yaml
+++ b/apps/sscs/sscs-tribunals-api/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:pr-4194-05d466f-20250109115712 #{"$imagepolicy": "flux-system:demo-sscs-tribunals-api"}
+      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-8b7c43a-20250108142543 #{"$imagepolicy": "flux-system:demo-sscs-tribunals-api"}
       aadIdentityName: sscs
       spotInstances:
         enabled: true
@@ -22,7 +22,7 @@ spec:
         POSTPONEMENTS_FEATURE: true
         DM_GATEWAY_URL: https://manage-case.demo.platform.hmcts.net
         SSCS2_FEATURE: true
-        DUMMY_PROPERTY: false
+        DUMMY_PROPERTY: true
         WORK_ALLOCATION_FEATURE: false
         RD_LOCATION_REF_API_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         JUDICIAL_REF_API_URL: http://rd-judicial-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### Jira link

See [SSCSCI-1428](https://tools.hmcts.net/jira/browse/SSCSCI-1428)

### Change description

Reverting SSCS tribunals demo back to prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo-image-policy.yaml` 🖼️
  - Removed annotations for prod-automated
  - Updated filterTags and extract pattern in spec

- `demo.yaml` ✨
  - Updated image version to prod-8b7c43a-20250108142543
  - Changed value of DUMMY_PROPERTY from false to true