### PR TITLE
Revert IA services to deploy prod images

### DIFF
--- a/apps/ia/ia-bail-case-api/demo-image-policy.yaml
+++ b/apps/ia/ia-bail-case-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ia-bail-case-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-540-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: ia-bail-case-api

--- a/apps/ia/ia-bail-case-api/demo.yaml
+++ b/apps/ia/ia-bail-case-api/demo.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/bail-case-api:pr-540-c40db09-20250117142206 #{"$imagepolicy": "flux-system:demo-ia-bail-case-api"}
+      image: hmctspublic.azurecr.io/ia/bail-case-api:prod-9bb7f03-20250110114848 #{"$imagepolicy": "flux-system:demo-ia-bail-case-api"}
       environment:
         COMMON_DATA_API: http://rd-commondata-api-demo.service.core-compute-demo.internal
         IA_HEARINGS_API_URL: http://ia-hearings-api-demo.service.core-compute-demo.internal/
         LOCATION_REF_DATA_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
-        RESTART_PODS: "3"
+        RESTART_PODS: "yes"

--- a/apps/ia/ia-case-api/demo-image-policy.yaml
+++ b/apps/ia/ia-case-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ia-case-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-2457-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: ia-case-api

--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/case-api:pr-2457-159cdb6-20250120103019 #{"$imagepolicy": "flux-system:demo-ia-case-api"}
+      image: hmctspublic.azurecr.io/ia/case-api:prod-3e94b96-20250113114626 #{"$imagepolicy": "flux-system:demo-ia-case-api"}
       environment:
         IA_HOME_OFFICE_INTEGRATION_ENABLED: "true"
         IA_TIMED_EVENT_SERVICE_ENABLED: "true"
@@ -15,6 +15,6 @@ spec:
         POSTGRES_USERNAME: pgadmin
         LOCATION_REF_DATA_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         FEES_REGISTER_API_URL: "http://fees-register-api-demo.service.core-compute-demo.internal"
-        DUMMY_VAR: "no"
+        DUMMY_VAR: "yes"
       spotInstances:
         enabled: true

--- a/apps/ia/ia-case-notifications-api/demo-image-policy.yaml
+++ b/apps/ia/ia-case-notifications-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ia-case-notifications-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1341-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/demo.yaml
+++ b/apps/ia/ia-case-notifications-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/case-notifications-api:pr-1341-48406d6-20250116132016 #{"$imagepolicy": "flux-system:demo-ia-case-notifications-api"}
+      image: hmctspublic.azurecr.io/ia/case-notifications-api:prod-b0b87df-20241205125057 #{"$imagepolicy": "flux-system:demo-ia-case-notifications-api"}
       environment:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net
         DUMMY: true

--- a/apps/ia/ia-hearings-api/demo-image-policy.yaml
+++ b/apps/ia/ia-hearings-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-ia-hearings-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-477-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: ia-hearings-api

--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ia/hearings-api:pr-477-86fb542-20250117134205 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
+      image: hmctspublic.azurecr.io/ia/hearings-api:prod-bb05e1a-20250114120739 #{"$imagepolicy": "flux-system:demo-ia-hearings-api"}
       ingressHost: ia-hearings-api-demo.service.core-compute-demo.internal
       spotInstances:
         enabled: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ia/ia-bail-case-api/demo-image-policy.yaml
- Removed annotations and policy settings for the image.
### apps/ia/ia-bail-case-api/demo.yaml
- Updated the image tag and the value of RESTART_PODS from \"3\" to \"yes\".
### apps/ia/ia-case-api/demo-image-policy.yaml
- Removed annotations and policy settings for the image.
### apps/ia/ia-case-api/demo.yaml
- Updated the image tag and the value of DUMMY_VAR from \"no\" to \"yes\".
### apps/ia/ia-case-notifications-api/demo-image-policy.yaml
- Removed annotations and policy settings for the image.
### apps/ia/ia-case-notifications-api/demo.yaml
- Updated the image tag.
### apps/ia/ia-hearings-api/demo-image-policy.yaml
- Removed annotations and policy settings for the image.
### apps/ia/ia-hearings-api/demo.yaml
- Updated the image tag and ingressHost.