### PR TITLE
DIAC-572 deploy IA case API changes in demo

### DIFF
--- a/apps/ia/ia-case-api/demo-image-policy.yaml
+++ b/apps/ia/ia-case-api/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ia-case-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-2456-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: ia-case-api

--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/case-api:prod-3e94b96-20250113114626 #{"$imagepolicy": "flux-system:ia-case-api"}
+      image: hmctspublic.azurecr.io/ia/case-api:pr-2456-fe35409-20250114164427 #{"$imagepolicy": "flux-system:demo-ia-case-api"}
       environment:
         IA_HOME_OFFICE_INTEGRATION_ENABLED: "true"
         IA_TIMED_EVENT_SERVICE_ENABLED: "true"
@@ -15,6 +15,6 @@ spec:
         POSTGRES_USERNAME: pgadmin
         LOCATION_REF_DATA_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         FEES_REGISTER_API_URL: "http://fees-register-api-demo.service.core-compute-demo.internal"
-        DUMMY_VAR: "yes"
+        DUMMY_VAR: "no"
       spotInstances:
         enabled: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- In `demo-image-policy.yaml`, an annotation `hmcts.github.com/prod-automated` with the value `disabled` was added under metadata.
- The `filterTags` and `policy` fields were added under spec in `demo-image-policy.yaml`.
- In `demo.yaml`, the image reference was updated to `hmctspublic.azurecr.io/ia/case-api:pr-2456-fe35409-20250114164427`.
- The value of `DUMMY_VAR` under spec in `demo.yaml` was changed from `\"yes\"` to `\"no\"`.