### PR TITLE
pr-4162 int2-demo-override-true-test-v2

### DIFF
--- a/apps/xui/xui-webapp-integration2/demo.yaml
+++ b/apps/xui/xui-webapp-integration2/demo.yaml
@@ -41,4 +41,5 @@ spec:
         SERVICES_TRANSLATION_API_URL: http://ts-translation-service-demo.service.core-compute-demo.internal
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
         SERVICES_IDAM_SERVICE_OVERRIDE: true
+        SERVICES_IDAM_CLIENT_ID: xuiwebapp_passport_0_7
       image: hmctspublic.azurecr.io/xui/webapp:pr-4162-724cfe4-20250127084227 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration2"}


### PR DESCRIPTION
added the SERVICES_IDAM_CLIENT_ID: xuiwebapp_passport_0_7 to the config.








## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `demo.yaml` file in `apps/xui/xui-webapp-integration2` has been modified to include a new `SERVICES_IDAM_CLIENT_ID` with the value `xuiwebapp_passport_0_7`.