### PR TITLE
Update perftest.yaml

### DIFF
--- a/apps/idam/idam-hmcts-access/perftest.yaml
+++ b/apps/idam/idam-hmcts-access/perftest.yaml
@@ -10,4 +10,6 @@ spec:
       ingressHost: hmcts-access.perftest.platform.hmcts.net
       environment:
         AZURE_IDAM_API_PROVIDER_NAME: 'keycloak-sso'
+        AZURE_IDAM_ISSUER: 'http://idam-perftest-jumpbox.service.core-compute-idam-perftest.internal:9080/auth/realms/jhipster'
         MOJ_IDAM_API_PROVIDER_NAME: 'keycloak-sso'
+        MOJ_IDAM_ISSUER: 'http://idam-perftest-jumpbox.service.core-compute-idam-perftest.internal:9080/auth/realms/jhipster'


### PR DESCRIPTION
### Change description

ADDED AZURE_IDAM_ISSUER & MOJ_IDAM_ISSUER variables to idam-hmcts-access perftest environment

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `perftest.yaml` file in `idam-hmcts-access` app has been updated to include `AZURE_IDAM_ISSUER` and `MOJ_IDAM_ISSUER` environment variables with new values.
- `AZURE_IDAM_ISSUER` is set to `'http://idam-perftest-jumpbox.service.core-compute-idam-perftest.internal:9080/auth/realms/jhipster'`
- `MOJ_IDAM_ISSUER` is set to `'http://idam-perftest-jumpbox.service.core-compute-idam-perftest.internal:9080/auth/realms/jhipster'`