### PR TITLE
COT-960 Enable`civil_wa_2_3` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: publiclaw_wa_1_8
+        DB_FEATURE_FLAG_ENABLE: civil_wa_2_3
         REFRESH_JOB: LEGAL_OPERATIONS-CIVIL-NEW-0-75
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

   [COT-960](https://tools.hmcts.net/jira/browse/COT-960) _"Enable 'civil_wa_2_3' ORM flag in a lower environment and refresh users ready for Civil to test"_

### Change description

Enable `civil_wa_2_3` ORM flag in Demo ready for Civil to test.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/am/am-org-role-mapping-service/demo.yaml
- Changed the value of DB_FEATURE_FLAG_ENABLE from \"publiclaw_wa_1_8\" to \"civil_wa_2_3\" 🔄