### PR TITLE
Bumping memory in Docmosis

### DIFF
--- a/apps/docmosis/docmosis/docmosis.yaml
+++ b/apps/docmosis/docmosis/docmosis.yaml
@@ -22,9 +22,9 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 5
-      memoryRequests: "1024Mi"
+      memoryRequests: "3Gi"
+      memoryLimits: "4Gi"
       cpuRequests: "1000m"
-      memoryLimits: "3072Mi"
       cpuLimits: "2000m"
   chart:
     spec:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25823

### Change description
- Bumping the memory for Docmosis lower envs to be closer to prod
- Currently AAT is pinned at the maximum number of pods due to exceeding the 80% utilisation

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `docmosis.yaml` 📋
  - Increased `memoryRequests` from \"1024Mi\" to \"3Gi\".
  - Updated `memoryLimits` from \"3072Mi\" to \"4Gi\".