### PR TITLE
Add pcs db for preview

### DIFF
--- a/apps/pcs/preview/aso/pcs-postgres.yaml
+++ b/apps/pcs/preview/aso/pcs-postgres.yaml
@@ -1,0 +1,10 @@
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+kind: FlexibleServer
+metadata:
+  name: ${NAMESPACE}-${ENVIRONMENT}
+  namespace: ${NAMESPACE}
+spec:
+  version: "16"
+  sku:
+    name: Standard_D2ds_v5
+    tier: GeneralPurpose

--- a/apps/pcs/preview/base/kustomization.yaml
+++ b/apps/pcs/preview/base/kustomization.yaml
@@ -5,6 +5,11 @@ resources:
   - ../../../base/workload-identity
   - ../../../base/docker-registry/dev
   - ../../../hmc/aat/aso
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
+  - ../sops-secrets
 namespace: pcs
 patches:
+  - path: ../aso/pcs-postgres.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/pcs/preview/sops-secrets/kustomization.yaml
+++ b/apps/pcs/preview/sops-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pcs-values.enc.yaml
+namespace: pcs

--- a/apps/pcs/preview/sops-secrets/pcs-values.enc.yaml
+++ b/apps/pcs/preview/sops-secrets/pcs-values.enc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+  PASSWORD: ENC[AES256_GCM,data:6BXnumrmajFbe9Gyxpeo8LVkKOTIByXJ,iv:SgX6yGvL5WJKfZj6Wl+ODAJThS+thCm7sXAPPKFNwGc=,tag:DiH1Wnp2N/D7srVTQyLh1A==,type:str]
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: postgres
+  namespace: pcs
+type: Opaque
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv:
+    - vault_url: https://dcdcftappsdevkv.vault.azure.net
+      name: sops-key
+      version: aedb9ea38954430ca1d0a46ed589c049
+      created_at: "2025-06-10T20:57:31Z"
+      enc: QptE63wcbzEtEywchctiLjza7aBkN8v2QrIxsKX2egd8SvPQb3RA3IiQRfm_0VSCSu4Pp8_SYDaH7UbyL49maQbJAExhg6wqlG7C3A0H9ca-i0LABtZ58FkDf8eDkIUnEwPBdZ5SDW5aKT7f_r01miq9v5NBBI5V1oJXOJ8R0y7mSooi8rRmA1Mj8paBMXySNhiqgxmIaZVa9dmZHUcuqzzxpX5Qj0MAIc1VTT8hGPUDQ8cH5HOOrzIxmT5VOShHaPFpeY4WA0s2v77jvaBWoHDl-NcmoApmQC5w52sGDiIb0mjJ7QYEIrT857lXy0R_-1oT0WcJ7YoxTxGEqbc41w
+  hc_vault: []
+  age: []
+  lastmodified: "2025-06-10T20:57:34Z"
+  mac: ENC[AES256_GCM,data:PaFROVYYtwKak01w+SpBRxu/uYxsCDEaTI3EvSQ6YZLMXVLFJmgVcCLI6IY/GVFqecPmhK5v70/erMHX30Ns4Jnlt6RqLMMjSb7HmGTvSKAOj2jdcvCQU9CswX/UktPuNdYeSJWtkCqsW06sgKwZHVBCfZEuGO9UF5lTnj9MuK4=,iv:HxPJO+P6UZ7K/MnqBz73nEWLn6QH/rUY62f73jnZOHI=,tag:hzWVAXT6JlknFw3EJV7aNA==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.9.1


### PR DESCRIPTION
### Jira link


https://tools.hmcts.net/jira/browse/HDPI-653
### Change description

- Adding a flexible server DB for preview.

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### Added
- **apps/pcs/preview/aso/pcs-postgres.yaml**
  - Added a new file defining a FlexibleServer for PostgreSQL with version \"16\" and Standard_D2ds_v5 SKU.
  
- **apps/pcs/preview/base/kustomization.yaml**
  - Added references to resources for Azure Service Operator system related to PostgreSQL.
  - Added a patch for a new path ./aso/pcs-postgres.yaml.

- **apps/pcs/preview/sops-secrets/kustomization.yaml**
  - Added a new file defining a Kustomization for secrets with a resource pcs-values.enc.yaml.

- **apps/pcs/preview/sops-secrets/pcs-values.enc.yaml**
  - Added a new file defining a Secret for PostgreSQL with encrypted values and related metadata.