### PR TITLE
ADOP-2305 testing without SendGrid secrets

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -10,7 +10,7 @@ spec:
       environment:
         TASK_NAME: AlertToSubmitApplicationToCourtTask
         VAR: trigger1
-      schedule: 20 10 * * *
+      schedule: 10 10 * * *
       keyVaults:
         adoption:
           secrets:
@@ -28,10 +28,6 @@ spec:
               alias: IDAM_SYSTEM_UPDATE_PASSWORD
             - name: launchDarkly-sdk-key
               alias: LAUNCH_DARKLY_SDK_KEY
-            - name: send-grid-api-key
-              alias: SEND_GRID_API_KEY
-            - name: sendgrid-notify-from-email
-              alias: SEND_GRID_NOTIFY_FROM_EMAIL
             - name: app-insight-connection-key
               alias: app-insight-connection-key
     global:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
The other cron jobs run without these SendGrid secrets configured in flux or chart. Confirming this one does too.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated schedule in `demo.yaml` from `20 10 * * *` to `10 10 * * *`
- Removed `send-grid-api-key` and `sendgrid-notify-from-email` aliases from `demo.yaml`