### PR TITLE
DTSPO-24310: Removing reference to hmctsprivate-creds to fix image automation

### DIFF
--- a/apps/flux-system/automation/hmctsprivate-image-repo.yaml
+++ b/apps/flux-system/automation/hmctsprivate-image-repo.yaml
@@ -4,5 +4,3 @@ metadata:
   name: default
 spec:
   interval: 5m0s
-  secretRef:
-    name: hmctsprivate-creds


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Removing reference to hmctsprivate-creds in image automation on PTL
- Currently returning a 401 Unauthorised when trying to read from the hmctsprivate container registry. The refreshing of the hmctsprivate-creds was removed [here](https://github.com/hmcts/cnp-flux-config/pull/37486/files#diff-ab913f2bd27046ea27ac8d3243bccaa8a4ce9f2036f8141308c767cbb46ca314L8) and so it will not contain the correct values to authenticate to the registry.
- Workload identity is currently enabled for image automation and should replace the need for the secret to authenticate to the private container registry once the reference to the secret is removed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/automation/hmctsprivate-image-repo.yaml
- Removed `secretRef` and `name` from the `spec` section.
- Updated the `interval` to `5m0s`.