### PR TITLE
DTSAM-433 Enable `employment_wa_1_4` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: privatelaw_wa_1_7
+        DB_FEATURE_FLAG_ENABLE: employment_wa_1_4
         REFRESH_JOB: LEGAL_OPERATIONS-CIVIL-NEW-0-75
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-433](https://tools.hmcts.net/jira/browse/DTSAM-433) _"Enable 'employment_wa_1_4' ORM flag in lower environment and refresh users ready for EMPLOYMENT to test"_

### Change description

Enable `employment_wa_1_4` ORM flag in Demo ready for ET to test.