### PR TITLE
CME-346: Re-enable am-role-assignment-refresh-batch in lower environments

### DIFF
--- a/apps/am/am-org-role-mapping-service/ithc.yaml
+++ b/apps/am/am-org-role-mapping-service/ithc.yaml
@@ -14,5 +14,3 @@ spec:
         # always set 'REFRESH_JOB_ALLOW_UPDATE' to false before next refresh (i.e. only use when setting existing job to ABORTED)
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: false
-        # Temporary set of TESTING_SUPPORT_ENABLED = true for CME-346
-        TESTING_SUPPORT_ENABLED: true

--- a/apps/am/am-role-assignment-refresh-batch/aat.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/aat.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "0 17 30 02 *"
+      schedule: "0 17 * * *"
       environment:
         DELETE_ORG: true
         EMAIL_ENABLED: true

--- a/apps/am/am-role-assignment-refresh-batch/demo.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "*/20 * 30 02 *"
+      schedule: "*/20 * * * *"
       environment:
         DELETE_ORG: false
         AM_RAS_URL: http://am-role-assignment-service-demo.service.core-compute-demo.internal

--- a/apps/am/am-role-assignment-refresh-batch/ithc.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/ithc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "*/20 * 30 02 *"
+      schedule: "*/20 * * * *"
       image: hmctspublic.azurecr.io/am/role-assignment-refresh-batch:pr-777-f4c413c-20250428152855 #{"$imagepolicy": "flux-system:ithc-am-role-assignment-refresh-batch"}
       environment:
         DELETE_ORG: false

--- a/apps/am/am-role-assignment-refresh-batch/perftest.yaml
+++ b/apps/am/am-role-assignment-refresh-batch/perftest.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      schedule: "*/10 * 30 02 *"
+      schedule: "*/20 * * * *"
       environment:
         AM_INFO: true
         DELETE_ORG: true


### PR DESCRIPTION
### Jira link

[CME-346](https://tools.hmcts.net/jira/browse/CME-346) _"Spring Boot 3 and Java 21 Upgrade Upgrade RARB"_

### Change description

Re-enable **am-role-assignment-refresh-batch** job in lower environments only after release of hmcts/am-org-role-mapping-service#2317 and hmcts/am-role-assignment-refresh-batch#777.

> NB: this is mostly a revert of #38325.









## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/am/am-org-role-mapping-service/ithc.yaml` 🔄 Removed the `TESTING_SUPPORT_ENABLED` flag and `DUMMY_VAR` flag.
- `apps/am/am-role-assignment-refresh-batch/aat.yaml` 🔄 Updated the job schedule from \"0 17 30 02 *\" to \"0 17 * * *\".
- `apps/am/am-role-assignment-refresh-batch/demo.yaml` 🔄 Updated the job schedule from \"*/20 * 30 02 *\" to \"*/20 * * * *\".
- `apps/am/am-role-assignment-refresh-batch/ithc.yaml` 🔄 Updated the job schedule from \"*/20 * 30 02 *\" to \"*/20 * * * *\".
- `apps/am/am-role-assignment-refresh-batch/perftest.yaml` 🔄 Updated the job schedule from \"*/10 * 30 02 *\" to \"*/20 * * * *\". Made changes in environment variables.