### PR TITLE
Reverting back to hmctsprivatetemp

### DIFF
--- a/apps/camunda/camunda-api/camunda-api.yaml
+++ b/apps/camunda/camunda-api/camunda-api.yaml
@@ -10,7 +10,7 @@ spec:
       autoscaling:
         enabled: false
       useInterpodAntiAffinity: true
-      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:camunda"}
       ingressHost: camunda-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
       environment:
         CAMUNDA_API_AUTH_ENABLED: false

--- a/apps/camunda/camunda-api/demo.yaml
+++ b/apps/camunda/camunda-api/demo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-c906008-20250226103724 #{"$imagepolicy": "flux-system:camunda"}
       environment:
         CAMUNDA_DB_HOST: "hmcts-camunda-v14-flexible-{{ .Values.global.environment }}.postgres.database.azure.com"
         CAMUNDA_DB_USER_NAME: "camundaadmin"

--- a/apps/camunda/camunda-api/ithc.yaml
+++ b/apps/camunda/camunda-api/ithc.yaml
@@ -11,4 +11,3 @@ spec:
         CAMUNDA_HISTORY_CLEANUP_START_TIME: "12:00+0100"
         CAMUNDA_HISTORY_CLEANUP_END_TIME: "14:00+0100"
         CAMUNDA_HISTORY_CLEANUP_STRATEGY: "removalTimeBased"
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-c906008-20250226103724 #{"$imagepolicy": "flux-system:camunda"}

--- a/apps/camunda/camunda-api/perftest.yaml
+++ b/apps/camunda/camunda-api/perftest.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-c906008-20250226103724 #{"$imagepolicy": "flux-system:perftest-camunda"}
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:perftest-camunda"}
       memoryRequests: '2Gi'
       memoryLimits: '4Gi'
       cpuRequests: '1'

--- a/apps/camunda/camunda-ui/camunda-ui.yaml
+++ b/apps/camunda/camunda-ui/camunda-ui.yaml
@@ -8,7 +8,7 @@ spec:
     java:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402
+      image: hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402 #{"$imagepolicy": "flux-system:camunda"}
       ingressHost: camunda-bpm.{{ .Values.global.environment }}.platform.hmcts.net
       ingressSessionAffinity:
         enabled: true

--- a/apps/camunda/camunda-ui/ithc.yaml
+++ b/apps/camunda/camunda-ui/ithc.yaml
@@ -6,4 +6,3 @@ spec:
   values:
     java:
       ingressClass: traefik
-      image: hmctsprivate.azurecr.io/camunda/bpm:prod-c906008-20250226103724 #{"$imagepolicy": "flux-system:camunda"}

--- a/apps/camunda/camunda/image-repo.yaml
+++ b/apps/camunda/camunda/image-repo.yaml
@@ -3,6 +3,6 @@ kind: ImageRepository
 metadata:
   name: camunda
   annotations:
-    hmcts.github.com/image-registry: hmctsprivate
+    hmcts.github.com/image-registry: hmctsprivatetemp
 spec:
-  image: hmctsprivate.azurecr.io/camunda/bpm
+  image: hmctsprivatetemp.azurecr.io/camunda/bpm


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24378

### Change description
- Confirmed `hmctsprivate` registry and image automation working
- Reverting to keep environments consistent
- Will redo along with other envs as part of CR on Monday night
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- camunda-api.yaml:
  - Changed the image from `hmctsprivate.azurecr.io/camunda/bpm:prod-c906008-20250226103724` to `hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402`

- demo.yaml:
  - Updated the value for the environment variable `CAMUNDA_DB_HOST`

- ithc.yaml:
  - Removed the image configuration

- perftest.yaml:
  - Changed the image from `hmctsprivate.azurecr.io/camunda/bpm:prod-c906008-20250226103724` to `hmctsprivatetemp.azurecr.io/camunda/bpm:prod-700cced-20250123072402`
  - Updated memory and CPU requests

- camunda-ui.yaml:
  - Updated image configuration

- ithc.yaml:
  - Removed the image configuration

- image-repo.yaml:
  - Updated the image registry from `hmctsprivate` to `hmctsprivatetemp`