### PR TITLE
DTSPO-24558: Upgrading artifactory version in sbox

### DIFF
--- a/apps/artifactory/artifactory/artifactory-patch.yaml
+++ b/apps/artifactory/artifactory/artifactory-patch.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: artifactory
 spec:
   chart:
-      spec:
-        chart: artifactory-oss
-        version: 107.104.10
+    spec:
+      chart: artifactory-oss
+      version: 107.104.10

--- a/apps/artifactory/artifactory/artifactory-patch.yaml
+++ b/apps/artifactory/artifactory/artifactory-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: artifactory-oss
+  namespace: artifactory
+spec:
+  chart:
+      spec:
+        chart: artifactory-oss
+        version: 107.104.10

--- a/apps/artifactory/sbox-intsvc/base/kustomization.yaml
+++ b/apps/artifactory/sbox-intsvc/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 
 patches:
   - path: ../ingress-patch.yaml
+  - path: ../../artifactory/artifactory-patch.yaml


### PR DESCRIPTION
Patching: [DTSPO-24558](https://tools.hmcts.net/jira/browse/DTSPO-24558)

Following guide in https://hmcts.github.io/ops-runbooks/aks/patching-artifactory.html#1-updating-cft-ptlsbox

Will disable artifactory using https://github.com/hmcts/cnp-jenkins-library/pull/1308 for testing 



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created file **artifactory-patch.yaml** with HelmRelease configuration for artifactory-oss.
- Updated **kustomization.yaml** in sbox-intsvc to include a reference to the newly created artifactory-patch.yaml file.