### PR TITLE
EM-6690-remove-VH-integration - fix policy file

### DIFF
--- a/apps/em/em-hrs-api/demo-image-policy.yaml
+++ b/apps/em/em-hrs-api/demo-image-policy.yaml
@@ -1,3 +1,4 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-em-hrs-api


### PR DESCRIPTION
### Jira link
EM-6690-remove-VH-integration - fix policy file whihc was broken with previous pr

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/em/em-hrs-api/demo-image-policy.yaml
- Added a new image policy with apiVersion \"image.toolkit.fluxcd.io/v1beta2\" and kind \"ImagePolicy\".