### PR TITLE
NFDIV-4854 Update to OCI chart for NFD crons

### DIFF
--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/nfdiv-cron-alert-application-not-reviewed.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/ithc/ithc.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/ithc/ithc.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.20
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/nfdiv-cron-applicant-can-sts-after-intention-fo.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/nfdiv-cron-applicant-can-sts-after-intention-fo.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/ithc.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/ithc.yaml
@@ -17,5 +17,5 @@ spec:
     spec:
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/nfdiv-cron-application-approved-reminder.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/nfdiv-cron-bulk-list-create.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/nfdiv-cron-eligible-for-switch-to-sole.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/nfdiv-cron-eligible-for-switch-to-sole.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/nfdiv-cron-final-order-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/nfdiv-cron-final-order-overdue.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/nfdiv-cron-find-cases-with-successful-payments.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/nfdiv-cron-find-cases-with-successful-payments.yaml
@@ -20,5 +20,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/nfdiv-cron-js-disputed-answer-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/nfdiv-cron-js-disputed-answer-overdue.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/nfdiv-cron-migrate-bulk-cases.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/nfdiv-cron-migrate-cases.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/ithc.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/ithc.yaml
@@ -17,5 +17,5 @@ spec:
     spec:
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/nfdiv-cron-notify-applicant-dispute-form-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/nfdiv-cron-notify-applicant-dispute-form-overdue.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/nfdiv-cron-notify-applicants-apply-co.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/nfdiv-cron-notify-applicants-apply-co.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/nfdiv-cron-notify-respondent-apply-final-order.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/nfdiv-cron-partner-not-applied-for-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/nfdiv-cron-partner-not-applied-for-final-order.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/nfdiv-cron-process-cases-to-be-removed.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/nfdiv-cron-process-cases-to-be-removed.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/nfdiv-cron-process-failed-pronounced-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/nfdiv-cron-process-failed-pronounced-cases.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/nfdiv-cron-process-failed-scheduled-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/nfdiv-cron-process-failed-scheduled-cases.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/nfdiv-cron-process-failed-to-unlink-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/nfdiv-cron-process-failed-to-unlink-cases.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/nfdiv-cron-progress-cases-to-aos-overdue.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/nfdiv-cron-progress-cases-to-aos-overdue.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/nfdiv-cron-progress-held-cases.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/nfdiv-cron-progress-held-cases.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/nfdiv-cron-progress-to-awaiting-final-order.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/nfdiv-cron-remind-applicant2.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/nfdiv-cron-remind-applicant2.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/nfdiv-cron-remind-applicants-apply-for-fo.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/ithc/ithc.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/ithc/ithc.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.20
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/nfdiv-cron-remind-awaiting-joint-final-order.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/nfdiv-cron-remind-awaiting-joint-final-order.yaml
@@ -32,5 +32,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/nfdiv-cron-remind-respondent-solicitor.yaml
@@ -31,5 +31,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system

--- a/apps/nfdiv/nfdiv-cron-states-report/nfdiv-cron-states-report.yaml
+++ b/apps/nfdiv/nfdiv-cron-states-report/nfdiv-cron-states-report.yaml
@@ -36,5 +36,5 @@ spec:
       version: 0.0.23
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/NFDIV-4854

### Change description

Update to OCI chart for nfdiv crons

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated the `nfdiv-cron-alert-application-not-reviewed.yaml`, `nfdiv-cron-applicant-can-sts-after-intention-fo.yaml`, `nfdiv-cron-application-approved-reminder.yaml`, `nfdiv-cron-bulk-list-create.yaml`, `nfdiv-cron-eligible-for-switch-to-sole.yaml`, `nfdiv-cron-final-order-overdue.yaml`, `nfdiv-cron-find-cases-with-successful-payments.yaml`, `nfdiv-cron-js-disputed-answer-overdue.yaml`, `nfdiv-cron-migrate-bulk-cases.yaml`, `nfdiv-cron-migrate-cases.yaml`, `nfdiv-cron-notify-applicant-dispute-form-overdue.yaml`, `nfdiv-cron-notify-applicants-apply-co.yaml`, `nfdiv-cron-notify-respondent-apply-final-order.yaml`, `nfdiv-cron-partner-not-applied-for-final-order.yaml`, `nfdiv-cron-process-cases-to-be-removed.yaml`, `nfdiv-cron-process-failed-pronounced-cases.yaml`, `nfdiv-cron-process-failed-scheduled-cases.yaml`, `nfdiv-cron-process-failed-to-unlink-cases.yaml`, `nfdiv-cron-progress-cases-to-aos-overdue.yaml`, `nfdiv-cron-progress-held-cases.yaml`, `nfdiv-cron-progress-to-awaiting-final-order.yaml`, `nfdiv-cron-remind-applicant2.yaml`, `nfdiv-cron-remind-applicants-apply-for-fo.yaml`, `nfdiv-cron-remind-awaiting-joint-final-order.yaml`, `nfdiv-cron-remind-respondent-solicitor.yaml`, `nfdiv-cron-states-report.yaml` files to use `hmctspublic-oci` instead of `hmctspublic`.