### PR TITLE
Remove ADOP-2657 from demo and schedule demo cron for 30th Feb

### DIFF
--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/demo-image-policy.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-adoption-cron-ccd-data-migration-tool
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-75-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: adoption-cron-ccd-data-migration-tool

--- a/apps/adoption/adoption-cron-ccd-data-migration-tool/demo/00.yaml
+++ b/apps/adoption/adoption-cron-ccd-data-migration-tool/demo/00.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     job:
       image: hmctspublic.azurecr.io/adoption/cron-ccd-data-migration-tool:pr-75-ca7a5b1-20250417132133 #{"$imagepolicy": "flux-system:demo-adoption-cron-ccd-data-migration-tool"}
-      schedule: "0/20 * * * *"
+      schedule: "30 12 30 2 *"
       environment:
         ENABLED: true
         MIGRATION_ID: ADOP-2555


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2305

### Change description
Remove ADOP-2657 from demo and schedule demo cron for 30th Feb so it doesn't run


### Checklist
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


-  `demo-image-policy.yaml`
  - Removed annotations for prod-automated and filterTags, extract, and policy specifications, and reorganized the order of the image policy for adoption-cron-ccd-data-migration-tool.

- `demo/00.yaml`
  - Updated the schedule from \"0/20 * * * *\" to \"30 12 30 2 *\" for the adoption-cron-ccd-data-migration-tool job.