### PR TITLE
Adding preview(dev) docker-creds secret to each namespace preview base config

### DIFF
--- a/apps/aac/preview/base/kustomization.yaml
+++ b/apps/aac/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: aac
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/adoption/preview/base/kustomization.yaml
+++ b/apps/adoption/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
@@ -11,7 +12,6 @@ resources:
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../aso/adoption-postgres-config.yaml
   - ../sops-secrets
-
 namespace: adoption
 patches:
   - path: ../../../ccd/identity/aat.yaml

--- a/apps/am/preview/base/kustomization.yaml
+++ b/apps/am/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml

--- a/apps/bsp/preview/base/kustomization.yaml
+++ b/apps/bsp/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../sops-secrets
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml

--- a/apps/ccd/preview/base/kustomization.yaml
+++ b/apps/ccd/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../sealed-secrets
   - ../../identity/identity.yaml
   - ../../../am/identity/identity.yaml

--- a/apps/chart-tests/preview/base/kustomization.yaml
+++ b/apps/chart-tests/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../sealed-secrets
   - ../../../money-claims/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml

--- a/apps/civil/preview/base/kustomization.yaml
+++ b/apps/civil/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../am/identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml

--- a/apps/cnp/preview/base/kustomization.yaml
+++ b/apps/cnp/preview/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../../base
   - ../../../base/workload-identity
   - ../../../base/resourcequota-pvc.yaml
+  - ../../../base/docker-registry/dev
   - ../../plum-batch/plum-batch.yaml
 namespace: cnp
 patches:

--- a/apps/cpo/preview/base/kustomization.yaml
+++ b/apps/cpo/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: cpo
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/cui/preview/base/kustomization.yaml
+++ b/apps/cui/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: cui
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/dg/preview/base/kustomization.yaml
+++ b/apps/dg/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: dg
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/disposer/preview/base/kustomization.yaml
+++ b/apps/disposer/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: disposer
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/divorce/preview/base/kustomization.yaml
+++ b/apps/divorce/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml

--- a/apps/dm-store/preview/base/kustomization.yaml
+++ b/apps/dm-store/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../xui/identity/identity.yaml

--- a/apps/dtsse/preview/base/kustomization.yaml
+++ b/apps/dtsse/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
 namespace: dtsse
 patches:

--- a/apps/em/preview/base/kustomization.yaml
+++ b/apps/em/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../ia/identity/identity.yaml

--- a/apps/enforcement/preview/base/kustomization.yaml
+++ b/apps/enforcement/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: enforcement
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/et-pet/preview/base/kustomization.yaml
+++ b/apps/et-pet/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
 namespace: et-pet
 patches:

--- a/apps/et/preview/base/kustomization.yaml
+++ b/apps/et/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml

--- a/apps/ethos/preview/base/kustomization.yaml
+++ b/apps/ethos/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: ethos
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/fact/preview/base/kustomization.yaml
+++ b/apps/fact/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: fact
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/family-public-law/preview/base/kustomization.yaml
+++ b/apps/family-public-law/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../wa/identity/identity.yaml

--- a/apps/fees-pay/preview/base/kustomization.yaml
+++ b/apps/fees-pay/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets

--- a/apps/financial-remedy/preview/base/kustomization.yaml
+++ b/apps/financial-remedy/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml

--- a/apps/fis/preview/base/kustomization.yaml
+++ b/apps/fis/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml
   - ../../../xui/identity/identity.yaml

--- a/apps/help-with-fees/preview/base/kustomization.yaml
+++ b/apps/help-with-fees/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: help-with-fees
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/hmc/preview/base/kustomization.yaml
+++ b/apps/hmc/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml
   - ../sops-secrets

--- a/apps/ia/preview/base/kustomization.yaml
+++ b/apps/ia/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../rpe/identity/identity.yaml

--- a/apps/idam/preview/base/kustomization.yaml
+++ b/apps/idam/preview/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../../../base/docker-registry/dev
   - ../../base
   - ../../idam-testing-support-api/idam-testing-support-api.yaml
 namespace: idam

