### PR TITLE
DIAC-941 DB does not exist in Preview - flexible postgress server tie…

### DIFF
--- a/apps/ia/preview/aso/ia-postgres.yaml
+++ b/apps/ia/preview/aso/ia-postgres.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   version: "14"
   sku:
-    name: Standard_B4ms
-    tier: Burstable
+    name: Standard_D2ds_v5
+    tier: GeneralPurpose


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-941

### Change description
DIAC-941 DB does not exist in Preview - flexible postgress server name and tier changed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **apps/ia/preview/aso/ia-postgres.yaml**
  - Changed the `sku` from `Standard_B4ms` to `Standard_D2ds_v5` and added `tier: GeneralPurpose`.