### PR TITLE
Remove ADOP-2487 from demo

### DIFF
--- a/apps/adoption/adoption-web/demo-image-policy.yaml
+++ b/apps/adoption/adoption-web/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-adoption-web
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1690-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: adoption-web


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2487

### Change description
Removing following testing & merge to production



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-web/demo-image-policy.yaml
- Removed annotations section
- Removed filterTags and policy sections
- Updated imageRepositoryRef configuration