### PR TITLE
Adding dynatrace crds to perftest to complete patching

### DIFF
--- a/apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml
+++ b/apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/dynatrace/dynatrace-crds-upgrade

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -58,3 +58,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/perftest/base/kustomize.yaml
+  - path: ../../../apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-26165

### Change description
CRD update hasnt been completed as part of patching, applying to perftest as first step.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml
- A new file `kustomize.yaml` has been added for managing the Dynatrace Custom Resource Definitions (CRDs) upgrade. 
- It specifies the apiVersion, kind, metadata, spec, interval, and path for the Kustomization resource.

### clusters/perftest/base/kustomization.yaml
- The path to include the `dynatrace-crds-upgrade/kustomize.yaml` file has been added to the existing file.