### PR TITLE
ADOP-2305 change cron time for testing

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -10,7 +10,7 @@ spec:
       environment:
         TASK_NAME: AlertToSubmitApplicationToCourtTask
         VAR: trigger1
-      schedule: 10 10 * * *
+      schedule: 10 11 * * *
       keyVaults:
         adoption:
           secrets:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Retest as ran against the wrong date.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
- Updated the schedule from `10 10 * * *` to `10 11 * * *` 🔧.