### PR TITLE
DTSPO-24310: Removing aadpodidentity from sbox for logs

### DIFF
--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-- aks-sops-aadpodidentity.yaml
-patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
+#- aks-sops-aadpodidentity.yaml
+# patches:
+# - path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
**Jira link**

https://tools.hmcts.net/jira/browse/DTSPO-24310

**Change description**

Removing kustomize-controller-patch.yaml from sbox
Removing aadpodidentity from sbox to test whether it is still required.


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


md
- The file `kustomization.yaml` in the `flux-system/sbox/base` directory has been modified.
- The change involves removing the file `aks-sops-aadpodidentity.yaml` from the list of resources and removing a patch file `kustomize-controller-patch.yaml`.
```