### PR TITLE
restarting ccd-def-store and ccd-data-store after new LB Switch

### DIFF
--- a/apps/ccd/ccd-data-store-api/aat.yaml
+++ b/apps/ccd/ccd-data-store-api/aat.yaml
@@ -25,7 +25,7 @@ spec:
         DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,bulk_scan_payment_processor,pcq_consolidation_service,em_npa_app,ecm_consumer,aac_manage_case_assignment,am_role_assignment_service,wa_task_configuration_api,divorce_frontend,wa_task_management_api,wa_workflow_api,em_hrs_api,nfdiv_case_api,civil_service,wa_task_monitor,ccd_case_document_am_api,adoption_cos_api,adoption_web,et_cos,et_msg_handler,prl_cos_api,wa_case_event_handler,et_sya_api,ds_ui,hmc_cft_hearing_service,prl_cos_api,fis_hmc_api,ccd_next_hearing_date_updater,civil_general_applications,fis_cos_api,sptribs_case_api,et_wa_post_deployment_ft_tests,em_annotation_app,et_hearings_api,sptribs_dss_update_case_web
         DEFAULT_CACHE_TTL_SEC: 30
         DEFINITION_CACHE_JURISDICTION_TTL_SEC: 120
-        DUMMY_RESTART_VAR: 7
+        DUMMY_RESTART_VAR: 6
         ELASTIC_SEARCH_REQUEST_TIMEOUT: 16000
         HTTP_CLIENT_MAX_CLIENT_PER_ROUTE: 40
         DATA_STORE_DB_MAX_POOL_SIZE: 15

--- a/apps/ccd/ccd-definition-store-api/aat.yaml
+++ b/apps/ccd/ccd-definition-store-api/aat.yaml
@@ -20,4 +20,4 @@ spec:
         DEFINITION_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_admin,jui_webapp,pui_webapp,aac_manage_case_assignment,em_hrs_api,ds_ui,fis_cos_api,xui_webapp,am_org_role_mapping_service
         DEFINITION_STORE_DB_NAME: ccd_definition_store
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v15-aat.postgres.database.azure.com
-        DUMMY_RESTART_VAR: 2
+        DUMMY_RESTART_VAR: 1


### PR DESCRIPTION
restarting ccd-def-store and ccd-data-store after new LB Switch

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


**apps/ccd/ccd-data-store-api/aat.yaml**
- Changed the value of `DUMMY_RESTART_VAR` from 7 to 6.
  
**apps/ccd/ccd-definition-store-api/aat.yaml**
- Changed the value of `DUMMY_RESTART_VAR` from 2 to 1.