### PR TITLE
Test custom renovate config on sbox vm agents

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -115,7 +115,7 @@ spec:
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
                           galleryImageDefinition: "jenkins-ubuntu"
-                          #renovate: datasource=github-tags depName=hmcts/jenkins-pacler extractVersion=^1.4.(?<version>.*)$ versioning=regex:^(?<minor>\d+d+d+)$
+                          #renovate: datasource=github-tags depName=hmcts/jenkins-packer extractVersion=^1.4.(?<version>\d+)$ versioning=regex:^(?<minor>\d+)$
                           galleryImageVersion: "1.4.222"
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -115,6 +115,7 @@ spec:
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
                           galleryImageDefinition: "jenkins-ubuntu"
+                          #renovate: datasource=github-tags depName=hmcts/jenkins-pacler extractVersion=^1.4.(?<version>.*)$ versioning=regex:^(?<minor>\d+d+d+)$
                           galleryImageVersion: "1.4.222"
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"


### PR DESCRIPTION
### Jira link

[DTSPO-23931](https://tools.hmcts.net/jira/browse/DTSPO-23931)

### Change description

During testing of new jenkins-packer versions, we want to prevent renovate from autoupdating to the new naming convention as the new versions are not fully working.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
