### PR TITLE
Revert "CIV-17066 - make sure aat uses pr image"

### DIFF
--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/civil/service:pr-6489-6b6ea98-20250506154311 #{"$imagepolicy": "flux-system:aat-civil-service"}
+      image: hmctspublic.azurecr.io/civil/service:prod-1c45813-20250506144935 #{"$imagepolicy": "flux-system:civil-service"}
       keyVaults:
         civil:
           resourceGroup: civil

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -19,7 +19,6 @@ EXCLUSIONS_LIST=(
     apps/sscs/sscs-tribunals-api/aat.yaml
     apps/sscs/sscs-tya-notif/aat.yaml
     apps/hmc/hmc-operational-reports-runner-int/hmc-operational-reports-runner-int.yaml
-    apps/civil/civil-service/aat.yaml
     .*perftest.*
     .*sbox.*
     .*test.*


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#38401

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/aat.yaml
- Updated the image for the Java service to `hmctspublic.azurecr.io/civil/service:prod-1c45813-20250506144935`

### tests/flux-v2-image-automation.sh
- Removed `apps/civil/civil-service/aat.yaml` from the exclusions list.