### PR TITLE
Adoption: add LA_PORTAL_BASEURL for Adoption Cron Job Email Notifications

### DIFF
--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/prod.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/prod.yaml
@@ -12,6 +12,7 @@ spec:
         NOTIFY_TEMPLATE_SIGN_IN_ADOPTION_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/
         IDAM_API_REDIRECT_URL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/receiver
         IDAM_API_BASEURL: https://idam-api.platform.hmcts.net
+        LA_PORTAL_BASEURL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/la-portal/kba-case-ref
     global:
       jobKind: CronJob
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2658

### Change description
Fixing INC5703888 (emails being sent out with a link based on non-prod environments)

### Checklist
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **prod.yaml** 🔄
  - Added LA_PORTAL_BASEURL: https://apply-to-adopt-a-child-placed-in-your-care.service.gov.uk/la-portal/kba-case-ref to spec section.