### PR TITLE
restart hmc-hmi-outbound-adapter

### DIFF
--- a/apps/hmc/hmc-hmi-outbound-adapter/hmc-hmi-outbound-adapter.yaml
+++ b/apps/hmc/hmc-hmi-outbound-adapter/hmc-hmi-outbound-adapter.yaml
@@ -10,7 +10,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/hmc/hmi-outbound-adapter:prod-0e0a060-20250416113847 #{"$imagepolicy": "flux-system:hmc-hmi-outbound-adapter"}
       environment:
-        DUMMY_VAR: 1
+        DUMMY_VAR: 0
   chart:
     spec:
       chart: ./stable/hmc-hmi-outbound-adapter


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `apps/hmc/hmc-hmi-outbound-adapter/hmc-hmi-outbound-adapter.yaml` has the environment variable `DUMMY_VAR` changed from 1 to 0.
- The image version `prod-0e0a060-20250416113847` and the use of interpod anti-affinity are maintained.
- The chart reference remains unchanged.