### PR TITLE
fix: missing traefik args in demo

### DIFF
--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -14,6 +14,8 @@ spec:
     serviceAccount:
       name: admin
     additionalArguments:
+      - "--entryPoints.web.forwardedHeaders.insecure=true"
+      - "--entryPoints.websecure.forwardedHeaders.insecure=true"
       - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
       - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
       - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -14,6 +14,8 @@ spec:
     serviceAccount:
       name: admin
     additionalArguments:
+      - "--entryPoints.web.forwardedHeaders.insecure=true"
+      - "--entryPoints.websecure.forwardedHeaders.insecure=true"
       - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
       - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
       - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `00.yaml` 🛠️ Added additional arguments for `web` and `websecure` entry points in the Traefik demo configuration.
- `01.yaml` 🛠️ Added additional arguments for `web` and `websecure` entry points in the Traefik demo configuration.