### PR TITLE
Revert "Test custom renovate config on sbox vm agents"

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -115,7 +115,6 @@ spec:
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
                           galleryImageDefinition: "jenkins-ubuntu"
-                          #renovate: datasource=github-tags depName=hmcts/jenkins-packer extractVersion=^1.4.(?<version>\d+)$ versioning=regex:^(?<minor>\d+)$
                           galleryImageVersion: "1.4.222"
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#36989

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `jenkins-azure-vm-agent.yaml` had the `galleryImageVersion` field removed in this pull request.