### PR TITLE
DTSPO 23720 - Patching Traefik to v34.2.0 on non-prod

### DIFF
--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/aat/01.yaml
+++ b/apps/admin/traefik2/aat/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/preview/01.yaml
+++ b/apps/admin/traefik2/preview/01.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/aat/base/kustomization.yaml
+++ b/clusters/aat/base/kustomization.yaml
@@ -64,3 +64,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/aat/base/kustomize.yaml
   - path: ../../../apps/admin/aat/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -60,3 +60,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -64,3 +64,4 @@ patches:
   - path: ../../../apps/tax-tribunals/ithc/base/kustomize.yaml
   - path: ../../../apps/neuvector/ithc/base/kustomize.yaml
   - path: ../../../apps/admin/ithc/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -58,3 +58,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/perftest/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -62,3 +62,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/preview/base/kustomize.yaml
   - path: ../../../apps/admin/preview/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23720

### Change description

- Patching Traefik to v34.2.0 on non-prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The AAT, Demo, ITHC, Perftest, and Preview directories under apps/admin/traefik2 have all been updated to include a new version (34.2.0) of the Helm chart for Traefik with a specified source reference.
- The kustomization.yaml files in clusters/aat/base, clusters/demo/base, clusters/ithc/base, clusters/perftest/base, and clusters/preview/base have been modified to include an addition to the path pointing to apps/admin/traefik-crds-upgrade-v34/kustomize.yaml.