### PR TITLE
CCD-6198 - reverting-pr-38903 after sanity check

### DIFF
--- a/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-2550-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2550-66bdbd6-20250605084842 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-e8cb58f-20250602091837 #{"$imagepolicy": "flux-system:ccd-data-store-api"}
       replicas: 4
       autoscaling:
         enabled: true


### PR DESCRIPTION
CCD-6198 - reverting-pr-38903 after sanity check

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### demo-image-policy.yaml
- Changed the annotation `hmcts.github.com/prod-automated` from \"disabled\" to \"enabled\".
- Updated the `filterTags` pattern from `^pr-2550-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
  
### demo.yaml
- Updated the image tag from `hmctspublic.azurecr.io/ccd/data-store-api:pr-2550-66bdbd6-20250605084842` to `hmctspublic.azurecr.io/ccd/data-store-api:prod-e8cb58f-20250602091837`.
- Adjusted the number of replicas to 4 and enabled autoscaling.