### PR TITLE
feat: remove elevated traefik timeouts in demo and perftest

### DIFF
--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -13,10 +13,3 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=180"

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -13,10 +13,3 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=180"

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -13,13 +13,6 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"
     ingressRoute:
       dashboard:
         enabled: true

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -13,10 +13,3 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"


### PR DESCRIPTION
Removes elevated timeouts in demo and perftest.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `00.yaml`, `01.yaml` in `apps/admin/traefik2/demo/` and `perftest/`:
  - Removed the `additionalArguments` related to `entryPoints` and `respondingTimeouts`.
- `00.yaml`, `01.yaml` in `apps/admin/traefik2/perftest/`:
  - Added an `ingressRoute` with `dashboard` enabled.