### PR TITLE
CCD-6386 - reverting-pr-38958-from-demo-ccd-CCD-6386 after exui integ…

### DIFF
--- a/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-definition-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-1557-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -14,7 +14,7 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-1557-82383d1-20250612121015 #{"$imagepolicy": "flux-system:demo-ccd-definition-store-api"}
+      image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-464e526-20250611134237 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
       environment:
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"


### PR DESCRIPTION
CCD-6386 - reverting-pr-38958-from-demo-ccd-CCD-6386 after exui integration testing

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


ℹ️ demo-image-policy.yaml
- Changed annotation from \"disabled\" to \"enabled\" for prod-automated
- Updated filterTags pattern from '^pr-1557-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'

ℹ️ demo.yaml
- Updated image from 'hmctspublic.azurecr.io/ccd/definition-store-api:pr-1557-82383d1-20250612121015' to 'hmctspublic.azurecr.io/ccd/definition-store-api:prod-464e526-20250611134237'