### PR TITLE
[NFDIV-4403] Turn on service request migration in prod

### DIFF
--- a/apps/nfdiv/nfdiv-cron-create-service-request/aat.yaml
+++ b/apps/nfdiv/nfdiv-cron-create-service-request/aat.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      suspend: false
+      suspend: true
       schedule: 0,30 * * * *
     global:
       jobKind: CronJob

--- a/apps/nfdiv/nfdiv-cron-create-service-request/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-create-service-request/prod.yaml
@@ -5,9 +5,12 @@ metadata:
 spec:
   values:
     job:
-      suspend: true
+      suspend: false
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
+        CCD_SEARCH_MAX_RESULTS: 10
+        CCD_SEARCH_PAGE_SIZE: 100
+      schedule: 0 * * * *
     global:
       jobKind: CronJob
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/NFDIV-4403

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `nfdiv-cron-create-service-request/aat.yaml`:
  - Changed the `suspend` value from `false` to `true` for the job schedule.
- `nfdiv-cron-create-service-request/prod.yaml`:
  - Changed the `suspend` value from `true` to `false` for the job schedule.
  - Added environment variables: `IDAM_API_BASEURL`, `CCD_SEARCH_MAX_RESULTS`, and `CCD_SEARCH_PAGE_SIZE`.
  - Updated the schedule to `0 * * * *`.