### PR TITLE
Upgrade artifactory in PTL

### DIFF
--- a/apps/artifactory/artifactory/artifactory.yaml
+++ b/apps/artifactory/artifactory/artifactory.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: artifactory-oss
-      version: 107.98.9
+      version: 107.104.10
       sourceRef:
         kind: HelmRepository
         name: artifactory

--- a/apps/artifactory/sbox-intsvc/base/kustomization.yaml
+++ b/apps/artifactory/sbox-intsvc/base/kustomization.yaml
@@ -8,4 +8,3 @@ resources:
 
 patches:
   - path: ../ingress-patch.yaml
-  - path: ../../artifactory/artifactory-patch.yaml


### PR DESCRIPTION
Disabled artifactory in Jenkins: https://github.com/hmcts/cnp-jenkins-library/pull/1308/files

Tested in ptlsbox with https://github.com/hmcts/cnp-flux-config/pull/37289 - all pods running, HR in succeeded state, no errors in namespace

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `artifactory.yaml`:
  - Changed the version from 107.98.9 to 107.104.10.

- Updated `kustomization.yaml` in `sbox-intsvc`:
  - Removed `./artifactory/artifactory-patch.yaml` and `./ingress-patch.yaml`.