### PR TITLE
DTSPB-4259: Redirect demo to ticket specific builds

### DIFF
--- a/apps/probate/probate-back-office/demo-image-policy.yaml
+++ b/apps/probate/probate-back-office/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2953-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2897-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-frontend/demo-image-policy.yaml
+++ b/apps/probate/probate-frontend/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2335-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-orchestrator-service/demo-image-policy.yaml
+++ b/apps/probate/probate-orchestrator-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1143-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/probate/probate-submit-service/demo-image-policy.yaml
+++ b/apps/probate/probate-submit-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1023-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **demo-image-policy.yaml**
  - Updated the pattern for filterTags from `'pr-2953-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'pr-2897-[a-f0-9]+-(?P<ts>[0-9]+)'` for probate-back-office.
  - Updated the pattern for filterTags from `'pr-2335-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'prod-[a-f0-9]+-(?P<ts>[0-9]+)'` for probate-frontend.
  - Updated the pattern for filterTags from `'pr-1143-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'prod-[a-f0-9]+-(?P<ts>[0-9]+)'` for probate-orchestrator-service.
  - Updated the pattern for filterTags from `'pr-1023-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'prod-[a-f0-9]+-(?P<ts>[0-9]+)'` for probate-submit-service.