### PR TITLE
DTSPO-24310: Update patches for Workload Identity on sbox

### DIFF
--- a/apps/flux-system/base/kustomize.yaml
+++ b/apps/flux-system/base/kustomize.yaml
@@ -14,4 +14,3 @@ spec:
   postBuild:
     substitute:
       NAMESPACE: "flux-system"
-      WI_NAME: aks

--- a/apps/flux-system/base/patches/workload-identity-deployment-patch.yaml
+++ b/apps/flux-system/base/patches/workload-identity-deployment-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  labels:
+    azure.workload.identity/use: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        azure.workload.identity/use: "true"

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
 - ../../base/gotk-components.yaml
 - ../workload-identity
 patches:
-- ../../serviceaccount/sbox.yaml
-- ../../base/patches/workload-identity-deployment-patch.yaml
+- path: ../../serviceaccount/sbox.yaml
+- path: ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
 - ../../base
 - ../../base/gotk-components.yaml
 - ../workload-identity
+patches:
 - ../../serviceaccount/sbox.yaml
+- ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/sbox/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/flux-system/sbox/workload-identity/workload-identity-federated-credential.yaml
@@ -1,12 +1,12 @@
 apiVersion: managedidentity.azure.com/v1api20220131preview
 kind: FederatedIdentityCredential
 metadata:
-  name: ${WI_NAME}-${WI_CLUSTER}-fic
+  name: aks-${WI_CLUSTER}-fic
   namespace: ${NAMESPACE}
 spec:
   owner:
-    name: ${WI_NAME}-${ENVIRONMENT}-mi
+    name: aks-${ENVIRONMENT}-mi
   audiences:
     - api://AzureADTokenExchange
   issuer: ${ISSUER_URL}
-  subject: system:serviceaccount:${NAMESPACE}:${NAMESPACE}
+  subject: system:serviceaccount:${NAMESPACE}:kustomize-controller

--- a/apps/flux-system/sbox/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/flux-system/sbox/workload-identity/workload-identity-ua-identity.yaml
@@ -1,7 +1,7 @@
 apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
-  name: ${WI_NAME}-${ENVIRONMENT}-mi
+  name: aks-${ENVIRONMENT}-mi
   namespace: ${NAMESPACE}
   annotations:
     serviceoperator.azure.com/reconcile-policy: skip

--- a/apps/flux-system/serviceaccount/sbox.yaml
+++ b/apps/flux-system/serviceaccount/sbox.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     azure.workload.identity/client-id: "96775d73-e4f3-49ee-8bb6-f8660a19ba85"
   labels:
-          azure.workload.identity/use: "true"
+    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/sbox.yaml
+++ b/apps/flux-system/serviceaccount/sbox.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kustomize-controller
-  namespace: ${NAMESPACE}
+  namespace: flux-system
   annotations:
     azure.workload.identity/client-id: "96775d73-e4f3-49ee-8bb6-f8660a19ba85"
   labels:

--- a/apps/flux-system/serviceaccount/sbox.yaml
+++ b/apps/flux-system/serviceaccount/sbox.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${NAMESPACE}
+  name: kustomize-controller
   namespace: ${NAMESPACE}
   annotations:
     azure.workload.identity/client-id: "96775d73-e4f3-49ee-8bb6-f8660a19ba85"
+  labels:
+          azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changes should only affect sbox.
- Removed WI_NAME and hardcoded "aks" to fix error mapping values in '${WI_NAME}-${WI_CLUSTER}-fic'.
- Added deployment patch for workload identity as per [these instructions](https://fluxcd.io/flux/components/kustomize/kustomizations/#workload-identity).
- Added service account patch to "patches" rather than resources.
- Added label to use workload identity to service account patch.
- Changed NAMESPACE to kustomize-controller in workload-identity-federated-credential.yaml to ensure the name of the service accounts match.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Added
- **apps/flux-system/base/patches/workload-identity-deployment-patch.yaml**
  - Added a new patch file for workload identity deployment.

### Modified
- **apps/flux-system/base/kustomize.yaml**
  - Removed the WI_NAME: \"aks\" entry.
- **apps/flux-system/sbox/base/kustomization.yaml**
  - Added path to the new patch file for workload identity deployment.
- **apps/flux-system/sbox/workload-identity/workload-identity-federated-credential.yaml**
  - Replaced ${WI_NAME} with \"aks\" in the `name` field.
  - Replaced ${WI_NAME} with \"aks\" in the `owner` and `subject` fields.
- **apps/flux-system/sbox/workload-identity/workload-identity-ua-identity.yaml**
  - Replaced ${WI_NAME} with \"aks\" in the `name` field.
- **apps/flux-system/serviceaccount/sbox.yaml**
  - Updated the name to \"kustomize-controller\" and namespace to \"flux-system\".
  - Added use of workload identity label.