### PR TITLE
Revert "DTSPO-24310: Removing unused aadpodidentity files from flux-system"

### DIFF
--- a/apps/flux-system/aat/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/aat/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-aat-mi"
+  clientID: "857a5d57-00d7-44c7-b061-7f1306673207"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/base/patches/kustomize-controller-patch.yaml
+++ b/apps/flux-system/base/patches/kustomize-controller-patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+spec:
+  template:
+    metadata:
+      labels:
+        aadpodidbinding: aks-pod-identity-mi
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: AZURE_AUTH_METHOD
+          value: msi

--- a/apps/flux-system/demo/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/demo/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/d025fece-ce99-4df2-b7a9-b649d3ff2060/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-demo-mi"
+  clientID: "dbe8290e-2878-403c-bdab-d2d813047b96"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/ithc/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/ithc/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/62864d44-5da9-4ae9-89e7-0cf33942fa09/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ithc-mi"
+  clientID: "0f44a6f0-4da1-433f-a298-4fa50072ea2c"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/perftest/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/perftest/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-perftest-mi"
+  clientID: "7734e33b-4bb6-44eb-89c4-0dca2b6d351c"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/preview/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/preview/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-preview-mi"
+  clientID: "dc9bf214-5644-4c23-a5ad-56a015626fae"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/prod/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/prod/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-prod-mi"
+  clientID: "38704ebd-a955-4314-8f57-ff7c259ad07e"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/ptl-intsvc/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/ptl-intsvc/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ptl-mi"
+  clientID: "e5f2dcc4-7c74-4b73-8523-c8283e07266c"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/sbox-intsvc/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/sbox-intsvc/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,18 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ptlsbox-mi"
+  clientID: "098e5021-722a-45cf-9547-d7db0b831b32"
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi

--- a/apps/flux-system/sbox/base/aks-sops-aadpodidentity.yaml
+++ b/apps/flux-system/sbox/base/aks-sops-aadpodidentity.yaml
@@ -1,0 +1,19 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: aks-pod-identity-mi
+  namespace: flux-system
+spec:
+  type: 0
+  resourceID: "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-sbox-mi"
+  clientID: "96775d73-e4f3-49ee-8bb6-f8660a19ba85"
+
+---
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: aks-pod-identity-mi-binding
+  namespace: flux-system
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: aks-pod-identity-mi


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37499

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Created new file `aks-sops-aadpodidentity.yaml` in the following directories: `apps/flux-system/aat/base`, `apps/flux-system/base/patches`, `apps/flux-system/demo/base`, `apps/flux-system/ithc/base`, `apps/flux-system/perftest/base`, `apps/flux-system/preview/base`, `apps/flux-system/prod/base`, `apps/flux-system/ptl-intsvc/base`, `apps/flux-system/sbox-intsvc/base`, `apps/flux-system/sbox/base`
- Added AzureIdentity and AzureIdentityBinding configurations with specific details in each file.