### PR TITLE
SSCSCI - disable completed migration

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/prod.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/prod.yaml
@@ -14,7 +14,7 @@ spec:
       memoryRequests: "1024Mi"
       memoryLimits: "4096Mi"
       restartPolicy: Never
-      schedule: "0 21-23,0-7 * * *"
+      schedule: "0 21 * * *"
       keyVaults:
         sscs:
           resourceGroup: sscs
@@ -54,7 +54,7 @@ spec:
         MIGRATION_DWP_ENABLED: false
         MIGRATION_CASE_MANAGERMENT_LOCATION_ENABLED: false
         MIGRATION_WA_FIELDS_REMOVAL_ENABLED: false
-        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: false
         NON_LISTED_HEARINGS_OUTCOMES_ENABLED: false
         HMCTS_DWP_STATE_MIGRATION_ENABLED: false
         CASE_OUTCOME_GAPS_MIGRATION_ENABLED: false


### PR DESCRIPTION
### Change description

set completed outcome migration to false

set migrations to run once at 9pm every day

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed file: `prod.yaml`
- Updated schedule from \"0 21-23,0-7 * * *\" to \"0 21 * * *\"
- Changed value of `COMPLETED_HEARINGS_OUTCOMES_ENABLED` from `true` to `false`