### PR TITLE
DTSPO24156 - add rbac to cluster role and disable kubernetes info event 

### DIFF
--- a/apps/monitoring/botkube/botkube-clusterrole.yaml
+++ b/apps/monitoring/botkube/botkube-clusterrole.yaml
@@ -4,8 +4,8 @@ metadata:
   name: botkube-clusterrole
 rules:
   - apiGroups: [""]
-    resources: ["pods/log", "secrets"]
-    verbs: []
+    resources: ["events", "namespaces", "nodes", "pods", "services", "daemonsets", "deployments", "ingresses", "replicasets", "jobs", "configmaps", "helmreleases"]
+    verbs: ["get", "watch", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/apps/monitoring/botkube/botkube.yaml
+++ b/apps/monitoring/botkube/botkube.yaml
@@ -82,7 +82,7 @@ spec:
       'k8s-all-events':
         displayName: "Kubernetes Info"
         botkube/kubernetes:
-          enabled: true
+          enabled: false
           config:
             filters:
               objectAnnotationChecker: true


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-24156](https://tools.hmcts.net/jira/browse/DTSPO-24156)

### Change description

Add missing file to reference sbox base file to install botkube. See previous PR here https://github.com/hmcts/cnp-flux-config/pull/36911

- [ ] Bug fix (non-breaking change which fixes an issue)a
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Install botkube on cft sbox  00 cluster  and fix issue with below. added rbac to cluster role to exclude secrets and logs as wanted to deny them and block access to kuberentes event 

### Issues Found

monitoring  ClusterRole/botkube-clusterrole dry-run failed (Invalid): ClusterRole.rbac.authorization.k8s.io "botkube-clusterrole" is invalid: rules[0].verbs: Required value: verbs must contain at least one value...
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Deployment Steps

Please provide the steps required to deploy these changes to Azure.

## Additional Information

Please add any other information that is important to this PR, such as screenshots, logs, or links to other related PRs.

https://github.com/hmcts/cnp-flux-config/pull/36931


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created new file `apps/monitoring/sbox/00/botkube-values.enc.yaml` which contains encrypted data for `botkube-values`
- Added `botkube-values.enc.yaml` to `apps/monitoring/sbox/00/kustomization.yaml` for deployment
- Added `botkube-values.enc.yaml` encryption and version details to the file