### PR TITLE
DTSPO-25686: Removing pod disruption budgets for perftest upgrade

### DIFF
--- a/apps/ccd/ccd-logstash-indexer/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer/perftest.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     replicas: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/ccd/ccd-logstash-indexer2/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer2/perftest.yaml
@@ -1,11 +1,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ccd-logstash-indexer
+  name: ccd-logstash-indexer2
   namespace: ccd
 spec:
-  releaseName: ccd-logstash-indexer
+  releaseName: ccd-logstash-indexer2
   values:
-    replicas: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/ccd/ccd-logstash-indexer3/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer3/perftest.yaml
@@ -1,11 +1,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ccd-logstash-indexer
+  name: ccd-logstash-indexer3
   namespace: ccd
 spec:
-  releaseName: ccd-logstash-indexer
+  releaseName: ccd-logstash-indexer3
   values:
-    replicas: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/ccd/ccd-logstash-indexer4/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer4/perftest.yaml
@@ -1,11 +1,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ccd-logstash-indexer
+  name: ccd-logstash-indexer4
   namespace: ccd
 spec:
-  releaseName: ccd-logstash-indexer
+  releaseName: ccd-logstash-indexer4
   values:
-    replicas: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/ccd/ccd-logstash-indexer5/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer5/perftest.yaml
@@ -1,11 +1,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ccd-logstash-indexer
+  name: ccd-logstash-indexer5
   namespace: ccd
 spec:
-  releaseName: ccd-logstash-indexer
+  releaseName: ccd-logstash-indexer5
   values:
-    replicas: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/ccd/ccd-logstash-indexer6/perftest.yaml
+++ b/apps/ccd/ccd-logstash-indexer6/perftest.yaml
@@ -1,11 +1,10 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: ccd-logstash-indexer
+  name: ccd-logstash-indexer6
   namespace: ccd
 spec:
-  releaseName: ccd-logstash-indexer
+  releaseName: ccd-logstash-indexer6
   values:
-    replicas: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/ccd/perftest/base/kustomization.yaml
+++ b/apps/ccd/perftest/base/kustomization.yaml
@@ -32,3 +32,8 @@ patches:
   - path: ../../ccd-logstash-ethos/perftest.yaml
   - path: ../../ccd-logstash-probate/perftest.yaml
   - path: ../../ccd-logstash-sscs/perftest.yaml
+  - path: ../../ccd-logstash-indexer2/perftest.yaml
+  - path: ../../ccd-logstash-indexer3/perftest.yaml
+  - path: ../../ccd-logstash-indexer4/perftest.yaml
+  - path: ../../ccd-logstash-indexer5/perftest.yaml
+  - path: ../../ccd-logstash-indexer6/perftest.yaml

--- a/apps/et/et-hearings-api/perftest.yaml
+++ b/apps/et/et-hearings-api/perftest.yaml
@@ -9,4 +9,4 @@ spec:
     java:
       image: hmctspublic.azurecr.io/et/hearings-api:prod-77b76c3-20231201191721 #{"$imagepolicy": "flux-system:perftest-et-hearings-api"}
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/et/et-hearings-api/perftest.yaml
+++ b/apps/et/et-hearings-api/perftest.yaml
@@ -8,3 +8,5 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/et/hearings-api:prod-77b76c3-20231201191721 #{"$imagepolicy": "flux-system:perftest-et-hearings-api"}
+    pdb:
+        enabled: false

--- a/apps/fis/fis-bulk-scan-api/perftest.yaml
+++ b/apps/fis/fis-bulk-scan-api/perftest.yaml
@@ -8,4 +8,4 @@ spec:
     java:
       image: hmctspublic.azurecr.io/fis/bulk-scan-api:prod-3c28dd7-20240910093549 #{"$imagepolicy": "flux-system:perftest-fis-bulk-scan-api"}
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/fis/fis-bulk-scan-api/perftest.yaml
+++ b/apps/fis/fis-bulk-scan-api/perftest.yaml
@@ -7,3 +7,5 @@ spec:
   values:
     java:
       image: hmctspublic.azurecr.io/fis/bulk-scan-api:prod-3c28dd7-20240910093549 #{"$imagepolicy": "flux-system:perftest-fis-bulk-scan-api"}
