### PR TITLE
  PAY-6995: HTTP 400 errors with GET /Refund endpoint

### DIFF
--- a/apps/fees-pay/ccpay-refunds-api-int/ccpay-refunds-api-int.yaml
+++ b/apps/fees-pay/ccpay-refunds-api-int/ccpay-refunds-api-int.yaml
@@ -7,8 +7,8 @@ spec:
   values:
     java:
       replicas: 2
-      useInterpodAntiAffinity: false
-      image: hmctspublic.azurecr.io/ccpay/refunds-api:prod-a0d6ba5-20250424123746 #{"$imagepolicy": "flux-system:ccpay-refunds-api"}
+      useInterpodAntiAffinity: true
+      image: hmctspublic.azurecr.io/ccpay/refunds-api:prod-a0d6ba5-20250424123746 #{"$imagepolicy": "flux-system:demo-int-ccpay-refunds-api"}
       ingressHost: ccpay-refunds-api-int-demo.service.core-compute-demo.internal
   chart:
     spec:


### PR DESCRIPTION
      PAY-6995: HTTP 400 errors with GET /Refund endpoint
                [PAY-6995] (https://tools.hmcts.net/jira/browse/PAY-6995).


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **ccpay-refunds-api-int.yaml**
  - `useInterpodAntiAffinity` changed from `false` to `true`
  - `image` updated to `hmctspublic.azurecr.io/ccpay/refunds-api:prod-a0d6ba5-20250424123746`