### PR TITLE
Set notifications scheduler to default config

### DIFF
--- a/apps/ia/ia-case-api/demo.yaml
+++ b/apps/ia/ia-case-api/demo.yaml
@@ -15,8 +15,6 @@ spec:
         POSTGRES_USERNAME: pgadmin
         LOCATION_REF_DATA_URL: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         FEES_REGISTER_API_URL: "http://fees-register-api-demo.service.core-compute-demo.internal"
-        DUMMY_VAR: "true"
-        SAVE_NOTIFICATIONS_DATA_SCHEDULE_HOUR: 18
-        SAVE_NOTIFICATIONS_DATA_SCHEDULE_MAX_MINUTES: 5
+        DUMMY_VAR: "Yes"
       spotInstances:
         enabled: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **demo.yaml**
  - Removed the `SAVE_NOTIFICATIONS_DATA_SCHEDULE_HOUR` and `SAVE_NOTIFICATIONS_DATA_SCHEDULE_MAX_MINUTES` configurations.
  - Updated the `DUMMY_VAR` configuration from \"true\" to \"Yes\".
  - Enabled spotInstances in the configuration.