### PR TITLE
DTSAM-547 Enable `privatelaw_hearing_1_0` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: privatelaw_wa_1_5
+        DB_FEATURE_FLAG_ENABLE: privatelaw_hearing_1_0
         REFRESH_JOB: LEGAL_OPERATIONS-PRIVATELAW-NEW-0-73
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

   [DTSAM-547](https://tools.hmcts.net/jira/browse/DTSAM-547) _"Enable 'privatelaw_hearing_1_0' ORM flag in Demo environment and refresh users ready for PRIVATELAW to test"_

### Change description

Enable `privatelaw_hearing_1_0` ORM flag in Demo ready for PRIVATELAW to test


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_



- The `demo.yaml` file in `am-org-role-mapping-service` app has been modified.
- The `DB_FEATURE_FLAG_ENABLE` environment variable has been updated from `privatelaw_wa_1_5` to `privatelaw_hearing_1_0`.
```