### PR TITLE
deploy of pr-4503 branch for IAC CR84

### DIFF
--- a/apps/xui/xui-webapp-hearings-integration/demo-image-policy.yaml
+++ b/apps/xui/xui-webapp-hearings-integration/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-4503-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/xui/xui-webapp-hearings-integration/demo.yaml
+++ b/apps/xui/xui-webapp-hearings-integration/demo.yaml
@@ -7,7 +7,7 @@ spec:
     nodejs:
       ingressHost: manage-case-hearings-int.demo.platform.hmcts.net
       environment:
-        DUMMY_VAR: 2
+        DUMMY_VAR: 1
         FEATURE_SECURE_COOKIE_ENABLED: false
         FEATURE_JRD_E_LINKS_V2_ENABLED: true
         SERVICES_MARKUP_API: http://em-npa-demo.service.core-compute-demo.internal


### PR DESCRIPTION

updating demo.yaml with DUMMY_VAR set to 1
updating demo-image-policy.yaml to point to new pr 4503

This is to allow IAC to test CR84 tickets on one environment.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/xui/xui-webapp-hearings-integration/demo-image-policy.yaml
- Changed the pattern in `filterTags` from `^prod-[a-f0-9]+-(?P<ts>[0-9]+)` to `^pr-4503-[a-f0-9]+-(?P<ts>[0-9]+)`.

### apps/xui/xui-webapp-hearings-integration/demo.yaml
- Updated the value of `DUMMY_VAR` from 2 to 1.
- Disabled feature `FEATURE_SECURE_COOKIE_ENABLED`.
- Enabled feature `FEATURE_JRD_E_LINKS_V2_ENABLED`.
- Updated `SERVICES_MARKUP_API` to http://em-npa-demo.service.core-compute-demo.internal.