### PR TITLE
ADOP-2305 override secrets and change cron schedule

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -6,10 +6,24 @@ spec:
   releaseName: adoption-cron-submit-application-to-court-alerts
   values:
     job:
-      schedule: 15 * * * *
+      schedule: 50 * * * *
       keyVaults:
         adoption:
           secrets:
+            - name: uk-gov-notify-api-key
+              alias: UK_GOV_NOTIFY_API_KEY
+            - name: s2s-secret-cos-api
+              alias: S2S_SECRET
+            - name: s2s-secret
+              alias: S2S_SECRET_WEB
+            - name: idam-secret
+              alias: IDAM_CLIENT_SECRET
+            - name: idam-system-user-name
+              alias: IDAM_SYSTEM_UPDATE_USERNAME
+            - name: idam-system-user-password
+              alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
             - name: app-insight-connection-key
               alias: app-insight-connection-key
       environment:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Change cron timing for testing



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo.yaml` 🔄
- Updated the job schedule from `15 * * * *` to `50 * * * *`
- Added new keyVaults for secrets: `uk-gov-notify-api-key`, `s2s-secret-cos-api`, `s2s-secret`, `idam-secret`, `idam-system-user-name`, `idam-system-user-password`, `launchDarkly-sdk-key`