### PR TITLE
Revert "DTSPO-24310: Removing aadpodidentity from sbox"

### DIFF
--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-#- aks-sops-aadpodidentity.yaml
-# patches:
-# - path: ../../base/patches/kustomize-controller-patch.yaml
+- aks-sops-aadpodidentity.yaml
+patches:
+- path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37051

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/sbox/base/kustomization.yaml
- Removed the line `- ././base/gotk-components.yaml`
- Added the line `aks-sops-aadpodidentity.yaml`
- Added a patch for `kustomize-controller-patch.yaml` at the specified path