### PR TITLE
reverting CME-110 from DEMO

### DIFF
--- a/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-2539-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2539-d50ad64-20250403113000 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-9d5d11a-20250408111455 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
       replicas: 4
       autoscaling:
         enabled: true


### PR DESCRIPTION
reverting CME-110 from DEMO

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-data-store-api/demo-image-policy.yaml
- Changed annotation from `disabled` to `enabled` for `hmcts.github.com/prod-automated`
- Updated the `pattern` in `filterTags` from '^pr-2539-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'

### apps/ccd/ccd-data-store-api/demo.yaml
- Updated the image tag from `pr-2539-d50ad64-20250403113000` to `prod-9d5d11a-20250408111455` in the `java` section.