### PR TITLE
DTSPO-24310: Adding WI to flux demo, preview and aat

### DIFF
--- a/apps/flux-system/aat/base/aso-controller-settings-patch.yaml
+++ b/apps/flux-system/aat/base/aso-controller-settings-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: ODU3YTVkNTctMDBkNy00NGM3LWIwNjEtN2YxMzA2NjczMjA3
+  AZURE_SUBSCRIPTION_ID: OTZjMjc0Y2UtODQ2ZC00ZTQ4LTg5YTctZDUyODQzMjI5OGE3
+  AZURE_TENANT_ID: NTMxZmY5NmQtMGFlOS00NjJhLThkMmQtYmVjN2MwYjQyMDgy
+  USE_WORKLOAD_IDENTITY_AUTH: dHJ1ZQ==
+kind: Secret
+metadata:
+  name: aso-credential
+  namespace: flux-system
+type: Opaque

--- a/apps/flux-system/aat/base/kustomization.yaml
+++ b/apps/flux-system/aat/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-- aks-sops-aadpodidentity.yaml
+- ../../workload-identity
+- aso-controller-settings-patch.yaml
 patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
+- path: ../../serviceaccount/aat.yaml
+- path: ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/demo/base/aso-controller-settings-patch.yaml
+++ b/apps/flux-system/demo/base/aso-controller-settings-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: ZGJlODI5MGUtMjg3OC00MDNjLWJkYWItZDJkODEzMDQ3Yjk2
+  AZURE_SUBSCRIPTION_ID: ZDAyNWZlY2UtY2U5OS00ZGYyLWI3YTktYjY0OWQzZmYyMDYw
+  AZURE_TENANT_ID: NTMxZmY5NmQtMGFlOS00NjJhLThkMmQtYmVjN2MwYjQyMDgy
+  USE_WORKLOAD_IDENTITY_AUTH: dHJ1ZQ==
+kind: Secret
+metadata:
+  name: aso-credential
+  namespace: flux-system
+type: Opaque

--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-- aks-sops-aadpodidentity.yaml
+- ../../workload-identity
+- aso-controller-settings-patch.yaml
 patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
+- path: ../../serviceaccount/demo.yaml
+- path: ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/preview/base/aso-controller-settings-patch.yaml
+++ b/apps/flux-system/preview/base/aso-controller-settings-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: ZGM5YmYyMTQtNTY0NC00YzIzLWE1YWQtNTZhMDE1NjI2ZmFl
+  AZURE_SUBSCRIPTION_ID: OGI2ZWE5MjItMDg2Mi00NDNlLWFmMTUtNjA1NmUxYzliOWE0
+  AZURE_TENANT_ID: NTMxZmY5NmQtMGFlOS00NjJhLThkMmQtYmVjN2MwYjQyMDgy
+  USE_WORKLOAD_IDENTITY_AUTH: dHJ1ZQ==
+kind: Secret
+metadata:
+  name: aso-credential
+  namespace: flux-system
+type: Opaque

--- a/apps/flux-system/preview/base/kustomization.yaml
+++ b/apps/flux-system/preview/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-- aks-sops-aadpodidentity.yaml
+- ../../workload-identity
+- aso-controller-settings-patch.yaml
 patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
+- path: ../../serviceaccount/preview.yaml
+- path: ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/serviceaccount/aat.yaml
+++ b/apps/flux-system/serviceaccount/aat.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "857a5d57-00d7-44c7-b061-7f1306673207"
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/demo.yaml
+++ b/apps/flux-system/serviceaccount/demo.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "dbe8290e-2878-403c-bdab-d2d813047b96"
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/preview.yaml
+++ b/apps/flux-system/serviceaccount/preview.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "dc9bf214-5644-4c23-a5ad-56a015626fae"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Replacing aadpodidentity with workload identity in flux-system demo, preview and aat.
- Each env has a serviceaccount patch with the client id of the MI being used.
- Each env has an aso-credential patch as the subscription in azureserviceoperator-system does not match the subscription the MIs being used are in.
- Each env brings in the /workload-identity dir in /flux-system. The value for ENVIRONMENT in each env, which is used in the workload-identity dir, correctly maps to the value needed for the name of the MI.
- Each env also brings in a workload-identity-deployment-patch.
-  
### Testing done

- Has been added to sbox, ptlsbox, ithc and perftest across several PRs, e.g. https://github.com/hmcts/cnp-flux-config/pull/37338
- All kustomizations in flux-system on other envs are reconciling.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/aat/base/aso-controller-settings-patch.yaml

- Added a secret with Azure authentication credentials including client ID, subscription ID, tenant ID, and workload identity authentication.
- Defines the secret's name and namespace.

### apps/flux-system/aat/base/kustomization.yaml

- Removed the aks-sops-aadpodidentity.yaml resource.
- Added the workload-identity resource and aso-controller-settings-patch.yaml.
- Updated the patch paths to include workload-identity and serviceaccount/aat.yaml.

### apps/flux-system/demo/base/aso-controller-settings-patch.yaml

- Similar to apps/flux-system/aat/base/aso-controller-settings-patch.yaml, but with different Azure authentication credentials.

### apps/flux-system/demo/base/kustomization.yaml

- Removed the aks-sops-aadpodidentity.yaml resource.
- Added the workload-identity resource and aso-controller-settings-patch.yaml.
- Updated the patch paths to include workload-identity and serviceaccount/demo.yaml.

### apps/flux-system/preview/base/aso-controller-settings-patch.yaml

- Similar to apps/flux-system/aat/base/aso-controller-settings-patch.yaml, but with different Azure authentication credentials.

### apps/flux-system/preview/base/kustomization.yaml

- Removed the aks-sops-aadpodidentity.yaml resource.
- Added the workload-identity resource and aso-controller-settings-patch.yaml.
- Updated the patch paths to include workload-identity and serviceaccount/preview.yaml.

### apps/flux-system/serviceaccount/aat.yaml

- Added a service account named kustomize-controller with Azure workload identity annotations.

### apps/flux-system/serviceaccount/demo.yaml

- Added a service account named kustomize-controller with Azure workload identity annotations.

### apps/flux-system/serviceaccount/preview.yaml

- Added a service account named kustomize-controller with Azure workload identity annotations.