### PR TITLE
Point civil service demo back to prod

### DIFF
--- a/apps/civil/civil-service/demo.yaml
+++ b/apps/civil/civil-service/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-6143-2b96e3d-20250311142034 #{"$imagepolicy": "flux-system:demo-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-80b0f6c-20250312090535 #{"$imagepolicy": "flux-system:demo-civil-service"}
       environment:
         TESTING_SUPPORT_ENABLED: true
         EM_CCD_ORCHESTRATOR_URL: http://em-ccd-orchestrator-demo.service.core-compute-demo.internal


### PR DESCRIPTION
### Change description
Point civil-service image in demo to prod image

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/demo.yaml
- Updated the Java image for the `civil-service` to `hmctspublic.azurecr.io/civil/service:prod-80b0f6c-20250312090535`. Testing support is enabled and the CCD orchestrator URL is set to http://em-ccd-orchestrator-demo.service.core-compute-demo.internal.