### PR TITLE
Fix 'charts' in the plum chart path to 'stable' as this is the correct path

### DIFF
--- a/apps/cnp/plum-frontend/aat.yaml
+++ b/apps/cnp/plum-frontend/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      chart: ./charts/plum-frontend
+      chart: ./stable/plum-frontend
       interval: 1m
       sourceRef:
         kind: GitRepository

--- a/apps/cnp/plum-frontend/demo.yaml
+++ b/apps/cnp/plum-frontend/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      chart: ./charts/plum-frontend
+      chart: ./stable/plum-frontend
       interval: 1m
       sourceRef:
         kind: GitRepository

--- a/apps/cnp/plum-frontend/ithc.yaml
+++ b/apps/cnp/plum-frontend/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      chart: ./charts/plum-frontend
+      chart: ./stable/plum-frontend
       interval: 1m
       sourceRef:
         kind: GitRepository

--- a/apps/cnp/plum-frontend/perftest.yaml
+++ b/apps/cnp/plum-frontend/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   chart:
     spec:
-      chart: ./charts/plum-frontend
+      chart: ./stable/plum-frontend
       interval: 1m
       sourceRef:
         kind: GitRepository

--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   chart:
     spec:
-      chart: ./charts/plum-frontend
+      chart: ./stable/plum-frontend
       interval: 1m
       sourceRef:
         kind: GitRepository


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24241

### Change description
Made a mistake in the path, for some reason I used 'charts' instead of 'stable'

### Testing done
Can see errors in the flux controller complaining chart doesn't exist

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
