### PR TITLE
Update Camunda to use the temp ACR

### DIFF
--- a/apps/camunda/camunda-api/camunda-api.yaml
+++ b/apps/camunda/camunda-api/camunda-api.yaml
@@ -10,7 +10,7 @@ spec:
       autoscaling:
         enabled: false
       useInterpodAntiAffinity: true
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:camunda"}
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:camunda"}
       ingressHost: camunda-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
       environment:
         CAMUNDA_API_AUTH_ENABLED: false

--- a/apps/camunda/camunda-ui/camunda-ui.yaml
+++ b/apps/camunda/camunda-ui/camunda-ui.yaml
@@ -8,7 +8,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:camunda"}
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:camunda"}
       ingressHost: camunda-bpm.{{ .Values.global.environment }}.platform.hmcts.net
       ingressSessionAffinity:
         enabled: true

--- a/apps/camunda/camunda/image-repo.yaml
+++ b/apps/camunda/camunda/image-repo.yaml
@@ -3,6 +3,6 @@ kind: ImageRepository
 metadata:
   name: camunda
   annotations:
-    hmcts.github.com/image-registry: hmctsprivate
+    hmcts.github.com/image-registry: hmctsprivatetemp
 spec:
-  image: hmctsprivate.azurecr.io/camunda/bpm
+  image: hmctsprivatetemp.azurecr.io/camunda/bpm


### PR DESCRIPTION
### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

Update Camunda to use the temp ACR

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/camunda/camunda-api/camunda-api.yaml
- Updated the image repository from `hmctsprivate.azurecr.io` to `hmctsprivatetemp.azurecr.io`.
  
### apps/camunda/camunda-ui/camunda-ui.yaml
- Updated the image repository from `hmctsprivate.azurecr.io` to `hmctsprivatetemp.azurecr.io`.

### apps/camunda/camunda/image-repo.yaml
- Updated the image repository from `hmctsprivate` to `hmctsprivatetemp`.