### PR TITLE
DTSPO-24310: Adding WI to flux PTL

### DIFF
--- a/apps/flux-system/ptl-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/ptl-intsvc/base/kustomization.yaml
@@ -6,8 +6,9 @@ resources:
 - ./gotk-components.yaml
 - ../../automation
 - ../../base/image-update-automation.yaml
-- aks-sops-aadpodidentity.yaml
+- ../workload-identity
 
 patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
 - path: ../../base/patches/image-automation-components-patch.yaml
+- path: ../../serviceaccount/ptl.yaml
+- path: ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/ptl-intsvc/workload-identity/kustomization.yaml
+++ b/apps/flux-system/ptl-intsvc/workload-identity/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - workload-identity-federated-credential.yaml
+  - workload-identity-rg.yaml
+  - workload-identity-ua-identity.yaml

--- a/apps/flux-system/ptl-intsvc/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/flux-system/ptl-intsvc/workload-identity/workload-identity-federated-credential.yaml
@@ -1,0 +1,12 @@
+apiVersion: managedidentity.azure.com/v1api20220131preview
+kind: FederatedIdentityCredential
+metadata:
+  name: aks-${WI_CLUSTER}-fic
+  namespace: flux-system
+spec:
+  owner:
+    name: aks-ptl-mi
+  audiences:
+    - api://AzureADTokenExchange
+  issuer: ${ISSUER_URL}
+  subject: system:serviceaccount:flux-system:kustomize-controller

--- a/apps/flux-system/ptl-intsvc/workload-identity/workload-identity-rg.yaml
+++ b/apps/flux-system/ptl-intsvc/workload-identity/workload-identity-rg.yaml
@@ -1,0 +1,10 @@
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: genesis-rg
+  namespace: flux-system
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  location: uksouth
+  azureName: genesis-rg

--- a/apps/flux-system/ptl-intsvc/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/flux-system/ptl-intsvc/workload-identity/workload-identity-ua-identity.yaml
@@ -1,0 +1,11 @@
+apiVersion: managedidentity.azure.com/v1api20181130
+kind: UserAssignedIdentity
+metadata:
+  name: aks-ptl-mi
+  namespace: flux-system
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
+spec:
+  location: uksouth
+  owner:
+    name: genesis-rg

--- a/apps/flux-system/serviceaccount/ptl.yaml
+++ b/apps/flux-system/serviceaccount/ptl.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "e5f2dcc4-7c74-4b73-8523-c8283e07266c"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Replacing aadpodidentity with workload identity in flux-system PTL
- Adding a service account patch with the client id of the ptl MI being used
- Adding a workload-identity dir to /ptl-intsvc. The value of ENVIRONMENT, which is used in the workload-identity dir in /flux-system, does not map to the value required for the name of the MI (aks-ptl-mi). Therefore, a copy of the workload-identity fir has been added with the name of the MI hardcoded
- Image automation is still using aadpodidentity

### Testing done

- Has been added to all envs in sds and non-prod in cft across several PRs, e.g. https://github.com/hmcts/cnp-flux-config/pull/37338
- All kustomizations in flux-system on other envs are reconciling.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `apps/flux-system/ptl-intsvc/base/kustomization.yaml`
  - Removed `aks-sops-aadpodidentity.yaml`
  - Added `workload-identity-deployment-patch.yaml`
  - Updated paths for patches and added a new one for service account

- Added `apps/flux-system/ptl-intsvc/workload-identity/kustomization.yaml`
  - Contains specifications for workload identity resources

- Added `apps/flux-system/ptl-intsvc/workload-identity/workload-identity-federated-credential.yaml`
  - Contains specifications for federated identity credential

- Added `apps/flux-system/ptl-intsvc/workload-identity/workload-identity-rg.yaml`
  - Contains specifications for resource group for workload identity

- Added `apps/flux-system/ptl-intsvc/workload-identity/workload-identity-ua-identity.yaml`
  - Contains specifications for user-assigned identity for workload identity

- Added `apps/flux-system/serviceaccount/ptl.yaml`
  - Contains specifications for service account with annotations for workload identity properties