### PR TITLE
FPLVT-608 update PRL crons to use oci for hmctspublic

### DIFF
--- a/apps/private-law/prl-cron-fm5-reminder/prl-cron-fm5-reminder.yaml
+++ b/apps/private-law/prl-cron-fm5-reminder/prl-cron-fm5-reminder.yaml
@@ -72,5 +72,5 @@ spec:
       version: 0.0.18
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/private-law/prl-cron-hearing-actual-task/prl-cron-hearing-actual-task.yaml
+++ b/apps/private-law/prl-cron-hearing-actual-task/prl-cron-hearing-actual-task.yaml
@@ -72,5 +72,5 @@ spec:
       version: 0.0.17
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/private-law/prl-cron-hwf-citizen-update-state/prl-cron-hwf-citizen-update-state.yaml
+++ b/apps/private-law/prl-cron-hwf-citizen-update-state/prl-cron-hwf-citizen-update-state.yaml
@@ -71,5 +71,5 @@ spec:
       version: 0.0.18
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/private-law/prl-cron-hwf-process-awp/prl-cron-hwf-process-awp.yaml
+++ b/apps/private-law/prl-cron-hwf-process-awp/prl-cron-hwf-process-awp.yaml
@@ -71,5 +71,5 @@ spec:
       version: 0.0.18
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system


### PR DESCRIPTION
resolves: https://tools.hmcts.net/jira/browse/FPVTL-608

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated 4 files in the `prl-cron-fm5-reminder`, `prl-cron-hearing-actual-task`, `prl-cron-hwf-citizen-update-state`, and `prl-cron-hwf-process-awp` directories
- Updated the `name` in the `spec` section of each file from `hmctspublic` to `hmctspublic-oci` for the `HelmRepository`