### PR TITLE
DTSPO-18332 - Upgrade flexible server api version to allow version 16 deployments within automation script

### DIFF
--- a/apps/azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
+++ b/apps/azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: maxconnections

--- a/apps/azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+++ b/apps/azureserviceoperator-system/resources/flexibleserver-postgres.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServer
 metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -102,6 +102,7 @@ resources:
   - ../../../base
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../sops-secrets
 namespace: $NAMESPACE_NAME
 patches:

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -34,7 +34,7 @@ metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
-  version: "14"
+  version: "16"
   sku:
     name: Standard_D2ds_v5
     tier: GeneralPurpose

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -28,7 +28,7 @@ if [ ! -f "apps/$NAMESPACE_NAME/preview/aso" ]; then
 
   (
     cat <<EOF
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServer
 metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}


### PR DESCRIPTION
### Jira link
DTSPO-18332

### Change description
Upgrade flexible server api version to allow version 16 deployments within automation script
Update automation script to deploy a postgres flexible server as version 16 by default instead of version 14 as allowed by api version upgrade
Add line that was missing if kustomization was created as new file

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `flexibleserver-postgres-config.yaml` 🔄 The `apiVersion` has been updated from `dbforpostgresql.azure.com/v1api20210601` to `dbforpostgresql.azure.com/v1api20230601preview`.
- `flexibleserver-postgres.yaml` 🔄 The `apiVersion` has been updated from `dbforpostgresql.azure.com/v1api20210601` to `dbforpostgresql.azure.com/v1api20230601preview`. The `version` has been changed from \"14\" to \"16\".
- `postgres-setup.sh` 🔄 The `apiVersion` has been updated from `dbforpostgresql.azure.com/v1api20210601` to `dbforpostgresql.azure.com/v1api20230601preview`. The `version` field has been changed from \"14\" to \"16\". Additionally, `flexibleserver-postgres-config.yaml` has been added as a resource.