### PR TITLE
EXUI-2910: update icp url for prod

### DIFF
--- a/apps/xui/xui-webapp/prod.yaml
+++ b/apps/xui/xui-webapp/prod.yaml
@@ -25,3 +25,4 @@ spec:
         FEATURE_COMPRESSION_ENABLED: false
         DUMMY_VAR_TO_RESTART: 1
         SERVICES_HEARINGS_COMPONENT_API_SSCS: http://sscs-tribunals-api-prod.service.core-compute-prod.internal
+        SERVICES_ICP_API: https://em-icp.platform.hmcts.net


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EXUI-2910

### Change description
adding prod url


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/xui/xui-webapp/prod.yaml
- Added a new environment variable `SERVICES_ICP_API` with the value `https://em-icp.platform.hmcts.net` to the production configuration.