### PR TITLE
DFR-3781: Enable send to FRC for draft order review overdue notifications

### DIFF
--- a/apps/financial-remedy/finrem-cron-draft-order-review-overdue/prod/prod.yaml
+++ b/apps/financial-remedy/finrem-cron-draft-order-review-overdue/prod/prod.yaml
@@ -20,6 +20,7 @@ spec:
         FEATURE_CASEWORKER_NOC: true
         FEATURE_CFV_ENABLED: true
         SECURE_DOC_ENABLED: false
+        FEATURE_SEND_TO_FRC: true
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_API_REDIRECT_URL: https://www.financial-remedy.reform.hmcts.net/oauth2/callback
         DOCUMENT_MANAGEMENT_STORE_URL: http://dm-store-prod.service.core-compute-prod.internal


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3781

### Change description

Enable send to FRC feature flag for draft order review overdue notifications


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/financial-remedy/finrem-cron-draft-order-review-overdue/prod/prod.yaml
- Added a new feature to enable sending to FRC.
- Set SECURE_DOC_ENABLED to false.
- Updated FEATURE_CFV_ENABLED to true.