### PR TITLE
hmctsprivatetemp - camunda working on lower envs

### DIFF
--- a/apps/camunda/camunda-ui/demo.yaml
+++ b/apps/camunda/camunda-ui/demo.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       ingressClass: traefik

--- a/apps/camunda/camunda-ui/ithc.yaml
+++ b/apps/camunda/camunda-ui/ithc.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       ingressClass: traefik

--- a/apps/camunda/camunda-ui/perftest.yaml
+++ b/apps/camunda/camunda-ui/perftest.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   values:
     java:
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
       ingressClass: traefik


### PR DESCRIPTION
### Jira link

DTSPO-23611

### Change description

Camunda UI set to use hmctsprivatetemp repo to get camunda working on these envs again.
Will continue working with MSFT to get resolution on issues with hmctsprivate

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/camunda/camunda-ui/demo.yaml
- Added a new java image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
- Updated the ingressClass to traefik

### apps/camunda/camunda-ui/ithc.yaml
- Added a new java image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
- Updated the ingressClass to traefik

### apps/camunda/camunda-ui/perftest.yaml
- Added a new java image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
- Updated the ingressClass to traefik