### PR TITLE
CCD-5980 - demo deployment

### DIFF
--- a/apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-hmc-hmi-inbound-adapter
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod'
+    pattern: '^pr-198'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:prod-a0a0ace-20241014081135 #{"$imagepolicy": "flux-system:demo-hmc-inbound-adapter"}
+      image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:pr-198-95703d3-20250211094207 #{"$imagepolicy": "flux-system:demo-hmc-inbound-adapter"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG


### PR DESCRIPTION
### CCD-5980 - demo deployment for testing

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### demo-image-policy.yaml
- The `demo-image-policy.yaml` file has had a change in the `annotations` section, where `hmcts.github.com/prod-automated` has been switched from `enabled` to `disabled`. Additionally, the `filterTags` section has been updated, changing the `pattern` from `'^prod'` to `'^pr-198'`.

### demo.yaml
- In the `demo.yaml` file, the image for java has been updated to `hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:pr-198-95703d3-20250211094207`.