### PR TITLE
ADOP-2305 Override secrets for all environments

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/adoption-cron-submit-application-to-court-alerts.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/adoption-cron-submit-application-to-court-alerts.yaml
@@ -10,6 +10,25 @@ spec:
       environment:
         TASK_NAME: AlertToSubmitApplicationToCourtTask
       schedule: 30 2 * * *
+      keyVaults:
+        adoption:
+          secrets:
+            - name: uk-gov-notify-api-key
+              alias: UK_GOV_NOTIFY_API_KEY
+            - name: s2s-secret-cos-api
+              alias: S2S_SECRET
+            - name: s2s-secret
+              alias: S2S_SECRET_WEB
+            - name: idam-secret
+              alias: IDAM_CLIENT_SECRET
+            - name: idam-system-user-name
+              alias: IDAM_SYSTEM_UPDATE_USERNAME
+            - name: idam-system-user-password
+              alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
+            - name: app-insight-connection-key
+              alias: app-insight-connection-key
   chart:
     spec:
       chart: adoption-cron


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Override secrets for all environments (app-insights-connection-key wasn't being picked up from chart)

### Testing done
Tested in demo.

### Checklist
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `adoption-cron-submit-application-to-court-alerts.yaml` 🔄 Added new keyVaults for adoption secrets with corresponding aliases.