### PR TITLE
Revert "Add automation for aat-image-policy.yaml"

### DIFF
--- a/apps/xui/automation/kustomization.yaml
+++ b/apps/xui/automation/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - ../xui-ao-webapp/demo-image-policy.yaml
   - ../xui-ao-webapp/ithc-image-policy.yaml
   - ../xui-ao-webapp/perftest-image-policy.yaml
-  - ../xui-ao-webapp/aat-image-policy.yaml
   - ../xui-webapp/image-repo.yaml
   - ../xui-webapp/image-policy.yaml
   - ../xui-webapp/demo-image-policy.yaml


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37320

Image policy not actually changing aat image to PR. PR also tests whether the image policy change may have directly/indirectly fixed the aat issue we were experiencing on AO