### PR TITLE
DTSPO-18332 - patch max connections in order to test a config change

### DIFF
--- a/apps/adoption/preview/aso/adoption-postgres-config.yaml
+++ b/apps/adoption/preview/aso/adoption-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions

--- a/apps/azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
+++ b/apps/azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: maxconnections

--- a/apps/chart-tests/azure-service-operator/flexibleserver-postgres-config.yaml
+++ b/apps/chart-tests/azure-service-operator/flexibleserver-postgres-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+kind: FlexibleServersConfiguration
+metadata:
+  name: maxconnections
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  owner:
+    name: ${NAMESPACE}-${ENVIRONMENT}
+  azureName: max_connections
+  source: user-override
+  value: "4000"

--- a/apps/chart-tests/preview/base/kustomization.yaml
+++ b/apps/chart-tests/preview/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../sops-secrets
 namespace: chart-tests
 patches:
+  - path: ../../azure-service-operator/flexibleserver-postgres-config.yaml
   - path: ../../../money-claims/identity/aat.yaml
   - path: ../../../ccd/identity/aat.yaml
   - path: ../../../wa/identity/aat.yaml

--- a/apps/civil/preview/aso/civil-postgres-config.yaml
+++ b/apps/civil/preview/aso/civil-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions

--- a/apps/et/preview/aso/et-postgres-config.yaml
+++ b/apps/et/preview/aso/et-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions

--- a/apps/family-public-law/preview/aso/fpl-postgres-config.yaml
+++ b/apps/family-public-law/preview/aso/fpl-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions

--- a/apps/ia/preview/aso/ia-postgres-config.yaml
+++ b/apps/ia/preview/aso/ia-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions

--- a/apps/sptribs/preview/aso/sptribs-postgres-config.yaml
+++ b/apps/sptribs/preview/aso/sptribs-postgres-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServersConfiguration
 metadata:
   name: extensions


### PR DESCRIPTION
### Jira link
DTSPO-18332

### Change description
patch max connections in order to test a config change

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `adoption-postgres-config.yaml`:
  - updated `apiVersion` from `dbforpostgresql.azure.com/v1api20210601` to `dbforpostgresql.azure.com/v1api20230601preview`.

- `flexibleserver-postgres-config.yaml`:
  - updated `apiVersion` from `dbforpostgresql.azure.com/v1api20210601` to `dbforpostgresql.azure.com/v1api20230601preview`.

- Added new file `flexibleserver-postgres-config.yaml` to `chart-tests/azure-service-operator/` with content for FlexibleServersConfiguration.

- `kustomization.yaml`:
  - Added a new patch path for `././azure-service-operator/flexibleserver-postgres-config.yaml`.

- Other files:
  - Updated the `apiVersion` from `dbforpostgresql.azure.com/v1api20210601` to `dbforpostgresql.azure.com/v1api20230601preview` in various `*postgres-config.yaml` files for different apps.