### PR TITLE
DFR-3721: Update finrem-cron-draft-order-review-overdue to use oci helm chart

### DIFF
--- a/apps/financial-remedy/finrem-cron-draft-order-review-overdue/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-draft-order-review-overdue/aat/aat.yaml
@@ -28,11 +28,3 @@ spec:
       enableKeyVaults: true
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       environment: aat
-  chart:
-    spec:
-      chart: finrem-cron
-      version: 0.0.8
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/financial-remedy/finrem-cron-draft-order-review-overdue/finrem-cron-draft-order-review-overdue.yaml
+++ b/apps/financial-remedy/finrem-cron-draft-order-review-overdue/finrem-cron-draft-order-review-overdue.yaml
@@ -14,8 +14,8 @@ spec:
   chart:
     spec:
       chart: finrem-cron
-      version: 0.0.8
+      version: 0.0.9
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3721

### Change description

Update finrem-cron-draft-order-review-overdue to use oci helm chart


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `aat.yaml` 🔄 Updated the configuration to remove the chart details and added the environment field.
- `finrem-cron-draft-order-review-overdue.yaml` 🔄 Updated the version from 0.0.8 to 0.0.9 and the Helm repository name from hmctspublic to hmctspublic-oci.