### PR TITLE
Add authorized services to the LAU case backend to allow whitelisting…

### DIFF
--- a/apps/lau/lau-case-backend/aat.yaml
+++ b/apps/lau/lau-case-backend/aat.yaml
@@ -9,5 +9,4 @@ spec:
       spotInstances:
         enabled: false
       environment:
-        DUMMY_RESTART_VAR: 1
         LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer,xui_webapp

--- a/apps/lau/lau-case-backend/demo.yaml
+++ b/apps/lau/lau-case-backend/demo.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   values:
     java:
+      environment:
+        LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer,xui_webapp

--- a/apps/lau/lau-case-backend/ithc.yaml
+++ b/apps/lau/lau-case-backend/ithc.yaml
@@ -6,3 +6,5 @@ spec:
   releaseName: lau-case-backend
   values:
     java:
+      environment:
+        LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer,xui_webapp

--- a/apps/lau/lau-case-backend/perftest.yaml
+++ b/apps/lau/lau-case-backend/perftest.yaml
@@ -11,3 +11,5 @@ spec:
         maxReplicas: 4
       spotInstances:
         enabled: false
+      environment:
+        LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer,xui_webapp

--- a/apps/lau/lau-case-backend/prod.yaml
+++ b/apps/lau/lau-case-backend/prod.yaml
@@ -13,4 +13,4 @@ spec:
         enabled: false
       environment:
         IDAM_API_URL: "https://idam-api.platform.hmcts.net"
-        DUMMY_RESTART_VAR: 1
+        LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer


### PR DESCRIPTION
Add authorized services to the LAU case backend to allow whitelisting of XUI as part of the release.

### Jira link
https://tools.hmcts.net/jira/browse/LAU-934


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `aat.yaml`:
  - Removed `DUMMY_RESTART_VAR: 1` from the environment.
- `demo.yaml`, `ithc.yaml`, `perftest.yaml`:
  - Added `LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer,xui_webapp` to the environment for different environments.
- `prod.yaml`:
  - Replaced `DUMMY_RESTART_VAR: 1` with `LAU_AUTHORISED_SERVICES: lau_frontend,ccd_data,ccd_case_disposer`.