### PR TITLE
Revert "(RST-7076) ET PET PDF release to demo"

### DIFF
--- a/apps/et-pet/et-pet-api/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-api
-  filterTags:
-    pattern: '^pr-728-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc

--- a/apps/et-pet/et-pet-ccd-export/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-ccd-export/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-ccd-export
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-ccd-export
-  filterTags:
-    pattern: '^pr-386-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc

--- a/apps/et-pet/et-pet-et1/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-et1/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-et1
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-et1
-  filterTags:
-    pattern: '^pr-1658-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc

--- a/apps/et-pet/et-pet-et3/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-et3/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-et3
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-et3
-  filterTags:
-    pattern: '^pr-689-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37027

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated demo-image-policy.yaml in et-pet-api, et-pet-ccd-export, et-pet-et1, and et-pet-et3.
- Removed annotations for hmcts.github.com/prod-automated: disabled.
- Removed filterTags and extract sections related to PR image patterns.