### PR TITLE
Update botkube to latest version: 1.14.0

### DIFF
--- a/apps/monitoring/botkube/botkube.yaml
+++ b/apps/monitoring/botkube/botkube.yaml
@@ -19,7 +19,7 @@ spec:
       name: "botkube-values"
   values:
     image:
-      tag: v1.10.0
+      tag: v1.14.0
     settings:
       clusterName: cft-${CLUSTER_FULL_NAME}-aks
       upgradeNotifier: false


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24045

### Change description
Botkube is not running on the prod00 and 01 clusters anymore, it seems like it might be out of date
Current version is 1.10.0 from 8th April 2024
Lates version is 1.14.0 from 13th November 2024

### Testing done
N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed file: botkube.yaml
- Updated the image tag from v1.10.0 to v1.14.0 for the BotKube application.