### PR TITLE
Restarting def and data store on demo

### DIFF
--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -28,7 +28,7 @@ spec:
         DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,bulk_scan_payment_processor,pcq_consolidation_service,em_npa_app,ecm_consumer,aac_manage_case_assignment,am_role_assignment_service,nfdiv_cms,nfdiv_cos,divorce_frontend,em_hrs_api,nfdiv_case_api,civil_service,ccd_case_document_am_api,wa_task_monitor,wa_task_management_api,adoption_cos_api,adoption_web,et_cos,et_msg_handler,prl_cos_api,et_sya_api,ds_ui,hmc_cft_hearing_service,prl_cos_api,fis_hmc_api,ccd_next_hearing_date_updater,civil_general_applications,fis_cos_api,sptribs_case_api,em_annotation_app,divorce,et_hearings_api,sptribs_dss_update_case_web
         DEFAULT_CACHE_TTL_SEC: 30
         DEFINITION_CACHE_JURISDICTION_TTL_SEC: 120
-        DUMMY_RESTART_VAR: 2
+        DUMMY_RESTART_VAR: 3
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net
         SERVER_MAX_HTTP_HEADER_SIZE: 100KB
         ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL: true

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -21,5 +21,5 @@ spec:
         DEFINITION_STORE_DB_MAX_POOL_SIZE: 20
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v15-demo.postgres.database.azure.com
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp,aac_manage_case_assignment,em_hrs_api,ds_ui,fis_cos_api,xui_webapp,am_org_role_mapping_service
-        DUMMY_RESTART_VAR: 3
+        DUMMY_RESTART_VAR: 2
         WELSH_TRANSLATION_ENABLED: true


### PR DESCRIPTION
Restating definition and data store on demo

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-data-store-api/demo.yaml
- Changed the value of `DUMMY_RESTART_VAR` from 2 to 3.
- Updated the `ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL` to true.

### apps/ccd/ccd-definition-store-api/demo.yaml
- Changed the value of `DUMMY_RESTART_VAR` from 3 to 2.