### PR TITLE
FPVTL-54: Move case ids to prepare for heaaring to allow Service of Application

### DIFF
--- a/apps/private-law/prl-ccd-case-migration/prod/00.yaml
+++ b/apps/private-law/prl-ccd-case-migration/prod/00.yaml
@@ -6,9 +6,9 @@ spec:
   releaseName: prl-ccd-case-migration
   values:
     job:
-      schedule: "30 10 26 02 *"
+      schedule: "15 11 03 03 *"
       image: hmctspublic.azurecr.io/prl/ccd-case-migration:prod-c0eb6d6-20250303100107 #{"$imagepolicy": "flux-system:prl-ccd-case-migration"}
       environment:
         MIGRATION_ENABLED: true
-        MIGRATION_CASE_IDS: "1734374821838612,1738847462153934"
+        MIGRATION_CASE_IDS: "1736786715359355,1738017674336178,1738017838906841"
         IDAM_API_URL: https://idam-api.platform.hmcts.net


### PR DESCRIPTION
### Jira link

See [FPVTL-54](https://tools.hmcts.net/jira/browse/FPVTL-54)

### Change description

3 cases in production ended up in a state that does not allow Service of Application.
The changes are a migration of case state to prepare for hearing so Service of Application can be performed.
No case data changes. 

### Testing done

Details of the testing procedure and PO approval can be found in the Jira ticket linked above

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/private-law/prl-ccd-case-migration/prod/00.yaml
- Updated job schedule from \"30 10 26 02 *\" to \"15 11 03 03 *\"
- Updated MIGRATION_CASE_IDS from \"1734374821838612,1738847462153934\" to \"1736786715359355,1738017674336178,1738017838906841\"