### PR TITLE
DTSPO-24310: Adding WI to flux prod

### DIFF
--- a/apps/flux-system/prod/base/aso-controller-settings-patch.yaml
+++ b/apps/flux-system/prod/base/aso-controller-settings-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  AZURE_CLIENT_ID: Mzg3MDRlYmQtYTk1NS00MzE0LThmNTctZmY3YzI1OWFkMDdl
+  AZURE_SUBSCRIPTION_ID: OGNiYzZmMzYtN2M1Ni00OTYzLTlkMzYtNzM5ZGI1ZDAwYjI3
+  AZURE_TENANT_ID: NTMxZmY5NmQtMGFlOS00NjJhLThkMmQtYmVjN2MwYjQyMDgy
+  USE_WORKLOAD_IDENTITY_AUTH: dHJ1ZQ==
+kind: Secret
+metadata:
+  name: aso-credential
+  namespace: flux-system
+type: Opaque

--- a/apps/flux-system/prod/base/kustomization.yaml
+++ b/apps/flux-system/prod/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/gotk-components.yaml
-- aks-sops-aadpodidentity.yaml
+- ../../workload-identity
+- aso-controller-settings-patch.yaml
 patches:
-- path: ../../base/patches/kustomize-controller-patch.yaml
+- path: ../../serviceaccount/prod.yaml
+- path: ../../base/patches/workload-identity-deployment-patch.yaml

--- a/apps/flux-system/serviceaccount/prod.yaml
+++ b/apps/flux-system/serviceaccount/prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "38704ebd-a955-4314-8f57-ff7c259ad07e"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Replacing addpodidentity with workload identity in flux-system prod
- Adding an aso-credential patch to point to the correct subscription for the prod MI
- Adding a service account patch for prod which has the client id for the prod MI

### Testing done

- Has been added to all other envs in sds and cft

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Added a new file `aso-controller-settings-patch.yaml` under `apps/flux-system/prod/base/` containing Azure configuration settings for the aso controller.
- Updated `kustomization.yaml` by adding `workload-identity` and `aso-controller-settings-patch.yaml` and removing `aks-sops-aadpodidentity.yaml`.
- Added a new file `prod.yaml` in the `serviceaccount` directory, defining a service account for the kustomize controller with associated annotations and labels for Azure workload identity.