### PR TITLE
[ADOP-2305] Add secrets to Adoption cron jobs

### DIFF
--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
@@ -10,6 +10,25 @@ spec:
       environment:
         TASK_NAME: AlertDraftCaseApplicantBeforeDeletionTask
       schedule: 0 3 * * *
+      keyVaults:
+        adoption:
+          secrets:
+            - name: uk-gov-notify-api-key
+              alias: UK_GOV_NOTIFY_API_KEY
+            - name: s2s-secret-cos-api
+              alias: S2S_SECRET
+            - name: s2s-secret
+              alias: S2S_SECRET_WEB
+            - name: idam-secret
+              alias: IDAM_CLIENT_SECRET
+            - name: idam-system-user-name
+              alias: IDAM_SYSTEM_UPDATE_USERNAME
+            - name: idam-system-user-password
+              alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
+            - name: app-insight-connection-key
+              alias: app-insight-connection-key
   chart:
     spec:
       chart: adoption-cron

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
@@ -10,6 +10,25 @@ spec:
       environment:
         TASK_NAME: AlertMultiChildApplicationToSubmitTask
       schedule: 0 22 * * *
+      keyVaults:
+        adoption:
+          secrets:
+            - name: uk-gov-notify-api-key
+              alias: UK_GOV_NOTIFY_API_KEY
+            - name: s2s-secret-cos-api
+              alias: S2S_SECRET
+            - name: s2s-secret
+              alias: S2S_SECRET_WEB
+            - name: idam-secret
+              alias: IDAM_CLIENT_SECRET
+            - name: idam-system-user-name
+              alias: IDAM_SYSTEM_UPDATE_USERNAME
+            - name: idam-system-user-password
+              alias: IDAM_SYSTEM_UPDATE_PASSWORD
+            - name: launchDarkly-sdk-key
+              alias: LAUNCH_DARKLY_SDK_KEY
+            - name: app-insight-connection-key
+              alias: app-insight-connection-key
   chart:
     spec:
       chart: adoption-cron


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
adding secrets to Adoption cron jobs to enable log consumption by application insights

### Checklist
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
- Added secret keyVaults for uk-gov-notify, s2s, idam, launchDarkly, and app-insight.
- Updated the schedule to run the task at 3:00 AM.

### apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
- Added secret keyVaults for uk-gov-notify, s2s, idam, launchDarkly, and app-insight.
- Updated the schedule to run the task at 10:00 PM.