### PR TITLE
Docmosis path rewrite - lower envs

### DIFF
--- a/apps/docmosis/aat/base/docmosis-ingress.yaml
+++ b/apps/docmosis/aat/base/docmosis-ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-rstoapipathrewrite@kubernetescrd
+  name: docmosis-ingress
+  namespace: docmosis
+spec:
+  rules:
+    - host: docmosis.aat.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: docmosis-base
+                port:
+                  number: 80
+            path: /rs
+            pathType: Prefix
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: rstoapipathrewrite
+  namespace: docmosis
+spec:
+  replacePathRegex:
+    regex: '^/rs/(.*)'
+    replacement: '/api/$1'

--- a/apps/docmosis/aat/base/kustomization.yaml
+++ b/apps/docmosis/aat/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
   - ../../../base/slack-provider/aat
 namespace: docmosis
 patches:

--- a/apps/docmosis/demo/base/kustomization.yaml
+++ b/apps/docmosis/demo/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
   - ../../../base/slack-provider/demo
 namespace: docmosis
 patches:

--- a/apps/docmosis/ithc/base/kustomization.yaml
+++ b/apps/docmosis/ithc/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
   - ../../../base/slack-provider/ithc
 namespace: docmosis
 patches:

--- a/apps/docmosis/perftest/base/docmosis-ingress.yaml
+++ b/apps/docmosis/perftest/base/docmosis-ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-rstoapipathrewrite@kubernetescrd
+  name: docmosis-ingress
+  namespace: docmosis
+spec:
+  rules:
+    - host: docmosis.perftest.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: docmosis-base
+                port:
+                  number: 80
+            path: /rs
+            pathType: Prefix
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: rstoapipathrewrite
+  namespace: docmosis
+spec:
+  replacePathRegex:
+    regex: '^/rs/(.*)'
+    replacement: '/api/$1'

--- a/apps/docmosis/perftest/base/kustomization.yaml
+++ b/apps/docmosis/perftest/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
   - ../../../base/slack-provider/perftest
 namespace: docmosis
 patches:

--- a/apps/docmosis/preview/base/docmosis-ingress.yaml
+++ b/apps/docmosis/preview/base/docmosis-ingress.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.middlewares: docmosis-rstoapipathrewrite@kubernetescrd
+  name: docmosis-ingress
+  namespace: docmosis
+spec:
+  rules:
+    - host: docmosis.preview.platform.hmcts.net
+      http:
+        paths:
+          - backend:
+              service:
+                name: docmosis-base
+                port:
+                  number: 80
+            path: /rs
+            pathType: Prefix
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: rstoapipathrewrite
+  namespace: docmosis
+spec:
+  replacePathRegex:
+    regex: '^/rs/(.*)'
+    replacement: '/api/$1'

--- a/apps/docmosis/preview/base/kustomization.yaml
+++ b/apps/docmosis/preview/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - docmosis-secret.yaml
+  - docmosis-ingress.yaml
   - ../../../base/slack-provider/dev
 namespace: docmosis
 patches:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-18049

### Change description
- Adding path rewrite middleware to lower environments to accommodate changes in new version of Docmosis
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created `docmosis-ingress.yaml` in `apps/docmosis/aat/base/` to define Ingress rules for the docmosis application.
- Added `docmosis-ingress.yaml` to the kustomization in `apps/docmosis/aat/base/kustomization.yaml` to include it as a resource for deployment.
- Updated `apps/docmosis/demo/base/kustomization.yaml`, `apps/docmosis/ithc/base/kustomization.yaml`, `apps/docmosis/perftest/base/kustomization.yaml`, and `apps/docmosis/preview/base/kustomization.yaml` to include `docmosis-ingress.yaml` as a resource for deployment.