### PR TITLE
DFR-3854: Revert div-cfs to use prod image on demo

### DIFF
--- a/apps/divorce/div-cfs/demo-image-policy.yaml
+++ b/apps/divorce/div-cfs/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-div-cfs
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-373-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: div-cfs


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3854

### Change description

Revert div-cfs to use prod image on demo



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/divorce/div-cfs/demo-image-policy.yaml
- Removed annotations related to automated production deployment.
- Updated the filterTags pattern and extract fields in the spec section.