### PR TITLE
Remove groups requirement for eJudiciary SSO

### DIFF
--- a/apps/idam/idam-api/aat.yaml
+++ b/apps/idam/idam-api/aat.yaml
@@ -33,8 +33,8 @@ spec:
         SSL_TRUST_HOSTNAMES_1: forgerock-am.service.core-compute-idam-aat2.internal
         SSL_TRUST_HOSTNAMES_2: forgerock-idm.service.core-compute-idam-aat.internal
         SSL_TRUST_HOSTNAMES_3: forgerock-am.service.core-compute-idam-aat.internal
-        STRATEGIC_SSO_PROVIDERS_EJUDICIARY_USERINFOENDPOINT: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
         STRATEGIC_SSO_PROVIDERS_EJUDICIARY_REQUIREDATTRIBUTES:
+        STRATEGIC_SSO_PROVIDERS_EJUDICIARY_USERINFOENDPOINT: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
         STRATEGIC_SSO_PROVIDERS_MOJ_USERINFOENDPOINT: https://login.windows.net/34c125c9-c7f3-486f-a78c-cf762c718831/openid/userinfo
         STRATEGIC_PULLREQUESTREWRITE_CLIENTS_0: ALL
         LOG_AND_AUDIT_IDAM_ENABLED: true

--- a/apps/idam/idam-api/aat.yaml
+++ b/apps/idam/idam-api/aat.yaml
@@ -34,6 +34,7 @@ spec:
         SSL_TRUST_HOSTNAMES_2: forgerock-idm.service.core-compute-idam-aat.internal
         SSL_TRUST_HOSTNAMES_3: forgerock-am.service.core-compute-idam-aat.internal
         STRATEGIC_SSO_PROVIDERS_EJUDICIARY_USERINFOENDPOINT: https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo
+        STRATEGIC_SSO_PROVIDERS_EJUDICIARY_REQUIREDATTRIBUTES:
         STRATEGIC_SSO_PROVIDERS_MOJ_USERINFOENDPOINT: https://login.windows.net/34c125c9-c7f3-486f-a78c-cf762c718831/openid/userinfo
         STRATEGIC_PULLREQUESTREWRITE_CLIENTS_0: ALL
         LOG_AND_AUDIT_IDAM_ENABLED: true


### PR DESCRIPTION
### Jira link
N/A

### Change description
Remove the requirement for test SSO users to belong to a specific AAD group when doing eJudiciary SSO.

### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/idam-api/aat.yaml
- Added a new environment variable `STRATEGIC_SSO_PROVIDERS_EJUDICIARY_REQUIREDATTRIBUTES` with the value of `STRATEGIC_SSO_PROVIDERS_EJUDICIARY_USERINFOENDPOINT` set to `https://login.windows.net/723e4557-2f17-43ed-9e71-f1beb253e546/openid/userinfo`.