+    pdb:
+        enabled: false

--- a/apps/fis/fis-cos-api/perftest.yaml
+++ b/apps/fis/fis-cos-api/perftest.yaml
@@ -12,6 +12,8 @@ spec:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
+    pdb:
+        enabled: false
   chart:
     spec:
       chart: ./stable/fis-cos-api

--- a/apps/fis/fis-cos-api/perftest.yaml
+++ b/apps/fis/fis-cos-api/perftest.yaml
@@ -13,7 +13,7 @@ spec:
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
     pdb:
-        enabled: false
+      enabled: false
   chart:
     spec:
       chart: ./stable/fis-cos-api

--- a/apps/fis/fis-ds-update-web/perftest.yaml
+++ b/apps/fis/fis-ds-update-web/perftest.yaml
@@ -19,7 +19,7 @@ spec:
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
     pdb:
-        enabled: false
+      enabled: false
   chart:
     spec:
       chart: ./stable/fis-ds-update-web

--- a/apps/fis/fis-ds-update-web/perftest.yaml
+++ b/apps/fis/fis-ds-update-web/perftest.yaml
@@ -18,6 +18,8 @@ spec:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
+    pdb:
+        enabled: false
   chart:
     spec:
       chart: ./stable/fis-ds-update-web

--- a/apps/fis/fis-ds-web/perftest.yaml
+++ b/apps/fis/fis-ds-web/perftest.yaml
@@ -13,6 +13,8 @@ spec:
       environment: perftest
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
+    pdb:
+        enabled: false
   chart:
     spec:
       chart: ./stable/fis-ds-web

--- a/apps/fis/fis-ds-web/perftest.yaml
+++ b/apps/fis/fis-ds-web/perftest.yaml
@@ -14,7 +14,7 @@ spec:
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
       enableKeyVaults: true
     pdb:
-        enabled: false
+      enabled: false
   chart:
     spec:
       chart: ./stable/fis-ds-web

--- a/apps/reform-scan/reform-scan-notification-service/perftest.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/perftest.yaml
@@ -9,4 +9,4 @@ spec:
         PENDING_NOTIFICATIONS_TASK_DELAY_IN_MS: 600000
         PENDING_NOTIFICATIONS_SEND_DELAY_IN_MINUTE: 0
     pdb:
-        enabled: false
+      enabled: false

--- a/apps/reform-scan/reform-scan-notification-service/perftest.yaml
+++ b/apps/reform-scan/reform-scan-notification-service/perftest.yaml
@@ -8,3 +8,5 @@ spec:
       environment:
         PENDING_NOTIFICATIONS_TASK_DELAY_IN_MS: 600000
         PENDING_NOTIFICATIONS_SEND_DELAY_IN_MINUTE: 0
+    pdb:
+        enabled: false


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25686

### Change description

- Removing pod disruption budgets for AKS upgrade process by adding pdb enabled:false

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Added `perftest.yaml` for `ccd-logstash-indexer2` with PDB disabled
- Added `perftest.yaml` for `ccd-logstash-indexer3` with PDB disabled
- Added `perftest.yaml` for `ccd-logstash-indexer4` with PDB disabled
- Added `perftest.yaml` for `ccd-logstash-indexer5` with PDB disabled
- Added `perftest.yaml` for `ccd-logstash-indexer6` with PDB disabled
- Updated `kustomization.yaml` to include new `ccd-logstash-indexer` perftest yamls
- Added PDB disabled to `fis-bulk-scan-api`, `fis-cos-api`, `fis-ds-update-web`, `fis-ds-web`, `reform-scan-notification-service` perftest yamls