### PR TITLE
Add invalid HMC url to test manual hearing cancellation events

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -11,4 +11,4 @@ spec:
         enabled: true
       environment:
         HMC_DEPLOYMENT_ID: "dummy"
-        HMC_HEARINGS_LISTENING_ENABLED: false
+        HMC_API_URL: ''


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ia/ia-hearings-api/demo.yaml
- Updated the value of `HMC_HEARINGS_LISTENING_ENABLED` from `false` to an empty string.
- Added a new environment variable `HMC_API_URL`.