### PR TITLE
Updating vm agent to apply to all of civil, not just civil-citizen-ui.

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -122,7 +122,7 @@ spec:
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.4"
                         <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-ubuntu-civi"
+                      - templateName: "cnp-jenkins-ubuntu-civil"
                         templateDesc: "Jenkins build agents for Civil builds"
                         labels: "civil"
                         maxVirtualMachinesLimit: 25

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -122,10 +122,10 @@ spec:
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.4"
                         <<: *vm_template_values_anchor
-                      - templateName: "cnp-jenkins-ubuntu-civil-citizen-ui"
-                        templateDesc: "Jenkins build agents for Civil Citizen UI builds"
-                        labels: "civil-citizen-ui"
-                        maxVirtualMachinesLimit: 1
+                      - templateName: "cnp-jenkins-ubuntu-civi"
+                        templateDesc: "Jenkins build agents for Civil builds"
+                        labels: "civil"
+                        maxVirtualMachinesLimit: 25
                         retentionStrategy:
                           azureVMCloudRetentionStrategy:
                             idleTerminationMinutes: 5


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24729

### Change description

We created a PoC to improve the vm specs for agents running the civil-citizen-ui pipeline. Now that this has been tested and approved, we're applying this to all of civil.

### Testing done

We created a PoC for civil-citizen-ui, and the builds ran much faster for the team. 

- `jenkins-azure-vm-agent.yaml` 🔄
  - Removed the template for \"cnp-jenkins-ubuntu-civil-citizen-ui\" and added a new template for \"cnp-jenkins-ubuntu-civi\" with updated description and labels.
  - Increased the maximum virtual machines limit to 25 for the new template.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `jenkins-azure-vm-agent.yaml` 🛠️
  - Changed template for Jenkins build agents for Civil builds, increasing max virtual machines limit from 1 to 25. Updated template description and labels.

