### PR TITLE
Add invalid HMC url to test manual hearing cancellation events

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -11,4 +11,4 @@ spec:
         enabled: true
       environment:
         HMC_DEPLOYMENT_ID: "dummy"
-        HMC_API_URL: ''
+        HMC_API_URL: "http://hmc-cft-hearing-service-dem.service.core-compute-dem.internal"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ia/ia-hearings-api/demo.yaml
- Changed the value of HMC_API_URL from an empty string to \"http://hmc-cft-hearing-service-dem.service.core-compute-dem.internal\" 🔄