### PR TITLE
Add deployment id to test manual hearing cancellation event

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -10,4 +10,4 @@ spec:
       spotInstances:
         enabled: true
       environment:
-        RESTART_PODS: "yes"
+        HMC_DEPLOYMENT_ID: "dummy"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


md
- Updated apps/ia/ia-hearings-api/demo.yaml
- Added a new environment variable HMC_DEPLOYMENT_ID with value \"dummy\"
```