### PR TITLE
DFR-3854: Revert div-cms to use prod image on demo

### DIFF
--- a/apps/divorce/div-cms/demo-image-policy.yaml
+++ b/apps/divorce/div-cms/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-div-cms
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-782-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: div-cms


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3854

### Change description

Revert div-cms to use prod image on demo
