### PR TITLE
DTSPB-3761 Redeploy all probate pods in all envs

### DIFF
--- a/apps/probate/probate-back-office/probate-back-office.yaml
+++ b/apps/probate/probate-back-office/probate-back-office.yaml
@@ -13,7 +13,7 @@ spec:
       image: hmctspublic.azurecr.io/probate/back-office:prod-6707e09-20250109124038 #{"$imagepolicy": "flux-system:probate-back-office"}
       environment:
         # Does what it says on the tin - if this changes then all envs should redeploy
-        CHANGE_TO_REDEPLOY_ALL_ENVS: abc
+        CHANGE_TO_REDEPLOY_ALL_ENVS: abcd
   chart:
     spec:
       chart: ./stable/probate-back-office

--- a/apps/probate/probate-business-service/probate-business-service.yaml
+++ b/apps/probate/probate-business-service/probate-business-service.yaml
@@ -13,7 +13,7 @@ spec:
       image: hmctspublic.azurecr.io/probate/business-service:prod-9cfcb82-20250110124256 #{"$imagepolicy": "flux-system:probate-business-service"}
       environment:
         # Does what it says on the tin - if this changes then all envs should redeploy
-        CHANGE_TO_REDEPLOY_ALL_ENVS: abc
+        CHANGE_TO_REDEPLOY_ALL_ENVS: abcd
   chart:
     spec:
       chart: ./stable/probate-business-service

--- a/apps/probate/probate-caveats-fe/probate-caveats-fe.yaml
+++ b/apps/probate/probate-caveats-fe/probate-caveats-fe.yaml
@@ -12,7 +12,7 @@ spec:
       image: hmctspublic.azurecr.io/probate/caveats-fe:prod-1c3bcbd-20250110162833 #{"$imagepolicy": "flux-system:probate-caveats-fe"}
       environment:
         # Does what it says on the tin - if this changes then all envs should redeploy
-        CHANGE_TO_REDEPLOY_ALL_ENVS: abc
+        CHANGE_TO_REDEPLOY_ALL_ENVS: abcd
   chart:
     spec:
       chart: ./stable/probate-caveats-fe

--- a/apps/probate/probate-frontend/probate-frontend.yaml
+++ b/apps/probate/probate-frontend/probate-frontend.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctspublic.azurecr.io/probate/frontend:prod-593e182-20250109112324 #{"$imagepolicy": "flux-system:probate-frontend"}
       environment:
         # Does what it says on the tin - if this changes then all envs should redeploy
-        CHANGE_TO_REDEPLOY_ALL_ENVS: abc
+        CHANGE_TO_REDEPLOY_ALL_ENVS: abcd
   chart:
     spec:
       chart: ./stable/probate-frontend

--- a/apps/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
+++ b/apps/probate/probate-orchestrator-service/probate-orchestrator-service.yaml
@@ -19,7 +19,7 @@ spec:
       image: hmctspublic.azurecr.io/probate/orchestrator-service:prod-f8c6d85-20250110122134 #{"$imagepolicy": "flux-system:probate-orchestrator-service"}
       environment:
         # Does what it says on the tin - if this changes then all envs should redeploy
-        CHANGE_TO_REDEPLOY_ALL_ENVS: abc
+        CHANGE_TO_REDEPLOY_ALL_ENVS: abcd
   chart:
     spec:
       chart: ./stable/probate-orchestrator-service

--- a/apps/probate/probate-submit-service/probate-submit-service.yaml
+++ b/apps/probate/probate-submit-service/probate-submit-service.yaml
@@ -19,7 +19,7 @@ spec:
       image: hmctspublic.azurecr.io/probate/submit-service:prod-2e1ee4b-20250110163107 #{"$imagepolicy": "flux-system:probate-submit-service"}
       environment:
         # Does what it says on the tin - if this changes then all envs should redeploy
-        CHANGE_TO_REDEPLOY_ALL_ENVS: abc
+        CHANGE_TO_REDEPLOY_ALL_ENVS: abcd
   chart:
     spec:
       chart: ./stable/probate-submit-service


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPB-3761](https://tools.hmcts.net/jira/browse/DTSPB-3761)

### Change description

Update base var to redeploy all probate pods in all envs

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `probate-back-office.yaml`:
  - Changed the environment variable `CHANGE_TO_REDEPLOY_ALL_ENVS` from `abc` to `abcd`.
- `probate-business-service.yaml`:
  - Changed the environment variable `CHANGE_TO_REDEPLOY_ALL_ENVS` from `abc` to `abcd`.
- `probate-caveats-fe.yaml`:
  - Changed the environment variable `CHANGE_TO_REDEPLOY_ALL_ENVS` from `abc` to `abcd`.
- `probate-frontend.yaml`:
  - Changed the environment variable `CHANGE_TO_REDEPLOY_ALL_ENVS` from `abc` to `abcd`.
- `probate-orchestrator-service.yaml`:
  - Changed the environment variable `CHANGE_TO_REDEPLOY_ALL_ENVS` from `abc` to `abcd`.
- `probate-submit-service.yaml`:
  - Changed the environment variable `CHANGE_TO_REDEPLOY_ALL_ENVS` from `abc` to `abcd`.