### PR TITLE
Dtspo 237210 keda packing non prod

### DIFF
--- a/apps/keda/aat/base/kustomization.yaml
+++ b/apps/keda/aat/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/nonprod.yaml

--- a/apps/keda/demo/base/kustomization.yaml
+++ b/apps/keda/demo/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/nonprod.yaml

--- a/apps/keda/keda/nonprod.yaml
+++ b/apps/keda/keda/nonprod.yaml
@@ -7,4 +7,4 @@ spec:
   chart:
     spec:
       chart: keda
-      version: 2.16.1
+      version: 2.16.0

--- a/apps/keda/perftest/base/kustomization.yaml
+++ b/apps/keda/perftest/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/nonprod.yaml

--- a/apps/keda/preview/base/kustomization.yaml
+++ b/apps/keda/preview/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/nonprod.yaml

--- a/apps/keda/ptl-intsvc/base/kustomization.yaml
+++ b/apps/keda/ptl-intsvc/base/kustomization.yaml
@@ -6,4 +6,3 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
-  - path: ../../keda/nonprod.yaml

--- a/apps/keda/ptl-intsvc/base/kustomization.yaml
+++ b/apps/keda/ptl-intsvc/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/nonprod.yaml

--- a/apps/keda/sbox-intsvc/base/kustomization.yaml
+++ b/apps/keda/sbox-intsvc/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/nonprod.yaml


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-23721](https://tools.hmcts.net/jira/browse/DTSPO-23721)

## Description

Keda patching non-prod ITHC to version 2.16.0 by referencing patch file from keda directory to each environment like aat, demo,  perftest, preview, sbox-intsvc and ptl-intsvc. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on ITHC on here https://github.com/hmcts/cnp-flux-config/pull/36606

### Issues Found

N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Deployment Steps

Please provide the steps required to deploy these changes to Azure.

## Additional Information

Please add any other information that is important to this PR, such as screenshots, logs, or links to other related PRs.

confirmed ithc has been tested and on new version

<img width="1080" alt="Screenshot 2025-02-06 at 12 39 10" src="https://github.com/user-attachments/assets/87472244-da7b-460c-b5cd-08ac3793eb9b" />











## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/keda/aat/base/kustomization.yaml`:
  - Added `keda/nonprod.yaml` as a patch.

- `apps/keda/demo/base/kustomization.yaml`:
  - Added `keda/nonprod.yaml` as a patch.

- `apps/keda/keda/nonprod.yaml`:
  - Changed the version of the chart to 2.16.0.

- `apps/keda/perftest/base/kustomization.yaml`:
  - Added `keda/nonprod.yaml` as a patch.

- `apps/keda/preview/base/kustomization.yaml`:
  - Added `keda/nonprod.yaml` as a patch.

- `apps/keda/sbox-intsvc/base/kustomization.yaml`:
  - Added `keda/nonprod.yaml` as a patch.