### PR TITLE
put hearing service and outbound adapter for HMAN-581 on demo

### DIFF
--- a/apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-544'
+    pattern: '^pr-529'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-cft-hearing-service/demo.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-544-3b39d54-20250106123937 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
+      image: hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-529 #{"$imagepolicy": "flux-system:demo-hmc-cft-hearing-service"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-hmc-hmi-outbound-adapter
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-230'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: hmc-hmi-outbound-adapter

--- a/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-33dfe63-20250102163110 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
+      image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:pr-230 #{"$imagepolicy": "flux-system:demo-hmc-hmi-outbound-adapter"}
       keyVaults:
         hmc:
           secrets:


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo-image-policy.yaml`
  - Changed the filterTags pattern from '^prod' to '^pr-529' for the hmcts.github.com/prod-automated annotation.

- `demo.yaml`
  - Updated the image from 'hmctspublic.azurecr.io/hmc/cft-hearing-service:prod-cfbe3fb-20250127140528' to 'hmctspublic.azurecr.io/hmc/cft-hearing-service:pr-529' for the java value, and added environment variables related to logging.

- `demo-image-policy.yaml`
  - Added annotations to disable prod-automated, changed the filterTags pattern to '^pr-230' for the hmcts.github.com image policy.

- `demo.yaml`
  - Updated the image from 'hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-33dfe63-20250102163110' to 'hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:pr-230' for the java value, and added keyVaults related configurations.