### PR TITLE
Revert perftest to prod images

### DIFF
--- a/apps/ccd/ccd-case-document-am-api/perftest-image-policy.yaml
+++ b/apps/ccd/ccd-case-document-am-api/perftest-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: perftest-ccd-case-document-am-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-722-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-document-am-api/perftest.yaml
+++ b/apps/ccd/ccd-case-document-am-api/perftest.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/case-document-am-api:pr-722-1d7904b-20250304173543 #{"$imagepolicy": "flux-system:perftest-ccd-case-document-am-api"}
+      image: hmctspublic.azurecr.io/ccd/case-document-am-api:prod-9b08cfa-20250304101210 #{"$imagepolicy": "flux-system:perftest-ccd-case-document-am-api"}
       replicas: 7
       memoryRequests: "3Gi"
       cpuRequests: "1"

--- a/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: perftest-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-1973-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       replicas: 8
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-1973-8a8b48a-20250310084629 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-b509326-20250227125144 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
         enabled: false
         minReplicas: 4


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


File perftest-image-policy.yaml:
- Changed the pattern for filterTags from '^pr-722-' to '^prod-'.

File perftest.yaml:
- Updated the image tag from 'pr-722-1d7904b-20250304173543' to 'prod-9b08cfa-20250304101210' for the java image.

File perftest-image-policy.yaml:
- Changed the pattern for filterTags from '^pr-1973-' to '^prod-'.

File perftest.yaml:
- Updated the image tag from 'pr-1973-8a8b48a-20250310084629' to 'prod-b509326-20250227125144' for the java image.