### PR TITLE
Revert "DTSPO-25919 - Increase requests on data ingestion job"

### DIFF
--- a/apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
+++ b/apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
@@ -7,7 +7,5 @@ spec:
   values:
     job:
       schedule: "0,10,20,30,40,50 * * * *"
-      cpuRequests: "250m"
-      memoryRequests: "1Gi"
     global:
       jobKind: CronJob


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#38769

Issue was fixed by https://github.com/hmcts/dtsse-dashboard-ingestion/pull/708

Reverting this as it should not be required

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
- Removed the `cpuRequests` and `memoryRequests` values under the `spec` section.
- Updated the job schedule to run every 10 minutes.