### PR TITLE
reverting-pr-38828-after testing-ccd-6346

### DIFF
--- a/apps/ccd/ccd-case-activity-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-activity-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-case-activity-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-458-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-activity-api/demo.yaml
+++ b/apps/ccd/ccd-case-activity-api/demo.yaml
@@ -7,6 +7,6 @@ spec:
   values:
     nodejs:
       java:
-      image: hmctspublic.azurecr.io/ccd/case-activity-api:pr-458-c31e69a-20250604082733 #{"$imagepolicy": "flux-system:demo-ccd-case-activity-api"}
+      image: hmctspublic.azurecr.io/ccd/case-activity-api:prod-c8899fd-20250507122857 #{"$imagepolicy": "flux-system:ccd-case-activity-api"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1

--- a/apps/ccd/ccd-case-print-service/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-print-service/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-case-print-service
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-548-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-print-service/demo.yaml
+++ b/apps/ccd/ccd-case-print-service/demo.yaml
@@ -6,5 +6,6 @@ spec:
   releaseName: ccd-case-print-service
   values:
     nodejs:
+      image: hmctspublic.azurecr.io/ccd/case-print-service:prod-da0e290-20250529100645
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1

--- a/apps/ccd/ccd-case-print-service/demo.yaml
+++ b/apps/ccd/ccd-case-print-service/demo.yaml
@@ -6,6 +6,5 @@ spec:
   releaseName: ccd-case-print-service
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccd/case-print-service:pr-548-cba576a-20250530081440
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1


### PR DESCRIPTION
reverting prp38828(ccd-6346) after testing done.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-case-activity-api/demo-image-policy.yaml
- Enabled prod automated annotations.
- Updated the filterTag pattern to match prod image tags.

### apps/ccd/ccd-case-activity-api/demo.yaml
- Updated the image tag to use the prod tag instead of the pr-458 tag.

### apps/ccd/ccd-case-print-service/demo-image-policy.yaml
- Enabled prod automated annotations.
- Updated the filterTag pattern to match prod image tags.

### apps/ccd/ccd-case-print-service/demo.yaml
- Updated the image tag to use the prod tag instead of the pr-548 tag.