### PR TITLE
Get lower envs pointing at hmctsprivatetemp to fix while we talk to msft

### DIFF
--- a/apps/camunda/camunda-api/aat.yaml
+++ b/apps/camunda/camunda-api/aat.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       environment:
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         LOGGING_LEVEL_COM_ZAXXER_HIKARI_HIKARICONFIG: DEBUG

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:perftest-camunda"}
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       environment:
         CAMUNDA_DB_HOST: "hmcts-camunda-v14-flexible-{{ .Values.global.environment }}.postgres.database.azure.com"
         CAMUNDA_DB_USER_NAME: "camundaadmin"

--- a/apps/camunda/camunda-api/ithc.yaml
+++ b/apps/camunda/camunda-api/ithc.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       environment:
         WA_AUTO_CONFIGURE_TASKS_ENABLED: false
         DUMMY_REDEPLOY_VAR: false

--- a/apps/camunda/camunda-api/perftest.yaml
+++ b/apps/camunda/camunda-api/perftest.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:perftest-camunda"}
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       memoryRequests: '2Gi'
       memoryLimits: '4Gi'
       cpuRequests: '1'

--- a/apps/docmosis/docmosis/aat.yaml
+++ b/apps/docmosis/docmosis/aat.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:aat-01c9f2b-737395 #{"$imagepolicy": "flux-system:aat-docmosis"}
+    image: hmctsprivatetemp.azurecr.io/docmosis:aat-01c9f2b-737395

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:demo-01c9f2b-737395 #{"$imagepolicy": "flux-system:demo-docmosis"}
+    image: hmctsprivatetemp.azurecr.io/docmosis:demo-01c9f2b-737395

--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     replicas: 3
     ingressHost: docmosis.perftest.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:perftest-01c9f2b-737395 #{"$imagepolicy": "flux-system:perftest-docmosis"}
+    image: hmctsprivatetemp.azurecr.io/docmosis:perftest-01c9f2b-737395
     java:
       memoryRequests: '4Gi'
       memoryLimits: '5Gi'

--- a/apps/docmosis/docmosis/preview.yaml
+++ b/apps/docmosis/docmosis/preview.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.preview.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:preview-01c9f2b-737395 #{"$imagepolicy": "flux-system:preview-docmosis"}
+    image: hmctsprivatetemp.azurecr.io/docmosis:preview-01c9f2b-737395
     disableTraefikTls: false

--- a/apps/docmosis/docmosis/sbox.yaml
+++ b/apps/docmosis/docmosis/sbox.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.sandbox.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:sandbox-01c9f2b-737395 #{"$imagepolicy": "flux-system:sandbox-docmosis"}
+    image: hmctsprivatetemp.azurecr.io/docmosis:sandbox-01c9f2b-737395
     environment:
       DOCMOSIS_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
       DOCMOSIS_TORNADO_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net


### PR DESCRIPTION
### Jira link

DTSPO-23611

### Change description

Switch lower env images for camunda and docmosis over to new hmctsprivatetemp (has the same config as original). 
Images were migrated with the same names.
Change does remove image automation as this will still need changed over (unless problem with hmctsprivate is fixed first).

https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/rpe-acr-prod-rg/providers/Microsoft.ContainerRegistry/registries/hmctsprivatetemp/repository

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed aat.yaml, demo.yaml, ithc.yaml, and perftest.yaml in apps/camunda/camunda-api:
  - Updated the image URL to hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402 for the java container.

- Changed aat.yaml, demo.yaml, and perftest.yaml in apps/docmosis/docmosis:
  - Updated the image URL to hmctsprivatetemp.azurecr.io/docmosis:aat-01c9f2b-737395, hmctsprivatetemp.azurecr.io/docmosis:demo-01c9f2b-737395, and hmctsprivatetemp.azurecr.io/docmosis:perftest-01c9f2b-737395 for the containers.