### PR TITLE
ADOP-2305 remove demo specific schedule

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: adoption-cron-submit-application-to-court-alerts
   values:
     job:
-      schedule: 20 * * * *
       environment:
         VAR: trigger1
     global:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Changes to master have been merged and behaviour confirmed.  This PR stops the cron job running hourly in demo for testing.


### Checklist

- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-submit-application-to-court-alerts/demo.yaml
- Removed an old job schedule and updated the environment variable for `trigger1`.