### PR TITLE
Add plum-frontend-gitrepo to sbox kustomization

### DIFF
--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../../workload-identity
 - aso-controller-settings-patch.yaml
 - ../../docker-regcreds/sbox
+- ../../base/plum-frontend-gitrepo.yaml
 patches:
 - path: ../../serviceaccount/sbox.yaml
 - path: ../../base/patches/workload-identity-deployment-patch.yaml


### PR DESCRIPTION

### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24241

### Change description
It is currently missing in flux-system namespace.
This should get it created in sbox cluster so that flux is able to find it and the new github app credential I created is tested

### Testing done
This is a temporary change on sbox to test the new github credential

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/sbox/base/kustomization.yaml
- Added `././base/plum-frontend-gitrepo.yaml` to the resources section.
- Removed `././docker-regcreds/sbox` from the resources section.