### PR TITLE
DTSAM-817 Enable `civil_wa_2_4` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: publiclaw_wa_1_5
+        DB_FEATURE_FLAG_ENABLE: civil_wa_2_4
         REFRESH_JOB: LEGAL_OPERATIONS-CIVIL-NEW-0-75
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

   [DTSAM-817](https://tools.hmcts.net/jira/browse/DTSAM-817) _"Enable 'civil_wa_2_4' ORM flag in a lower environment and refresh users ready for Civil to test"_

### Change description

Enable `civil_wa_2_4` ORM flag in Demo ready for Civil to test


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


yaml
demo.yaml
- Updated the DB_FEATURE_FLAG_ENABLE from \"publiclaw_wa_1_5\" to \"civil_wa_2_4\"
```