### PR TITLE
Patch prometheus stack to 72.4.0

### DIFF
--- a/apps/monitoring/kube-prometheus-stack-crds/kustomization.yaml
+++ b/apps/monitoring/kube-prometheus-stack-crds/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-72.4.0/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -178,7 +178,7 @@ spec:
     spec:
       chart: kube-prometheus-stack
       # Update kube-prometheus-stack-crds/kustomization.yaml when updating this
-      version: 69.3.1
+      version: 72.4.0
       sourceRef:
         kind: HelmRepository
         name: prometheus


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25383


### Change description

Patch prometheus stack to 72.4.0

### Testing done

All working on SDS

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- In `apps/monitoring/kube-prometheus-stack-crds/kustomization.yaml`, the URLs for the CRDs have been updated from version 69.3.1 to version 72.4.0.
- In `apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml`, the version of the kube-prometheus-stack has been updated from 69.3.1 to 72.4.0.