### PR TITLE
Set case disposer to 1m rate limit in perftest

### DIFF
--- a/apps/ccd/ccd-case-disposer/perftest.yaml
+++ b/apps/ccd/ccd-case-disposer/perftest.yaml
@@ -25,3 +25,4 @@ spec:
         LOG_AND_AUDIT_HOST: "http://lau-case-backend-perftest.service.core-compute-perftest.internal"
         DELETE_CASE_TYPES: "DPR_FT_MasterCaseType, CARE_SUPERVISION_EPO, GrantOfRepresentation"
         SIMULATED_CASE_TYPES:
+        CCD_DISPOSER_REQUEST_LIMIT: 1000000


### PR DESCRIPTION
### Change description
Set case disposer to 1m rate limit in perftest, to support pertest team


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-case-disposer/perftest.yaml
- Added a new variable `SIMULATED_CASE_TYPES`.
- Set `CCD_DISPOSER_REQUEST_LIMIT` to 1000000.