### PR TITLE
Configure plum-frontend gitrepo to use GitHub App authentication properly

### DIFF
--- a/apps/flux-system/base/plum-frontend-gitrepo.yaml
+++ b/apps/flux-system/base/plum-frontend-gitrepo.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1m
-  url: ssh://github.com/hmcts/cnp-plum-frontend
+  url: https://github.com/hmcts/cnp-plum-frontend
   ref:
     branch: dtspo-24241/use-github-app-for-flux-auth
+  provider: github
   secretRef:
     name: github-app-credentials
   ignore: |


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24241

### Change description
I thought using SSH protocol and configuring new secret would ensure Flux is forced to authenticate with it to GitHub but Flux is complaining about missing SSH secret properties.
Turns out this was an incorrect way to go about this, to use GitHub app authentication one must:
- use HTTPS protocol
- set provider: github (similarly to how azure workload-identity is set)

This change is to remediate this and configure plum gitrepo as described in official docs: https://fluxcd.io/flux/components/source/gitrepositories/#github

### Testing done
This is part of the testing/trying to make this new authentication method work
Should be limited to plum frontend sbox in scope

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/flux-system/base/plum-frontend-gitrepo.yaml
- Updated the URL from \"ssh\" to \"https\" for the \"cnp-plum-frontend\" repository.
- Added a \"provider\" key with the value \"github\" to specify the provider as GitHub for authentication.
- Updated the branch to use a GitHub app for flux authentication.