### PR TITLE
Deploy Welsh for professional

### DIFF
--- a/apps/private-law/prl-cos/perftest.yaml
+++ b/apps/private-law/prl-cos/perftest.yaml
@@ -63,7 +63,7 @@ spec:
       readinessTimeout: 300
       readinessPeriod: 15
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/prl/cos:prod-17c9da5-20250317172929 #{"$imagepolicy": "flux-system:perftest-prl-cos"}
+      image: hmctspublic.azurecr.io/prl/cos:pr-3030-bbd2964-20250317172742 #{"$imagepolicy": "flux-system:perftest-prl-cos"}
       environment:
         FEATURE_EXAMPLE: true
         PRD_API_BASEURL: http://rd-professional-api-perftest.service.core-compute-perftest.internal


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/private-law/prl-cos/perftest.yaml
- Updated the image tag from `prod-17c9da5-20250317172929` to `pr-3030-bbd2964-20250317172742` for the `hmctspublic.azurecr.io/prl/cos` image.
- Set `FEATURE_EXAMPLE` environment variable to true and updated `PRD_API_BASEURL` to point to `http://rd-professional-api-perftest.service.core-compute-perftest.internal`.