### PR TITLE
ADOP-2657 Add Migration Tools logs to App Insights

### DIFF
--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/adoption-cron-ccd-data-migration-tool.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/adoption-cron-ccd-data-migration-tool.yaml
@@ -25,6 +25,21 @@ spec:
         DEFAULT_THREAD_LIMIT: 25
         DEFAULT_QUERY_SIZE: 100
         RETRY_FAILURES: true
+      keyVaults:
+        adoption:
+          secrets:
+            - name: idam-system-user-name
+              alias: IDAM_USERNAME
+            - name: idam-system-user-password
+              alias: IDAM_PASSWORD
+            - name: idam-secret
+              alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
+            - name: s2s-secret-cos-api
+              alias: DATA_STORE_IDAM_KEY
+            - name: migration-tool-case-id-list-mapping
+              alias: CASE_ID_LIST_MAPPING
+            - name: app-insight-connection-key
+              alias: app-insight-connection-key
   chart:
     spec:
       chart: ./stable/adoption-cron-ccd-data-migration-tool

--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/demo.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/demo.yaml
@@ -23,18 +23,3 @@ spec:
         CCD_DATA_STORE_API_BASE_URL: http://ccd-data-store-api-demo.service.core-compute-demo.internal
         DEFAULT_THREAD_LIMIT: 25
         DEFAULT_QUERY_SIZE: 100
-      keyVaults:
-        adoption:
-          secrets:
-            - name: idam-system-user-name
-              alias: IDAM_USERNAME
-            - name: idam-system-user-password
-              alias: IDAM_PASSWORD
-            - name: idam-secret
-              alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
-            - name: s2s-secret-cos-api
-              alias: DATA_STORE_IDAM_KEY
-            - name: migration-tool-case-id-list-mapping
-              alias: CASE_ID_LIST_MAPPING
-            - name: app-insight-connection-key
-              alias: app-insight-connection-key

--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/perftest.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/perftest.yaml
@@ -19,16 +19,3 @@ spec:
         DEFAULT_THREAD_LIMIT: 25
         DEFAULT_QUERY_SIZE: 100
         RETRY_FAILURES: true
-      keyVaults:
-        adoption:
-          secrets:
-            - name: idam-system-user-name
-              alias: IDAM_USERNAME
-            - name: idam-system-user-password
-              alias: IDAM_PASSWORD
-            - name: idam-secret-cos-api
-              alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
-            - name: s2s-secret-cos-api
-              alias: DATA_STORE_IDAM_KEY
-            - name: migration-tool-case-id-list-mapping
-              alias: CASE_ID_LIST_MAPPING

--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/prod.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/prod.yaml
@@ -26,4 +26,3 @@ spec:
         DEFAULT_THREAD_LIMIT: 25
         DEFAULT_QUERY_SIZE: 100
         RETRY_FAILURES: true
-

--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/prod.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/prod.yaml
@@ -26,16 +26,4 @@ spec:
         DEFAULT_THREAD_LIMIT: 25
         DEFAULT_QUERY_SIZE: 100
         RETRY_FAILURES: true
-      keyVaults:
-        adoption:
-          secrets:
-            - name: idam-system-user-name
-              alias: IDAM_USERNAME
-            - name: idam-system-user-password
-              alias: IDAM_PASSWORD
-            - name: idam-secret
-              alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
-            - name: s2s-secret-cos-api
-              alias: DATA_STORE_IDAM_KEY
-            - name: migration-tool-case-id-list-mapping
-              alias: CASE_ID_LIST_MAPPING
+

--- a/apps/adoption/prod/00/kustomization.yaml
+++ b/apps/adoption/prod/00/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 resources:
   - ../base
 namespace: adoption
+patches:
+  - path: ../../adoption-cron-ccd-data-migration-tool/prod/00.yaml
 sortOptions:
   order: fifo

--- a/apps/adoption/prod/01/kustomization.yaml
+++ b/apps/adoption/prod/01/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 resources:
   - ../base
 namespace: adoption
+patches:
+  - path: ../../adoption-cron-ccd-data-migration-tool/prod/01.yaml
 sortOptions:
   order: fifo

--- a/apps/adoption/prod/base/kustomization.yaml
+++ b/apps/adoption/prod/base/kustomization.yaml
@@ -10,4 +10,5 @@ patches:
   - path: ../../adoption-cron-draft-case-deletion-alert/prod.yaml
   - path: ../../adoption-cron-multi-child-draft-application-alert/prod.yaml
   - path: ../../adoption-cron-submit-application-to-court-alerts/prod.yaml
+  - path: ../../adoption-cron-ccd-data-migration-tool/prod.yaml
   - path: ../../serviceaccount/prod.yaml


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
- add app-insight-connection-key secret
- move secrets to migration-tool.yaml to reduce repetition
- add migration tool to Prod kustomization

### Testing done
Tested in demo.

### Checklist
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


**apps/adoption/adoption-cron-ccd-data-migration-tool/adoption-cron-ccd-data-migration-tool.yaml**
- Added keyVaults and secrets configuration for adoption.

**apps/adoption/adoption-cron-ccd-data-migration-tool/demo.yaml**
- Removed keyVaults and secrets configuration for adoption.

**apps/adoption/adoption-cron-ccd-data-migration-tool/perftest.yaml**
- Removed keyVaults and secrets configuration for adoption.

**apps/adoption/adoption-cron-ccd-data-migration-tool/prod.yaml**
- Removed keyVaults and secrets configuration for adoption.

**apps/adoption/prod/00/kustomization.yaml**
- Added a patch for ./adoption-cron-ccd-data-migration-tool/prod/00.yaml.

**apps/adoption/prod/01/kustomization.yaml**
- Added a patch for ./adoption-cron-ccd-data-migration-tool/prod/01.yaml.

**apps/adoption/prod/base/kustomization.yaml**
- Added a patch for ./adoption-cron-ccd-data-migration-tool/prod.yaml.