### PR TITLE
FPVTL-491: deploy cos-api PR-3093 to demo to be able to test hearing requests

### DIFF
--- a/apps/private-law/prl-cos/demo-image-policy.yaml
+++ b/apps/private-law/prl-cos/demo-image-policy.yaml
@@ -8,7 +8,7 @@ spec:
   imageRepositoryRef:
     name: prl-cos
   filterTags:
-    pattern: '^pr-3092-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-3093-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/private-law/prl-cos/demo.yaml
+++ b/apps/private-law/prl-cos/demo.yaml
@@ -65,7 +65,7 @@ spec:
       readinessTimeout: 300
       readinessPeriod: 10
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/prl/cos:pr-3092-36886e1-20250408164122 #{"$imagepolicy": "flux-system:demo-prl-cos"}
+      image: hmctspublic.azurecr.io/prl/cos:pr-3093-58773bd-20250408115345 #{"$imagepolicy": "flux-system:demo-prl-cos"}
       environment:
         FEATURE_EXAMPLE: false
         DOCMOSIS_SERVICE_BASE_URL: https://docmosis.demo.platform.hmcts.net


### PR DESCRIPTION
### Jira link

See [FPVTL-491](https://tools.hmcts.net/jira/browse/FPVTL-491)

### Change description

Deploy [PR-3093](https://github.com/hmcts/prl-cos-api/pull/3093) to demo to be able to test hearing requests, the idea is to see if the changes I made to fill in the partyId for applicants and respondents (C100) is enough for these values to travel in the hearing requests to HMC.

### Testing done

Tested locally that the partyId gets filled in for applicants and respondents for C100 applications but unable to test hearing requests on PR environment. Hence why the need to deploy to demo.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
