### PR TITLE
Fix idam api url in draft order overdue cron

### DIFF
--- a/apps/financial-remedy/finrem-cron-draft-order-review-overdue/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-draft-order-review-overdue/prod/prod.yaml
@@ -20,6 +20,8 @@ spec:
         FEATURE_CASEWORKER_NOC: true
         FEATURE_CFV_ENABLED: true
         SECURE_DOC_ENABLED: false
+        IDAM_API_URL: https://idam-api.platform.hmcts.net
+        IDAM_API_REDIRECT_URL: https://www.financial-remedy.reform.hmcts.net/oauth2/callback
         DOCUMENT_MANAGEMENT_STORE_URL: http://dm-store-prod.service.core-compute-prod.internal
         SEND_LETTER_SERVICE_BASEURL: http://rpe-send-letter-service-prod.service.core-compute-prod.internal
         CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-prod.service.core-compute-prod.internal


### PR DESCRIPTION
### Change description

Fix idam api url in draft order overdue cron



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/financial-remedy/finrem-cron-draft-order-review-overdue/prod/prod.yaml
- Added new environment variables `IDAM_API_URL` and `IDAM_API_REDIRECT_URL`.
- Updated the environment variable `SECURE_DOC_ENABLED` from `true` to `false`.