### PR TITLE
DFR-3639-Post Migration turn off Cron task after Tues

### DIFF
--- a/apps/financial-remedy/finrem-cron-one-off-task/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-one-off-task/aat/aat.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: finrem-cron-one-off-task
   values:
     job:
-      schedule: "*/10 * * * *"
+      schedule: "0 0 1 9 *"
       environment:
         DOCUMENT_MANAGEMENT_STORE_URL: http://dm-store-aat.service.core-compute-aat.internal
         SEND_LETTER_SERVICE_BASEURL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal
@@ -18,11 +18,10 @@ spec:
         FEATURE_CASEWORKER_NOC: true
         FEATURE_CFV_ENABLED: true
         CRON_WAIT_TIME_MINS: 1
-        TASK_NAME: AmendGeneralEmailTask
-        CRON_AMEND_GENERAL_EMAIL_ENABLED: true
-        CRON_AMEND_GENERAL_EMAIL_CASE_TYPE_ID: FinancialRemedyContested
-        CRON_AMEND_GENERAL_EMAIL_BATCH_SIZE: 100
-        CRON_AMEND_GENERAL_EMAIL_CASE_LIST_FILENAME: "caserefs-demo-encrypted.csv"
+        TASK_NAME: BulkAddOrganisationPolicyTask
+        CRON_BULK_ADD_ORGANISATION_POLICY_ENABLED: false
+        CRON_BULK_ADD_ORGANISATION_POLICY_CASE_TYPE_ID: FinancialRemedyContested
+        CRON_BULK_ADD_ORGANISATION_POLICY_BATCH_SIZE: 2000
     global:
       jobKind: CronJob
       enableKeyVaults: true

--- a/apps/financial-remedy/finrem-cron-one-off-task/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-one-off-task/prod/prod.yaml
@@ -26,7 +26,7 @@ spec:
         FEATURE_CFV_ENABLED: true
         CRON_WAIT_TIME_MINS: 1
         TASK_NAME: AmendGeneralEmailTask
-        CRON_AMEND_GENERAL_EMAIL_ENABLED: true
+        CRON_AMEND_GENERAL_EMAIL_ENABLED: false
         CRON_AMEND_GENERAL_EMAIL_CASE_TYPE_ID: FinancialRemedyMVP2
         CRON_AMEND_GENERAL_EMAIL_BATCH_SIZE: 100
         CRON_AMEND_GENERAL_EMAIL_CASE_LIST_FILENAME: "caserefs-prod-cs-encrypted.csv"


### PR DESCRIPTION
Jira link
https://tools.hmcts.net/jira/browse/DFR-3639

Change description
DFR-3639-Migration-General-Email-Field
Post Migration Clean up
Set cron enabled to false

Testing done

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### finrem-cron-one-off-task/aat/aat.yaml
- Changed job schedule from \"*/10 * * * *\" to \"0 0 1 9 *\"
- Changed TASK_NAME and related configurations from AmendGeneralEmailTask to BulkAddOrganisationPolicyTask

### finrem-cron-one-off-task/prod/prod.yaml
- Changed CRON_AMEND_GENERAL_EMAIL_ENABLED from true to false