### PR TITLE
Revert "Update demo-image-policy.yaml"

### DIFF
--- a/apps/em/em-hrs-api/demo-image-policy.yaml
+++ b/apps/em/em-hrs-api/demo-image-policy.yaml
@@ -2,14 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-em-hrs-api
-  # annotations:
-  #   hmcts.github.com/prod-automated: disabled
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
-  # filterTags:
-  #   pattern: '^pr-2475-[a-f0-9]+-(?P<ts>[0-9]+)'
-  #   extract: '$ts'
-  # policy:
-  #   alphabetical:
-  #     order: asc
+  filterTags:
+    pattern: '^pr-2475-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: em-hrs-api


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#38477
Deploying PR image for QA.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/em/em-hrs-api/demo-image-policy.yaml
- An annotation \"hmcts.github.com/prod-automated\" with value \"disabled\" has been added.
- The filterTags pattern has been updated to '^pr-2475-[a-f0-9]+-(?P<ts>[0-9]+)'
- The extract field has been updated to '$ts'
- The policy field \"alphabetical\" has been updated with \"order\" as \"asc\"