### PR TITLE
ADOP: Try using a timezone with the cronjob

### DIFF
--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/demo.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/demo.yaml
@@ -6,6 +6,8 @@ spec:
   releaseName: adoption-multi-child-draft-application-alert
   values:
     job:
+      schedule: 0 12 * * *
+      timeZone: Europe/London
       environment:
         VAR: trigger1
     global:


### PR DESCRIPTION
### Jira link
TBC

### Change description
 - add a timezone

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cron-multi-child-draft-application-alert/demo.yaml
- Added a new job schedule to trigger the job at 12:00 (UTC) every day.
- Set the timezone for the job to Europe/London.