### PR TITLE
ADOP-2665: Update jobs to use hmctspublic-oci

### DIFF
--- a/apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
+++ b/apps/adoption/adoption-cron-draft-case-deletion-alert/adoption-cron-draft-case-deletion-alert.yaml
@@ -35,5 +35,5 @@ spec:
       version: 0.0.14
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
@@ -35,5 +35,5 @@ spec:
       version: 0.0.14
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/adoption/adoption-cron-submit-application-to-court-alerts/adoption-cron-submit-application-to-court-alerts.yaml
+++ b/apps/adoption/adoption-cron-submit-application-to-court-alerts/adoption-cron-submit-application-to-court-alerts.yaml
@@ -35,5 +35,5 @@ spec:
       version: 0.0.14
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [ADOP-2665](https://tools.hmcts.net/jira/browse/ADOP-2665)

### Change description
Use oci:// urls

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### File changes
- `adoption-cron-draft-case-deletion-alert.yaml`
  - Changed the `name` value from `hmctspublic` to `hmctspublic-oci`.
- `adoption-cron-multi-child-draft-application-alert.yaml`
  - Changed the `name` value from `hmctspublic` to `hmctspublic-oci`.
- `adoption-cron-submit-application-to-court-alerts.yaml`
  - Changed the `name` value from `hmctspublic` to `hmctspublic-oci`.