### PR TITLE
Reset probate demo back-office to match production.

### DIFF
--- a/apps/probate/probate-back-office/demo-image-policy.yaml
+++ b/apps/probate/probate-back-office/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2987-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
Resets the demo image policy to use the production container.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### File Changed: demo-image-policy.yaml
- Updated the `filterTags` pattern to match a new format for production images, changing from `^pr-2987-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)` 🔄