### PR TITLE
CRF-12: Set other references to key vault in demo

### DIFF
--- a/apps/civil/civil-rtl-export/demo.yaml
+++ b/apps/civil/civil-rtl-export/demo.yaml
@@ -16,6 +16,14 @@ spec:
         # Temporarily set up references to key vault secrets to allow testing of pull request
         civil-rtl-export:
           secrets:
+            - name: civil-rtl-export-appinsights-connection-string
+              alias: APPINSIGHTS_CONNECTION_STRING
+            - name: civil-rtl-export-POSTGRES-USER-V15
+              alias: JF_DB_USERNAME
+            - name: civil-rtl-export-POSTGRES-PASS-V15
+              alias: JF_DB_PASSWORD
+            - name: civil-rtl-export-POSTGRES-HOST-V15
+              alias: JF_DB_HOST
             - name: civil-rtl-export-service-s2s-secret
               alias: CIVIL_RTL_EXPORT_S2S_KEY
             - name: civil-rtl-export-idam-client-secret


### PR DESCRIPTION
### Jira link
See [CRF-12](https://tools.hmcts.net/jira/browse/CRF-12)

### Change description
Temporarily set up references to other key vault secrets in demo to allow testing of pull request.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


The file `demo.yaml` in `apps/civil/civil-rtl-export` has been modified to add new secrets for the Civil RTL Export service:
- Added a new secret `civil-rtl-export-appinsights-connection-string` with alias `APPINSIGHTS_CONNECTION_STRING`.
- Added a new secret `civil-rtl-export-POSTGRES-USER-V15` with alias `JF_DB_USERNAME`.
- Added a new secret `civil-rtl-export-POSTGRES-PASS-V15` with alias `JF_DB_PASSWORD`.
- Added a new secret `civil-rtl-export-POSTGRES-HOST-V15` with alias `JF_DB_HOST`.