### PR TITLE
LAU keep one mil as mil

### DIFF
--- a/apps/ccd/ccd-case-disposer/perftest.yaml
+++ b/apps/ccd/ccd-case-disposer/perftest.yaml
@@ -25,4 +25,4 @@ spec:
         LOG_AND_AUDIT_HOST: "http://lau-case-backend-perftest.service.core-compute-perftest.internal"
         DELETE_CASE_TYPES: "DPR_FT_MasterCaseType, CARE_SUPERVISION_EPO, GrantOfRepresentation"
         SIMULATED_CASE_TYPES:
-        CCD_DISPOSER_REQUEST_LIMIT: 1000000
+        CCD_DISPOSER_REQUEST_LIMIT: "1000000"


### PR DESCRIPTION
### Change description
Yaml converts large integer to scientific notation. Making it a string, should keep it as is.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **perftest.yaml**
  - Updated the value of `CCD_DISPOSER_REQUEST_LIMIT` from `1000000` to `\"1000000\"` for simulated case types.