### PR TITLE
Update bsp-cron-trigger-daily-checks.yaml to correct chart

### DIFF
--- a/apps/bsp/bsp-cron-trigger-daily-checks/bsp-cron-trigger-daily-checks.yaml
+++ b/apps/bsp/bsp-cron-trigger-daily-checks/bsp-cron-trigger-daily-checks.yaml
@@ -11,7 +11,7 @@ spec:
       schedule: "*/10 * * * *"
   chart:
     spec:
-      chart: ./stable/bsp-cron-trigger
+      chart: ./stable/bulk-scan-cron-trigger
       sourceRef:
         kind: GitRepository
         name: hmcts-charts


### PR DESCRIPTION

### Change description
Update bsp-cron-trigger-daily-checks.yaml to correct chart

`bsp-cron-trigger-daily-checks   102m   False   HelmChart 'flux-system/bsp-bsp-cron-trigger-daily-checks' is not ready: invalid chart reference: stat /tmp/helmchart-flux-system-bsp-bsp-cron-trigger-daily-checks-1641706607/source/stable/bsp-cron-trigger: no such file or directory`

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/bsp/bsp-cron-trigger-daily-checks/bsp-cron-trigger-daily-checks.yaml
- Updated the chart value from ./stable/bsp-cron-trigger``` to ```./stable/bulk-scan-cron-trigger``` and the schedule from ```*/10 * * * *``` to ```5m```.