### PR TITLE
Disable one-off task cron on aat

### DIFF
--- a/apps/financial-remedy/finrem-cron-one-off-task/aat/aat.yaml
+++ b/apps/financial-remedy/finrem-cron-one-off-task/aat/aat.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: finrem-cron-one-off-task
   values:
     job:
-      schedule: "*/10 * * * *"
+      schedule: "0 0 9 5 *"
       environment:
         DOCUMENT_MANAGEMENT_STORE_URL: http://dm-store-aat.service.core-compute-aat.internal
         SEND_LETTER_SERVICE_BASEURL: http://rpe-send-letter-service-aat.service.core-compute-aat.internal
@@ -19,7 +19,7 @@ spec:
         FEATURE_CFV_ENABLED: true
         CRON_WAIT_TIME_MINS: 1
         TASK_NAME: AmendGeneralEmailTask
-        CRON_AMEND_GENERAL_EMAIL_ENABLED: true
+        CRON_AMEND_GENERAL_EMAIL_ENABLED: false
         CRON_AMEND_GENERAL_EMAIL_CASE_TYPE_ID: FinancialRemedyContested
         CRON_AMEND_GENERAL_EMAIL_BATCH_SIZE: 100
         CRON_AMEND_GENERAL_EMAIL_CASE_LIST_FILENAME: "caserefs-demo-encrypted.csv"


### PR DESCRIPTION
### Change description

Disable one-off task cron in aat
Set the schedule


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `aat.yaml` in the `finrem-cron-one-off-task` folder has been modified to change the job schedule from \"*/10 * * * *\" to \"0 0 9 5 *\".
- Additionally, the `CRON_AMEND_GENERAL_EMAIL_ENABLED` value has been changed from true to false.