### PR TITLE
DTSPO-24310: Adding spec.provider to hmctsprivate

### DIFF
--- a/apps/flux-system/automation/hmctsprivate-image-repo.yaml
+++ b/apps/flux-system/automation/hmctsprivate-image-repo.yaml
@@ -4,3 +4,4 @@ metadata:
   name: default
 spec:
   interval: 5m0s
+  provider: azure


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding spec.provider as azure to hmctsprivate image repository. This is to fix the authentication error when trying to read the hmctsprivate container registry.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/automation/hmctsprivate-image-repo.yaml
- Added a `provider: azure` to the image repository configuration.
- Updated the interval to `5m0s`.