### PR TITLE
Revert "point to new aat image policy and PR image"

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:pr-4735-71f0334-20250512152551 #{"$imagepolicy": "flux-system:aat-sscs-tribunals-api"}
       aadIdentityName: sscs
       environment:
         CREATE_CCD_ENDPOINT: true

--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   values:
     java:
+      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-02ce71e-20250527105204 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       aadIdentityName: sscs
       environment:
         CREATE_CCD_ENDPOINT: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#38723



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### File changed: aat.yaml
- Updated the `image` value for the `java` section from pr-4735-71f0334-20250512152551 to prod-02ce71e-20250527105204.