### PR TITLE
Revert "Update demo-image-policy.yaml"

### DIFF
--- a/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-2553-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2553-7ca577b-20250326114135
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-7e55a0d-20250326103711 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
       replicas: 4
       autoscaling:
         enabled: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37641

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **demo-image-policy.yaml**
  - Changed the annotation `hmcts.github.com/prod-automated` from disabled to enabled.
  - Updated the `filterTags` pattern from `^pr-2553-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
- **demo.yaml**
  - Changed the image tag from `hmctspublic.azurecr.io/ccd/data-store-api:pr-2553-7ca577b-20250326114135` to `hmctspublic.azurecr.io/ccd/data-store-api:prod-7e55a0d-20250326103711`.