### PR TITLE
CRF-12: Update AAT location ref data API auth services

### DIFF
--- a/apps/rd/rd-location-ref-api/aat.yaml
+++ b/apps/rd/rd-location-ref-api/aat.yaml
@@ -25,7 +25,7 @@ spec:
             - name: location-ref-api-POSTGRES-PASS
               alias: POSTGRES_PASSWORD
       environment:
-        LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api,rd_judicial_api,ccd_data,xui_webapp,prl_cos_api,sscs,sscs_bulkscan,adoption_web,civil_service,civil_general_applications,sptribs_case_api,fis_hmc_api,et_cos,iac
+        LRD_S2S_AUTHORISED_SERVICES: rd_location_ref_api,payment_app,rd_caseworker_ref_api,rd_judicial_api,ccd_data,xui_webapp,prl_cos_api,sscs,sscs_bulkscan,adoption_web,civil_service,civil_general_applications,sptribs_case_api,fis_hmc_api,et_cos,iac,civil_rtl_export
         DELETE_ORG: true
         ACTIVE_ORG_EXT: true
         POSTGRES_HOST: rd-location-ref-api-postgres-db-v16-aat.postgres.database.azure.com


### PR DESCRIPTION
### Jira link

See [CRF-12](https://tools.hmcts.net/jira/browse/CRF-12)

### Change description

Add civil_rtl_export to list of services authorised to use location reference data API in AAT environment.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/rd/rd-location-ref-api/aat.yaml
- Added `civil_rtl_export` to the `LRD_S2S_AUTHORISED_SERVICES` environment variable.
- Removed `DELETE_ORG` and `ACTIVE_ORG_EXT` environment variables.
- Updated the `POSTGRES_HOST` variable to `rd-location-ref-api-postgres-db-v16-aat.postgres.database.azure.com`.