### PR TITLE
LAU-1074 enable disposer cut off time

### DIFF
--- a/apps/disposer/disposer-idam-user/prod.yaml
+++ b/apps/disposer/disposer-idam-user/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 22 * * sun-thu"
+      schedule: "0 20 * * sun-thu"
       memoryRequests: "1024Mi"
       cpuRequests: "1000m"
       memoryLimits: "2048Mi"
@@ -16,4 +16,5 @@ spec:
         DISPOSER_IDAM_USER_SIMULATION_MODE: false
         DISPOSER_IDAM_USER_BATCH_SIZE: 100
         DISPOSER_IDAM_USER_REQUESTS_LIMIT: 50000
-        DISPOSER_IDAM_USER_START_PAGE: 13600
+        DISPOSER_IDAM_USER_START_PAGE: 0
+        DISPOSER_IDAM_USER_RUN_BEFORE_TIME: "06:00"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/LAU-1074

### Change description
Enable disposer cutoff time
Start from 0th page
Start running at 20:00 (instead of 22:00)


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/disposer/disposer-idam-user/prod.yaml
- Updated the job schedule from \"0 22 * * sun-thu\" to \"0 20 * * sun-thu\"
- Changed the value of DISPOSER_IDAM_USER_START_PAGE from 13600 to 0
- Added DISPOSER_IDAM_USER_RUN_BEFORE_TIME with a value of \"06:00\"