### PR TITLE
CCD - Align prod and perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      replicas: 8
+      replicas: 12
       image: hmctspublic.azurecr.io/ccd/data-store-api:prod-9d5d11a-20250408111455 #{"$imagepolicy": "flux-system:perftest-ccd-data-store-api"}
       autoscaling:
         enabled: false
@@ -14,7 +14,7 @@ spec:
         maxReplicas: 8
         memory:
           averageUtilization: 125
-      memoryRequests: '4096Mi'
+      memoryRequests: '5120Mi'
       memoryLimits: '6144Mi'
       cpuRequests: '1000m'
       cpuLimits: '3000m'


### PR DESCRIPTION
### Change description

Aligning resources limits with prod as per  https://github.com/hmcts/cnp-flux-config/pull/38136/files

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-data-store-api/perftest.yaml
- Increased the number of replicas from 8 to 12 for the java service.
- Updated the memory requests from '4096Mi' to '5120Mi' and memory limits to '6144Mi'.
- Adjusted the cpu requests to '1000m' and cpu limits to '3000m'.