### PR TITLE
Revert "CCD-5980 - demo deployment"

### DIFF
--- a/apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-hmc-hmi-inbound-adapter
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-198'
+    pattern: '^prod'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:pr-198-95703d3-20250211094207 #{"$imagepolicy": "flux-system:demo-hmc-inbound-adapter"}
+      image: hmctspublic.azurecr.io/hmc/hmi-inbound-adapter:prod-a0a0ace-20241014081135 #{"$imagepolicy": "flux-system:demo-hmc-inbound-adapter"}
       environment:
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37159

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Changed Files
---
#### apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
- Enabled prod-automated annotation
- Updated filter tags pattern from '^pr-198' to '^prod'
  
#### apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
- Updated image tag from 'pr-198-95703d3-20250211094207' to 'prod-a0a0ace-20241014081135'