### PR TITLE
upgrade traefik to v35.2 in sbox 00 and 01

### DIFF
--- a/apps/admin/traefik-crds-upgrade-v35/kustomization.yaml
+++ b/apps/admin/traefik-crds-upgrade-v35/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_traefikservices.yaml

--- a/apps/admin/traefik-crds-upgrade-v35/kustomize.yaml
+++ b/apps/admin/traefik-crds-upgrade-v35/kustomize.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/admin/traefik-crds-upgrade-v35

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -9,9 +9,9 @@ spec:
       chart: traefik
       version: 35.2.0
       sourceRef:
-            kind: HelmRepository
-            name: traefik
-            namespace: admin
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     deployment:
       additionalVolumes:

--- a/apps/admin/traefik2/sbox/00.yaml
+++ b/apps/admin/traefik2/sbox/00.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+            kind: HelmRepository
+            name: traefik
+            namespace: admin
   values:
     deployment:
       additionalVolumes:

--- a/apps/admin/traefik2/sbox/01.yaml
+++ b/apps/admin/traefik2/sbox/01.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -21,3 +21,4 @@ patches:
     annotationSelector: hmcts.github.com/kustomize-defaults != disabled
     kind: Kustomization
 - path: ../../../apps/admin/sbox/base/kustomize.yaml
+- path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25373

### Change description

upgrade traefik to v35.2.0

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines





## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Added new files `traefik-crds-upgrade-v35/kustomization.yaml` and `traefik-crds-upgrade-v35/kustomize.yaml`.
- Updated `traefik2/sbox/00.yaml` and `traefik2/sbox/01.yaml` to use Helm chart `traefik` version 35.2.0.
- Updated `sbox/base/kustomization.yaml` to add a new path for `traefik-crds-upgrade-v35/kustomize.yaml`.