### PR TITLE
Update demo reference to use OCI helm repo, chart and version do exist

### DIFF
--- a/apps/probate/probate-cron-draft-cases-with-payment/demo/demo.yaml
+++ b/apps/probate/probate-cron-draft-cases-with-payment/demo/demo.yaml
@@ -27,5 +27,5 @@ spec:
       version: 0.0.28
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic
+        name: hmctspublic-oci
         namespace: flux-system


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25674

### Change description
Update demo reference to use OCI helm repo, chart and version do exist

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/probate/probate-cron-draft-cases-with-payment/demo/demo.yaml
- Changed the name of the `hmctspublic` HelmRepository to `hmctspublic-oci` to update the source reference.