### PR TITLE
Chore - Increase memlimit for ccd-admin-web

### DIFF
--- a/apps/ccd/ccd-admin-web/ccd-admin-web.yaml
+++ b/apps/ccd/ccd-admin-web/ccd-admin-web.yaml
@@ -8,6 +8,7 @@ spec:
     nodejs:
       replicas: 2
       cpuRequests: "50m"
+      memoryLimits: "1024Mi"
       autoscaling:
         enabled: true
         maxReplicas: 4


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **ccd-admin-web.yaml**
  - Added memoryLimits setting to \"1024Mi\" for nodejs replicas.
  - Enabled autoscaling with a maximum of 4 replicas.