### PR TITLE
DTSPO-23720 - Patching Traefik to v34.2.0 on sbox

### DIFF
--- a/apps/admin/traefik-crds-upgrade-v34/kustomization.yaml
+++ b/apps/admin/traefik-crds-upgrade-v34/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_traefikservices.yaml

--- a/apps/admin/traefik-crds-upgrade-v34/kustomize.yaml
+++ b/apps/admin/traefik-crds-upgrade-v34/kustomize.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  path: ./apps/admin/traefik-crds-upgrade-v34

--- a/apps/admin/traefik2/sbox-intsvc/00.yaml
+++ b/apps/admin/traefik2/sbox-intsvc/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     deployment:
       additionalVolumes:

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
-chart:
+  chart:
     spec:
       chart: traefik
       # update the crd version in traefik-crds when updating this

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/sbox-intsvc/base/kustomization.yaml
+++ b/clusters/sbox-intsvc/base/kustomization.yaml
@@ -20,3 +20,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/sbox-intsvc/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -21,3 +21,4 @@ patches:
     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
     kind: Kustomization
 - path: ../../../apps/admin/sbox/base/kustomize.yaml
+- path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23720

### Change description

- Patching Traefik to v34.2.0 on sbox

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- In `apps/admin/traefik-crds-upgrade-v34/kustomization.yaml`, a new file is added with resource references to Traefik CRDs for upgrade to v34.
- A new file `apps/admin/traefik-crds-upgrade-v34/kustomize.yaml` is added to specify the path for kustomization with Traefik CRDs upgrade.
- In `apps/admin/traefik2/sbox-intsvc/00.yaml`, the chart version for Traefik is updated to 34.2.0.
- In `apps/admin/traefik2/sbox/00.yaml`, the chart version for Traefik is updated to 34.2.0.
- In `apps/admin/traefik2/sbox/01.yaml`, the chart version for Traefik is updated to 34.2.0.
- In `clusters/sbox-intsvc/base/kustomization.yaml`, path references are updated to include `apps/admin/traefik-crds-upgrade-v34/kustomize.yaml`.
- In `clusters/sbox/base/kustomization.yaml`, path references are updated to include `apps/admin/traefik-crds-upgrade-v34/kustomize.yaml`.