### PR TITLE
ADOP-2305 schedule cron in past to prevent running over the weekend

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -10,7 +10,7 @@ spec:
       environment:
         TASK_NAME: AlertToSubmitApplicationToCourtTask
         VAR: trigger1
-      schedule: 20 10 * * *
+      schedule: 0 10 20 3 *
       keyVaults:
         adoption:
           secrets:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Testing alert with cron in demo



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
- Updated the schedule from \"20 10 * * *\" to \"0 10 20 3 *\" for the `AlertToSubmitApplicationToCourtTask` job.