### PR TITLE
SIDM-9800 - Inactive users cleanup modified  to 30 days

### DIFF
--- a/apps/idam/idam-testing-support-api/perftest.yaml
+++ b/apps/idam/idam-testing-support-api/perftest.yaml
@@ -12,6 +12,6 @@ spec:
         IDAM_API_URL: https://idam-api.perftest.platform.hmcts.net
         SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: https://idam-web-public.perftest.platform.hmcts.net/o/jwks
         SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_IDAMTESTINGSUPPORTAPI_TOKENURI: https://idam-web-public.perftest.platform.hmcts.net/o/token
-        CLEANUP_SESSION_LIFESPAN: 180d
+        CLEANUP_SESSION_LIFESPAN: 30d
         NOTIFY_MAXPAGES: 50
         FEATUREFLAGS_ADDEMAILTONOTIFYREFERENCE: true


### PR DESCRIPTION
### Jira link

Inactive users will cleaned up in perf test in 30 days

### Change description

Inactive users will cleaned up in perf test in 30 days


### Testing done



### Security Vulnerability Assessment ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/idam-testing-support-api/perftest.yaml
- Updated `CLEANUP_SESSION_LIFESPAN` from `180d` to `30d`
- Added `NOTIFY_MAXPAGES: 50` and `FEATUREFLAGS_ADDEMAILTONOTIFYREFERENCE: true` properties.