### PR TITLE
Deploy idam-web-public's latest image to lower environments

### DIFF
--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-772a5e1-20250214092937
+      image: hmctspublic.azurecr.io/idam/web-public:prod-7da7236-20250214161440
       ingressHost: idam-web-public.aat.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-772a5e1-20250214092937
+      image: hmctspublic.azurecr.io/idam/web-public:prod-7da7236-20250214161440
       replicas: 1
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-772a5e1-20250214092937
+      image: hmctspublic.azurecr.io/idam/web-public:prod-7da7236-20250214161440
       ingressHost: idam-web-public.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-772a5e1-20250214092937
+      image: hmctspublic.azurecr.io/idam/web-public:prod-7da7236-20250214161440
       replicas: 2
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-772a5e1-20250214092937
+      image: hmctspublic.azurecr.io/idam/web-public:prod-7da7236-20250214161440
       ingressHost: idam-web-public.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1


### PR DESCRIPTION
### Jira link
N/A

### Change description
No functional changes - only reverting testing dependencies to older versions.


### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- aat.yaml: The image version for the Java application has been updated to prod-7da7236-20250214161440 in the aat environment.
- demo.yaml: The image version for the Java application has been updated to prod-7da7236-20250214161440 in the demo environment.
- ithc.yaml: The image version for the Java application has been updated to prod-7da7236-20250214161440 in the ithc environment.
- perftest.yaml: The image version for the Java application has been updated to prod-7da7236-20250214161440 in the perftest environment.
- sbox.yaml: The image version for the Java application has been updated to prod-7da7236-20250214161440 in the sandbox environment. Additionally, Traefik TLS has been disabled.