### PR TITLE
DTSPO-25686: Temporarily removing fis from perftest

### DIFF
--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -44,7 +44,7 @@ resources:
   - ../../../apps/rpts/base/kustomize.yaml
   - ../../../apps/sscs/base/kustomize.yaml
   - ../../../apps/ts/base/kustomize.yaml
-  - ../../../apps/fis/base/kustomize.yaml
+ # - ../../../apps/fis/base/kustomize.yaml
   - ../../../apps/sptribs/base/kustomize.yaml
   - ../../../apps/cui/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25686

### Change description

- Temporarily removing fis from the perftest clusters due to absence of secret in perftest keyvault leading to container creation errors.
- Will be added in once cluster is upgraded

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
