### PR TITLE
ADOP-2305 remove secrets from demo and change test schedule

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -6,26 +6,7 @@ spec:
   releaseName: adoption-cron-submit-application-to-court-alerts
   values:
     job:
-      schedule: 50 * * * *
-      keyVaults:
-        adoption:
-          secrets:
-            - name: uk-gov-notify-api-key
-              alias: UK_GOV_NOTIFY_API_KEY
-            - name: s2s-secret-cos-api
-              alias: S2S_SECRET
-            - name: s2s-secret
-              alias: S2S_SECRET_WEB
-            - name: idam-secret
-              alias: IDAM_CLIENT_SECRET
-            - name: idam-system-user-name
-              alias: IDAM_SYSTEM_UPDATE_USERNAME
-            - name: idam-system-user-password
-              alias: IDAM_SYSTEM_UPDATE_PASSWORD
-            - name: launchDarkly-sdk-key
-              alias: LAUNCH_DARKLY_SDK_KEY
-            - name: app-insight-connection-key
-              alias: app-insight-connection-key
+      schedule: 20 * * * *
       environment:
         VAR: trigger1
     global:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Test with secrets moved to adoption-cron-submit-application-to-court-alerts.yaml

### Checklist
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
- Changed the job schedule from `50 * * * *` to `20 * * * *` for the `adoption-cron-submit-application-to-court-alerts` job.
- Removed the `keyVaults` and `secrets` configuration and added a new `environment` variable `VAR` with value `trigger1`.