### PR TITLE
CIV-17066 reverted image policy change for testing AAT

### DIFF
--- a/apps/civil/civil-service/aat-image-policy.yaml
+++ b/apps/civil/civil-service/aat-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: aat-civil-service
+  annotations:
+    hmcts.github.com/prod-automated: enabled
 spec:
+  filterTags:
+    pattern: '^pr-6489-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/aat-image-policy.yaml
+++ b/apps/civil/civil-service/aat-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: aat-civil-service
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-6489-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: civil-service

--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-6489-6b6ea98-20250506154311 #{"$imagepolicy": "flux-system:aat-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:pr-6489-6b6ea98-20250506154311 #{"$imagepolicy": "flux-system:civil-service"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-6489-6b6ea98-20250506154311 #{"$imagepolicy": "flux-system:civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-67550d4-20250507112847 #{"$imagepolicy": "flux-system:civil-service"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -19,7 +19,6 @@ EXCLUSIONS_LIST=(
     apps/sscs/sscs-tribunals-api/aat.yaml
     apps/sscs/sscs-tya-notif/aat.yaml
     apps/hmc/hmc-operational-reports-runner-int/hmc-operational-reports-runner-int.yaml
-    apps/civil/civil-service/aat.yaml
     .*perftest.*
     .*sbox.*
     .*test.*


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CIV-17066

### Change description

Reverted changes which were done to test in CUI-ILA release in AAT








## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `aat-image-policy.yaml` 🔄: Changed the annotation value from \"disabled\" to \"enabled\".
- `aat.yaml` 🔄: Updated the image tag from \"pr-6489-6b6ea98-20250506154311\" to \"prod-67550d4-20250507112847\".
- `flux-v2-image-automation.sh` 🔄: Removed the reference to \"apps/civil/civil-service/aat.yaml\" from the exclusions list.