### PR TITLE
Revert div-dgs to use prod image on demo

### DIFF
--- a/apps/divorce/div-dgs/demo-image-policy.yaml
+++ b/apps/divorce/div-dgs/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-div-dgs
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-659-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: div-dgs


### PR DESCRIPTION
### Change description

Revert div-dgs to use prod image on demo



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/divorce/div-dgs/demo-image-policy.yaml
- Removed annotations related to production automation.
- Removed filterTags and policy related to image versioning.