### PR TITLE
DTSPO-24310: Re-enabling image automation on docmosis

### DIFF
--- a/apps/docmosis/docmosis/aat.yaml
+++ b/apps/docmosis/docmosis/aat.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:aat-5910d73-781371
+    image: hmctsprivate.azurecr.io/docmosis:aat-5910d73-781371 #{"$imagepolicy": "flux-system:aat-docmosis"}

--- a/apps/docmosis/docmosis/demo.yaml
+++ b/apps/docmosis/docmosis/demo.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:demo-5910d73-781371
+    image: hmctsprivate.azurecr.io/docmosis:demo-5910d73-781371 #{"$imagepolicy": "flux-system:demo-docmosis"}

--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -16,7 +16,7 @@ spec:
     ingressSessionAffinity:
       enabled: true
     envFromSecret: docmosis-secret
-    image: hmctsprivate.azurecr.io/docmosis:prod-5910d73-781371
+    image: hmctsprivate.azurecr.io/docmosis:prod-5910d73-781371 #{"$imagepolicy": "flux-system:docmosis"}
     java:
       memoryRequests: '1024Mi'
       cpuRequests: '1000m'

--- a/apps/docmosis/docmosis/ithc.yaml
+++ b/apps/docmosis/docmosis/ithc.yaml
@@ -11,4 +11,4 @@ spec:
           secrets:
             - name: appinsights-connection-string
               alias: appinsights-connection-string
-    image: hmctsprivate.azurecr.io/docmosis:ithc-5910d73-781371
+    image: hmctsprivate.azurecr.io/docmosis:ithc-5910d73-781371 #{"$imagepolicy": "flux-system:ithc-docmosis"}

--- a/apps/docmosis/docmosis/perftest.yaml
+++ b/apps/docmosis/docmosis/perftest.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     replicas: 3
     ingressHost: docmosis.perftest.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:perftest-5910d73-781371
+    image: hmctsprivate.azurecr.io/docmosis:perftest-5910d73-781371 #{"$imagepolicy": "flux-system:perftest-docmosis"}
     java:
       memoryRequests: '4Gi'
       memoryLimits: '5Gi'

--- a/apps/docmosis/docmosis/preview.yaml
+++ b/apps/docmosis/docmosis/preview.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   values:
     ingressHost: docmosis.preview.platform.hmcts.net
-    image: hmctsprivate.azurecr.io/docmosis:preview-5910d73-781371
+    image: hmctsprivate.azurecr.io/docmosis:preview-5910d73-781371 #{"$imagepolicy": "flux-system:preview-docmosis"}
     disableTraefikTls: false


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding image automation back into docmosis (was removed by [this PR](https://github.com/hmcts/cnp-flux-config/pull/37549))
- Flux is now picking up new images from the hmctsprivate container registry

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated image for AAT environment in `apps/docmosis/docmosis/aat.yaml`
- Updated image for demo environment in `apps/docmosis/docmosis/demo.yaml`
- Updated image for prod environment, along with memory and CPU requests in `apps/docmosis/docmosis/docmosis.yaml`
- Updated image for ITHC environment in `apps/docmosis/docmosis/ithc.yaml`
- Updated image for perftest environment, along with memory limits in `apps/docmosis/docmosis/perftest.yaml`
- Updated image for preview environment in `apps/docmosis/docmosis/preview.yaml`