### PR TITLE
ADOP-2305 run cron at 15mins past the hour in demo

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -6,6 +6,7 @@ spec:
   releaseName: adoption-cron-submit-application-to-court-alerts
   values:
     job:
+      schedule: 15 * * * *
       environment:
         VAR: trigger1
     global:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Testing why Prod logs aren't being pulled into application insights.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
- Added a new job schedule to trigger the job at 15 minutes past the hour.