### PR TITLE
Revert "Remove ADOP-2305 from demo-image-policy.yaml"

### DIFF
--- a/apps/adoption/adoption-cos-api/demo-image-policy.yaml
+++ b/apps/adoption/adoption-cos-api/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-adoption-cos-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-917-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: adoption-cos-api


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#33943

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cos-api/demo-image-policy.yaml
- Added annotations for disabling prod-automated
- Updated spec filterTags and added pattern, extract, and policy properties.