### PR TITLE
DTSPO-24310: Adding scope secret for sandbox

### DIFF
--- a/apps/flux-system/sbox/base/aso-controller-settings-patch.yaml
+++ b/apps/flux-system/sbox/base/aso-controller-settings-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: OTY3NzVkNzMtZTRmMy00OWVlLThiYjYtZjg2NjBhMTliYTg1
+  AZURE_SUBSCRIPTION_ID: YjcyYWI3YjctNzIzZi00YjE4LWI2ZjYtMDNiMGYyYzZhMWJiCg==
+  AZURE_TENANT_ID: NTMxZmY5NmQtMGFlOS00NjJhLThkMmQtYmVjN2MwYjQyMDgy
+  USE_WORKLOAD_IDENTITY_AUTH: dHJ1ZQ==
+kind: Secret
+metadata:
+  name: aso-controller
+  namespace: flux-system
+type: Opaque

--- a/apps/flux-system/sbox/base/aso-controller-settings-patch.yaml
+++ b/apps/flux-system/sbox/base/aso-controller-settings-patch.yaml
@@ -6,6 +6,6 @@ data:
   USE_WORKLOAD_IDENTITY_AUTH: dHJ1ZQ==
 kind: Secret
 metadata:
-  name: aso-controller
+  name: aso-credential
   namespace: flux-system
 type: Opaque

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 patches:
 - path: ../../serviceaccount/sbox.yaml
 - path: ../../base/patches/workload-identity-deployment-patch.yaml
-- path: ../aso-controller-settings.yaml
+- path: aso-controller-settings.yaml

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../base
 - ../../base/gotk-components.yaml
 - ../workload-identity
+- aso-controller-settings-patch.yaml
 patches:
 - path: ../../serviceaccount/sbox.yaml
 - path: ../../base/patches/workload-identity-deployment-patch.yaml
-- path: aso-controller-settings.yaml

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 patches:
 - path: ../../serviceaccount/sbox.yaml
 - path: ../../base/patches/workload-identity-deployment-patch.yaml
+- path: ../aso-controller-settings.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding secret to flux-system sandbox for workload-identity.
- Secret is namespace scoped to override aso-controller-settings.yaml as it is using a different subscription than is required for workload identity.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### `aso-controller-settings-patch.yaml`
- Added a new file `aso-controller-settings-patch.yaml` containing environment variables for Azure client ID, subscription ID, tenant ID, and workload identity authentication.

### `kustomization.yaml`
- Added a reference to `aso-controller-settings-patch.yaml` in the resources list.
- Applied a patch to the workload identity deployment.