### PR TITLE
restarting ccd-def-store and ccd-data-store after new LB Switch

### DIFF
--- a/apps/ccd/ccd-data-store-api/prod.yaml
+++ b/apps/ccd/ccd-data-store-api/prod.yaml
@@ -22,7 +22,7 @@ spec:
         DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,bulk_scan_payment_processor,pcq_consolidation_service,em_npa_app,ecm_consumer,aac_manage_case_assignment,am_role_assignment_service,divorce_frontend,am_role_assignment_service,nfdiv_case_api,wa_task_configuration_api,civil_service,em_hrs_api,wa_task_monitor,ccd_case_document_am_api,wa_task_management_api,nfdiv_case_api,adoption_cos_api,adoption_web,prl_cos_api,hmc_cft_hearing_service,et_cos,et_msg_handler,ccd_next_hearing_date_updater,et_sya_api,fis_hmc_api,sptribs_case_api,em_annotation_app,sptribs_dss_update_case_web,civil_general_applications
         DEFAULT_CACHE_TTL_SEC: 30
         DEFINITION_CACHE_JURISDICTION_TTL_SEC: 120
-        DUMMY_VAR_TO_RESTART: 4
+        DUMMY_VAR_TO_RESTART: 5
         ELASTIC_SEARCH_REQUEST_TIMEOUT: 16000
         SPRING_FLYWAY_ENABLED: true
         HTTP_CLIENT_MAX_CLIENT_PER_ROUTE: 40

--- a/apps/ccd/ccd-definition-store-api/prod.yaml
+++ b/apps/ccd/ccd-definition-store-api/prod.yaml
@@ -21,5 +21,5 @@ spec:
         DEFINITION_STORE_DB_MAX_POOL_SIZE: 65
         DEFINITION_STORE_DB_NAME: ccd_definition_store
         DEFINITION_STORE_DB_HOST: ccd-definition-store-api-postgres-db-v15-prod.postgres.database.azure.com
-        DUMMY_RESTART_VAR: 4
+        DUMMY_RESTART_VAR: 5
         test: "test1"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24753

### Change description

restarting ccd-def-store and ccd-data-store after new LB Switch  - this is in place for scheduled change on Monday 12th (CHG5020922)

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-data-store-api/prod.yaml
- Updated the value of DUMMY_VAR_TO_RESTART from 4 to 5.

### apps/ccd/ccd-definition-store-api/prod.yaml
- Updated the value of DUMMY_RESTART_VAR from 4 to 5.