### PR TITLE
Remove PR-1366 image policy from ia-case-notifications-api

### DIFF
--- a/apps/ia/ia-case-notifications-api/demo-image-policy.yaml
+++ b/apps/ia/ia-case-notifications-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-ia-case-notifications-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1366-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: ia-case-notifications-api

--- a/apps/ia/ia-case-notifications-api/demo.yaml
+++ b/apps/ia/ia-case-notifications-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
       image: hmctspublic.azurecr.io/ia/case-notifications-api:pr-1366-8ce73a0-20250522154955 #{"$imagepolicy": "flux-system:demo-ia-case-notifications-api"}
       environment:
         DOCMOSIS_ENDPOINT: https://docmosis.demo.platform.hmcts.net
-        DUMMY: "Yes"
+        RESTART_PODS: "Yes"
         CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated demo-image-policy.yaml``` in ```apps/ia/ia-case-notifications-api```:
  - Removed annotations and filterTags.
  - Removed policy details.
  - Updated imageRepositoryRef.

- Updated ```demo.yaml``` in ```apps/ia/ia-case-notifications-api```:
  - Changed value of DUMMY to RESTART_PODS.
  - Updated CASE_DOCUMENT_AM_URL.