### PR TITLE
SDT-246: Updated civil demo kustomization.yaml

### DIFF
--- a/apps/civil/demo/base/kustomization.yaml
+++ b/apps/civil/demo/base/kustomization.yaml
@@ -19,4 +19,5 @@ patches:
   - path: ../../civil-general-applications/demo.yaml
   - path: ../../serviceaccount/demo.yaml
   - path: ../../civil-sdt-gateway/demo.yaml
+  - path: ../../civil-sdt-commissioning/demo.yaml
   - path: ../../civil-rtl-export/demo.yaml


### PR DESCRIPTION
### Jira link

See [SDT-242](https://tools.hmcts.net/jira/browse/SDT-242), [SDT-243](https://tools.hmcts.net/jira/browse/SDT-243) and [SDT-246](https://tools.hmcts.net/jira/browse/SDT-246)

### Change description

Added reference to civil-sdt-commissioning demo.yaml file to patches section of civil/demo/base/kustomization.yaml.  This was missed in previous pull request and is preventing the image specified in demo.yaml from being deployed to demo.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
