### PR TITLE
DTSPO-24156 - add missing file to sbox base

### DIFF
--- a/apps/monitoring/sbox/base/kustomization.yaml
+++ b/apps/monitoring/sbox/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - ../../version-reporter/platopsapps/platops-apps.yaml
 - ../../version-reporter/helmcharts/helm-charts.yaml
 - prometheus-values.yaml
+- ../../botkube
 
 patches:
 - path: ../../kube-prometheus-stack/empty-nodelocaldns-alert-rules.yaml


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-24156](https://tools.hmcts.net/jira/browse/DTSPO-24156)

### Change description

Add missing file to reference sbox base file to install botkube. See previous PR here https://github.com/hmcts/cnp-flux-config/pull/36911

- [ ] Bug fix (non-breaking change which fixes an issue)a
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Install botkube on cft sbox  00 cluster 

### Issues Found

missing file to reference botkube deployment

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Deployment Steps

Please provide the steps required to deploy these changes to Azure.

## Additional Information

Please add any other information that is important to this PR, such as screenshots, logs, or links to other related PRs.

https://github.com/hmcts/cnp-flux-config/pull/36880



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created new file `apps/monitoring/sbox/00/botkube-values.enc.yaml` which contains encrypted data for `botkube-values`
- Added `botkube-values.enc.yaml` to `apps/monitoring/sbox/00/kustomization.yaml` for deployment
- Added `botkube-values.enc.yaml` encryption and version details to the file