### PR TITLE
fix: rollback ccd-api-gateway-web image in prod

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/prod.yaml
+++ b/apps/ccd/ccd-api-gateway-web/prod.yaml
@@ -6,6 +6,7 @@ spec:
   releaseName: ccd-api-gateway-web
   values:
     nodejs:
+      image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-66a4048-20250203150702
       replicas: 20
       autoscaling:
         enabled: false


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-api-gateway-web/prod.yaml
- Updated the `nodejs` image to `hmctspublic.azurecr.io/ccd/api-gateway-web:prod-66a4048-20250203150702`
- Increased the number of replicas to 20