### PR TITLE
Add invalid HMC url to test manual hearing cancellation events

### DIFF
--- a/apps/ia/ia-hearings-api/demo.yaml
+++ b/apps/ia/ia-hearings-api/demo.yaml
@@ -11,3 +11,4 @@ spec:
         enabled: true
       environment:
         DUMMY_VAR: "Y"
+        HMC_API_URL: "http://hmc-cft-hearing-service-dem.service.core-compute-dem.internal"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **demo.yaml**
  - Added a new environment variable `HMC_API_URL` with the value \"http://hmc-cft-hearing-service-dem.service.core-compute-dem.internal\"