### PR TITLE
CUIRA-382 Remove ITHC configurations to test DR.

### DIFF
--- a/apps/cui/ithc/base/kustomization.yaml
+++ b/apps/cui/ithc/base/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../../base
-  - ../../../rbac/nonprod-role.yaml
-  - ../../../base/slack-provider/ithc
-namespace: cui
-patches:
-  - path: ../../serviceaccount/ithc.yaml

--- a/apps/cui/serviceaccount/ithc.yaml
+++ b/apps/cui/serviceaccount/ithc.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: ${NAMESPACE}
-  namespace: ${NAMESPACE}
-  annotations:
-    azure.workload.identity/client-id: "4f23720c-451d-4385-88f6-80a14c2b69f3"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CUIRA-382
### Change description
Remove CUIRA ITHC configs to simulate disaster recovery


- Removed `kustomization.yaml` in `apps/cui/ithc/base`
- Removed `serviceaccount/ithc.yaml` in `apps/cui`