### PR TITLE
Updating pact-broker prod to release 0.12.0

### DIFF
--- a/apps/pact-broker/pact-broker/pact-broker.yaml
+++ b/apps/pact-broker/pact-broker/pact-broker.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: pact-broker
-      version: 0.11.1
+      version: 0.12.0
       sourceRef:
         kind: HelmRepository
         name: hmctspublic-oci

--- a/apps/pact-broker/pact-broker/sbox-intsvc.yaml
+++ b/apps/pact-broker/pact-broker/sbox-intsvc.yaml
@@ -8,11 +8,3 @@ spec:
     ingressHost: pact-broker.sandbox.platform.hmcts.net
     postgresqlHost: cft-pact-broker-ptlsbox.postgres.database.azure.com
     vaultName: cftsbox-intsvc
-  chart:
-    spec:
-      chart: pact-broker
-      version: 0.12.0
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic-oci
-        namespace: flux-system


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23736

### Change description
Updating pact-broker prod to release 0.12.0 and removing the block on non-prod that specifies the release for non-prod.

### Testing done
non-prod was updated last week with no issues and the same process has been followed multiple times. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


The following changes were made in this pull request:

- `pact-broker.yaml`:
  - Updated the version of the Pact Broker chart from 0.11.1 to 0.12.0.

- `sbox-intsvc.yaml`:
  - Removed the Pact Broker chart version update from 0.12.0
  - Removed the vaultName configuration related to cftsbox-intsvc.