### PR TITLE
Revert "CME-555: Deploy PR image into demo"

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-api-gateway-web
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-578-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-api-gateway-web
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccd/api-gateway-web:pr-578-ef02b48-20250613093520
+      image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-9f71629-20250317140812
       environment:
         CORS_ORIGIN_WHITELIST: "*"
         TIMING-ALLOW-ORIGIN: "https://www-ccd.demo.platform.hmcts.net"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#38979

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
- Changed the annotation for prod-automated from disabled to enabled.
- Updated the filterTags pattern to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'.
- Updated the policy for image filtering.

### apps/ccd/ccd-api-gateway-web/demo.yaml
- Updated the image tag from 'pr-578-ef02b48-20250613093520' to 'prod-9f71629-20250317140812' for ccd-api-gateway-web.