### PR TITLE
DTSAM-492 RAS enable Testing Support EV flag in AAT

### DIFF
--- a/apps/am/am-role-assignment-service/aat.yaml
+++ b/apps/am/am-role-assignment-service/aat.yaml
@@ -11,6 +11,7 @@ spec:
       environment:
         AM_INFO: false
         APPLICATION_LOGGING_LEVEL: INFO
+        TESTING_SUPPORT_ENABLED: true
         BYPASS_ORG_DROOL_RULE: true
         DB_FEATURE_FLAG_ENABLE: all_wa_services_case_allocator_1_0
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api


### PR DESCRIPTION
### Jira link

   [DTSAM-492](https://tools.hmcts.net/jira/browse/DTSAM-492) _"Decommission Launch Darkly RAS"_

### Change description

Set `TESTING_SUPPORT_ENABLED` to true in RAS AAT in advance of deployment of hmcts/am-role-assignment-service#2334.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `aat.yaml`:
  - Added `TESTING_SUPPORT_ENABLED: true` to the environment variables.