### PR TITLE
Change tier of postgres flexible server

### DIFF
--- a/apps/azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+++ b/apps/azureserviceoperator-system/resources/flexibleserver-postgres.yaml
@@ -16,8 +16,8 @@ spec:
   owner:
     name: ${NAMESPACE}-aso-${ENVIRONMENT}-rg
   sku:
-    name: Standard_B2s
-    tier: Burstable
+    name: Standard_D2ds_v5
+    tier: GeneralPurpose
   administratorLogin: hmcts
   administratorLoginPassword:
     name: postgres


### PR DESCRIPTION
### Change description

Postgres server is currently not working in preview.
Copying this change https://github.com/hmcts/sds-flux-config/pull/5727 in order to fix it as requested by @NickAzureDevops 


### Checklist

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/azureserviceoperator-system/resources/flexibleserver-postgres.yaml
- Updated the `sku` section, changing `name` from `Standard_B2s` to `Standard_D2ds_v5` and `tier` from `Burstable` to `GeneralPurpose`.