### PR TITLE
Manually bumping Docmosis image

### DIFF
--- a/apps/docmosis/docmosis/aat.yaml
+++ b/apps/docmosis/docmosis/aat.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:aat-9bc60af-777500 #{"$imagepolicy": "flux-system:aat-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:aat-67fd9a8-778909 #{"$imagepolicy": "flux-system:aat-docmosis"}

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:demo-9bc60af-777500 #{"$imagepolicy": "flux-system:demo-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:demo-67fd9a8-778909 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -16,12 +16,12 @@ spec:
     ingressSessionAffinity:
       enabled: true
     envFromSecret: docmosis-secret
-    image: hmctsprivate.azurecr.io/docmosis:prod-9bc60af-777500 #{"$imagepolicy": "flux-system:docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:prod-67fd9a8-778909 #{"$imagepolicy": "flux-system:docmosis"}
     java:
-      memoryRequests: "1024Mi"
-      cpuRequests: "1000m"
-      memoryLimits: "3072Mi"
-      cpuLimits: "2000m"
+      memoryRequests: '1024Mi'
+      cpuRequests: '1000m'
+      memoryLimits: '3072Mi'
+      cpuLimits: '2000m'
   chart:
     spec:
       chart: base

--- a/apps/docmosis/docmosis/ithc.yaml
+++ b/apps/docmosis/docmosis/ithc.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:ithc-9bc60af-777500 #{"$imagepolicy": "flux-system:ithc-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:ithc-67fd9a8-778909 #{"$imagepolicy": "flux-system:ithc-docmosis"}

--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     replicas: 3
     ingressHost: docmosis.perftest.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:perftest-9bc60af-777500 #{"$imagepolicy": "flux-system:perftest-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:perftest-67fd9a8-778909 #{"$imagepolicy": "flux-system:perftest-docmosis"}
     java:
       memoryRequests: '4Gi'
       memoryLimits: '5Gi'

--- a/apps/docmosis/docmosis/preview.yaml
+++ b/apps/docmosis/docmosis/preview.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.preview.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:preview-9bc60af-777500 #{"$imagepolicy": "flux-system:preview-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:preview-67fd9a8-778909 #{"$imagepolicy": "flux-system:preview-docmosis"}
     disableTraefikTls: false

--- a/apps/docmosis/docmosis/sbox.yaml
+++ b/apps/docmosis/docmosis/sbox.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.sandbox.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:sandbox-9bc60af-777500 #{"$imagepolicy": "flux-system:sandbox-docmosis"}
+    image: hmctsprivate.azurecr.io/docmosis:sandbox-67fd9a8-778909 #{"$imagepolicy": "flux-system:sandbox-docmosis"}
     environment:
       DOCMOSIS_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net
       DOCMOSIS_TORNADO_RENDER_USEURL: https://docmosis.sandbox.platform.hmcts.net


### PR DESCRIPTION
### Jira link


### Change description
- Manually bumping docmosis image to latest as flux hasn't auto-updated in the past 2 days
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- aat.yaml
  - Updated `docmosis` image to version `aat-67fd9a8-778909`

- demo.yaml
  - Updated `docmosis` image to version `demo-67fd9a8-778909`

- docmosis.yaml
  - Updated `docmosis` image to version `prod-67fd9a8-778909`
  - Updated CPU and memory limits and requests

- ithc.yaml
  - Updated `docmosis` image to version `ithc-67fd9a8-778909`

- perftest.yaml
  - Updated `docmosis` image to version `perftest-67fd9a8-778909`
  - Updated Java memory requests and limits

- preview.yaml
  - Updated `docmosis` image to version `preview-67fd9a8-778909`
  - Disabled Traefik TLS

- sbox.yaml
  - Updated `docmosis` image to version `sandbox-67fd9a8-778909`
  - Updated environment variables for `DOCIMOSIS_RENDER_USEURL` and `DOCIMOSIS_TORNADO_RENDER_USEURL`