### PR TITLE
Revert "AAT: Switch sscs-tribunals-api to acr chart 0.0.178"

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -57,11 +57,3 @@ spec:
         HMC_DEPLOYMENT_FILTER_ENABLED: false
         AMQP_RECONNECT_ON_EXCEPTION: true
         # HMC_DEPLOYMENT_ID: "deployment-sscs-tribunals-api-aat"
-  chart:
-    spec:
-      chart: sscs-tribunals-api
-      version: 0.0.178
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic-oci
-        namespace: flux-system


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#36792

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/sscs/sscs-tribunals-api/aat.yaml
- Removed chart information related to sscs-tribunals-api from the file.