--- a/apps/lau/preview/base/kustomization.yaml
+++ b/apps/lau/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: lau
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/money-claims/preview/base/kustomization.yaml
+++ b/apps/money-claims/preview/base/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: money-claims
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../sealed-secrets
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml

--- a/apps/nfdiv/preview/base/kustomization.yaml
+++ b/apps/nfdiv/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../am/identity/identity.yaml

--- a/apps/pcq/preview/base/kustomization.yaml
+++ b/apps/pcq/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
 namespace: pcq
 patches:

--- a/apps/pcs/preview/base/kustomization.yaml
+++ b/apps/pcs/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../hmc/aat/aso
 namespace: pcs
 patches:

--- a/apps/private-law/preview/base/kustomization.yaml
+++ b/apps/private-law/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../xui/identity/identity.yaml

--- a/apps/probate/preview/base/kustomization.yaml
+++ b/apps/probate/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../ccd/identity/identity.yaml

--- a/apps/rd/preview/base/kustomization.yaml
+++ b/apps/rd/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml

--- a/apps/reform-scan/preview/base/kustomization.yaml
+++ b/apps/reform-scan/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/servicebus-namespace.yaml

--- a/apps/response/base/kustomization.yaml
+++ b/apps/response/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../../../base/docker-registry/dev
   - ../../base
   - ../api/response-api.yaml
   - ../api/slack-ingress.yaml

--- a/apps/response/base/kustomization.yaml
+++ b/apps/response/base/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../base/docker-registry/dev
   - ../../base
   - ../api/response-api.yaml
   - ../api/slack-ingress.yaml

--- a/apps/rpe/preview/base/kustomization.yaml
+++ b/apps/rpe/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../../base/resourcequota-pvc.yaml
   - ../../../azureserviceoperator-system/resources/resource-group.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml

--- a/apps/rpts/preview/base/kustomization.yaml
+++ b/apps/rpts/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
 namespace: rpts
 patches:

--- a/apps/sptribs/preview/base/kustomization.yaml
+++ b/apps/sptribs/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
   - ../../../am/identity/identity.yaml

--- a/apps/sscs/preview/base/kustomization.yaml
+++ b/apps/sscs/preview/base/kustomization.yaml
@@ -5,6 +5,7 @@ sortOptions:
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../xui/identity/identity.yaml
   - ../../../rpe/identity/identity.yaml

--- a/apps/tax-tribunals/preview/base/kustomization.yaml
+++ b/apps/tax-tribunals/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
 namespace: tax-tribunals
 patches:
   - path: ../../base/workload-identity.yaml

--- a/apps/ts/preview/base/kustomization.yaml
+++ b/apps/ts/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
   - ../../../ccd/identity/identity.yaml
 namespace: ts

--- a/apps/wa/preview/base/kustomization.yaml
+++ b/apps/wa/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../sealed-secrets
   - ../../identity/identity.yaml
 namespace: wa

--- a/apps/xui/preview/base/kustomization.yaml
+++ b/apps/xui/preview/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
   - ../../identity/identity.yaml
 namespace: xui
 patches:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25928

### Change description
Adding preview(dev) docker-creds secret to each namespace preview base config

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Over several files, the changes include adding a reference to a Docker registry for the \"dev\" environment for various applications such as aac, adoption, am, bsp, ccd, chart-tests, civil, cnp, cpo, cui, dg, disposer, divorce, dm-store, dtsse, em, enforcement, et-pet, et, ethos, fact, family-public-law, fees-pay, financial-remedy, fis, help-with-fees, hmc, ia, idam, lau, money-claims, nfdiv, pcq, pcs, private-law, probate, rd, reform-scan, rpe, rpts, sptribs, sscs, tax-tribunals, ts, wa, and xui.
- The changes also involve adding \"docker-registry/dev\" references to the kustomization.yaml files for each of the respective components.