### PR TITLE
Revert "Disable ccd case migration on demo"

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: sscs-ccd-case-migration
   values:
     job:
-      suspend: true
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctspublic.azurecr.io/sscs/ccd-case-migration:prod-818ec8a-20250509162326 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#38516

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- 00.yaml```: The `suspend` property was removed from the job configuration, and `useInterpodAntiAffinity` and `aadIdentityName` properties were added to the job.