### PR TITLE
Revert "CCD-5977 - demo deployment for testing"

### DIFF
--- a/apps/ccd/ccd-next-hearing-date-updater/demo-image-policy.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-229-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-next-hearing-date-updater/demo/demo.yaml
+++ b/apps/ccd/ccd-next-hearing-date-updater/demo/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      image: hmctspublic.azurecr.io/ccd/next-hearing-date-updater:pr-229-ce82555-20250206140604 #{"$imagepolicy": "flux-system:demo-ccd-next-hearing-date-updater"}
+      image: hmctspublic.azurecr.io/ccd/next-hearing-date-updater:prod-5d0ee03-20250128103907 #{"$imagepolicy": "flux-system:demo-ccd-next-hearing-date-updater"}
       schedule: "0 */2 * * *"
       environment:
         CASE_TYPES: FT_NextHearingDate,PRLAPPS,CIVIL,Asylum


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37161

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-next-hearing-date-updater/demo-image-policy.yaml
- Modified the pattern in filterTags from `'^pr-229-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`

### apps/ccd/ccd-next-hearing-date-updater/demo/demo.yaml
- Changed the image from `hmctspublic.azurecr.io/ccd/next-hearing-date-updater:pr-229-ce82555-20250206140604` to `hmctspublic.azurecr.io/ccd/next-hearing-date-updater:prod-5d0ee03-20250128103907`
- Updated the schedule from \"0 */2 * * *\" to the same schedule