### PR TITLE
Update requests and limits

### DIFF
--- a/apps/et/et-cos/aat.yaml
+++ b/apps/et/et-cos/aat.yaml
@@ -9,7 +9,7 @@ spec:
       memoryLimits: "3072Mi"
       memoryRequests: "1536Mi"
       cpuLimits: "1000m"
-      cpuRequests: "400m"
+      cpuRequests: "200m"
       autoscaling:
         enabled: true
         cpu:

--- a/apps/et/et-cos/perftest.yaml
+++ b/apps/et/et-cos/perftest.yaml
@@ -9,7 +9,7 @@ spec:
       memoryLimits: "3072Mi"
       memoryRequests: "1536Mi"
       cpuLimits: "1000m"
-      cpuRequests: "400m"
+      cpuRequests: "200m"
       autoscaling:
         enabled: true
         cpu:

--- a/apps/et/et-msg-handler/aat.yaml
+++ b/apps/et/et-msg-handler/aat.yaml
@@ -9,7 +9,7 @@ spec:
       memoryLimits: "2048Mi"
       memoryRequests: "1536Mi"
       cpuLimits: "1500m"
-      cpuRequests: "400m"
+      cpuRequests: "200m"
       autoscaling:
         enabled: true
         cpu:

--- a/apps/et/et-msg-handler/perftest.yaml
+++ b/apps/et/et-msg-handler/perftest.yaml
@@ -10,7 +10,7 @@ spec:
       memoryLimits: "2048Mi"
       memoryRequests: "1536Mi"
       cpuLimits: "1500m"
-      cpuRequests: "400m"
+      cpuRequests: "200m"
       autoscaling:
         enabled: true
         cpu:

--- a/apps/et/et-sya-api/aat.yaml
+++ b/apps/et/et-sya-api/aat.yaml
@@ -10,7 +10,7 @@ spec:
       memoryLimits: "2048Mi"
       memoryRequests: "1536Mi"
       cpuLimits: "1000m"
-      cpuRequests: "300m"
+      cpuRequests: "100m"
       autoscaling:
         enabled: true
         cpu:

--- a/apps/et/et-sya/aat.yaml
+++ b/apps/et/et-sya/aat.yaml
@@ -11,7 +11,7 @@ spec:
       memoryLimits: "1024Mi"
       memoryRequests: "512Mi"
       cpuLimits: "1000m"
-      cpuRequests: "300m"
+      cpuRequests: "100m"
       autoscaling:
         enabled: true
         cpu:

--- a/apps/et/et-syr/aat.yaml
+++ b/apps/et/et-syr/aat.yaml
@@ -11,7 +11,7 @@ spec:
       memoryLimits: "1024Mi"
       memoryRequests: "512Mi"
       cpuLimits: "1000m"
-      cpuRequests: "150m"
+      cpuRequests: "50m"
       autoscaling:
         enabled: true
         cpu:


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->
Updates to CPU and Mem settings

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- In `aat.yaml` for `et-cos`, `et-sya-api`, `et-sya`, `et-syr`, and `et-msg-handler`, the `cpuRequests` has been updated from \"400m\" to \"200m\" for `et-cos`, and from \"300m\" to \"100m\" for `et-sya-api`, `et-sya`, and `et-syr`, as well as from \"150m\" to \"50m\" for `et-msg-handler`.