### PR TITLE
Set Gen Apps back to Prod

### DIFF
--- a/apps/civil/civil-general-applications/demo-image-policy.yaml
+++ b/apps/civil/civil-general-applications/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-civil-general-applications
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1711-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-general-applications

--- a/apps/civil/civil-general-applications/demo.yaml
+++ b/apps/civil/civil-general-applications/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/general-applications:pr-1711-b51f9cd-20250416101207 #{"$imagepolicy": "flux-system:demo-civil-general-applications"}
+      image: hmctspublic.azurecr.io/civil/general-applications:prod-d2b4708-20250417111539 #{"$imagepolicy": "flux-system:demo-civil-general-applications"}
       keyVaults:
         civil:
           resourceGroup: civil


### PR DESCRIPTION
### Change description
Just putting GenApps back to prod image


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo-image-policy.yaml`:
  - Removed annotations and filterTags from the ImagePolicy spec.
  - Removed the imageRepositoryRef's alphabetical policy.
- `demo.yaml`:
  - Updated the image tag from `pr-1711-b51f9cd-20250416101207` to `prod-d2b4708-20250417111539` for the `java` image.