### PR TITLE
Add hmc AAT topic for managing only subscriptions in preview

### DIFF
--- a/apps/pcs/preview/aso/hmc-servicebus-namespace.yaml
+++ b/apps/pcs/preview/aso/hmc-servicebus-namespace.yaml
@@ -1,0 +1,21 @@
+apiVersion: servicebus.azure.com/v1api20211101
+kind: Namespace
+metadata:
+  name: hmc-servicebus-aat
+  namespace: pcs
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
+spec:
+  tags:
+    builtFrom: https://github.com/hmcts/cnp-flux-config
+    businessArea: CFT
+    environment: development
+    app.kubernetes.io_name: ccd
+    application: core-case-data
+  location: uksouth
+  owner:
+    name: hmc-shared-aat
+  azureName: hmc-servicebus-aat
+  sku:
+    name: Standard
+  zoneRedundant: false

--- a/apps/pcs/preview/aso/hmc-servicebus-rg.yaml
+++ b/apps/pcs/preview/aso/hmc-servicebus-rg.yaml
@@ -1,0 +1,10 @@
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: hmc-shared-aat
+  namespace: pcs
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
+spec:
+  location: uksouth
+  azureName: hmc-shared-aat

--- a/apps/pcs/preview/aso/hmc-to-cft-topic.yaml
+++ b/apps/pcs/preview/aso/hmc-to-cft-topic.yaml
@@ -1,0 +1,11 @@
+apiVersion: servicebus.azure.com/v1api20211101
+kind: NamespacesTopic
+metadata:
+  name: hmc-to-cft-aat
+  namespace: pcs
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
+spec:
+  owner:
+    name: hmc-servicebus-aat
+  azureName: hmc-to-cft-aat

--- a/apps/pcs/preview/base/kustomization.yaml
+++ b/apps/pcs/preview/base/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../aso/hmc-servicebus-rg.yaml
+  - ../aso/hmc-servicebus-namespace.yaml
+  - ../aso/hmc-to-cft-topic.yaml
 namespace: pcs
 patches:
   - path: ../../serviceaccount/aat.yaml


### PR DESCRIPTION
This is a prerequisite to prove implementation work with dynamically creating subscriptions only on existing topic with correlationfilters.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Added new files `hmc-servicebus-namespace.yaml`, `hmc-servicebus-rg.yaml`, and `hmc-to-cft-topic.yaml` under the directory `apps/pcs/preview/aso/` 📄
- Updated `kustomization.yaml` to include the newly added YAML files for `hmc-servicebus` 🔄