### PR TITLE
ADOP-2305 change cron to run at 2:30am every day.

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/prod.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/prod.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: adoption-cron-submit-application-to-court-alerts
   values:
     job:
-      schedule: 30 2 7 4 *
+      schedule: 30 2 * * *
       environment:
         VAR: trigger1
         NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Ran a single day over the weekend to confirm behaviour. Now setting to final schedule of running at 2:30am every day.


### Checklist

- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-submit-application-to-court-alerts/prod.yaml
- Updated the cron job schedule from \"30 2 7 4 *\" to \"30 2 * * *\" to run the job on a daily basis.