### PR TITLE
Remove is_dev and demo.enabled from flux as it is by default true

### DIFF
--- a/apps/cui/cui-ra/aat.yaml
+++ b/apps/cui/cui-ra/aat.yaml
@@ -7,6 +7,3 @@ spec:
     nodejs:
       spotInstances:
         enabled: false
-      environment:
-        DEMO_ENABLED: true
-        IS_DEV: true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CUIRA-389

### Change description
Remove it from flux

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `aat.yaml` in the `apps/cui/cui-ra` directory has had the environment variables `DEMO_ENABLED` and `IS_DEV` removed.
- The `spotInstances` section has been modified with the `enabled` field set to `false`.