### PR TITLE
DTSPO-24310: Removing aadpodidentity from sbox

### DIFF
--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-- aks-sops-aadpodidentity.yaml
-patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
+#- aks-sops-aadpodidentity.yaml
+# patches:
+# - path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Removing kustomize-controller-patch.yaml from sbox
- Removing aadpodidentity from sbox to test whether it is still required.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/sbox/base/kustomization.yaml
- Removed the file `aks-sops-aadpodidentity.yaml`.
- Removed a patch for `kustomize-controller-patch.yaml`.