### PR TITLE
revering-pr-39081-ccd-6506 after sanity check

### DIFF
--- a/apps/ccd/ccd-case-print-service/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-print-service/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-case-print-service
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-551-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-print-service/demo.yaml
+++ b/apps/ccd/ccd-case-print-service/demo.yaml
@@ -6,6 +6,6 @@ spec:
   releaseName: ccd-case-print-service
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccd/case-print-service:pr-551-d82648a-20250618135920
+      image: hmctspublic.azurecr.io/ccd/case-print-service:prod-da0e290-20250529100645
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1


### PR DESCRIPTION
revering-pr-39081-ccd-6506 after sanity check

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-case-print-service/demo-image-policy.yaml
- Changed the annotation `hmcts.github.com/prod-automated` from `disabled` to `enabled`.
- Updated the `filterTags` pattern to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`.

### apps/ccd/ccd-case-print-service/demo.yaml
- Updated the image version for `hmctspublic.azurecr.io/ccd/case-print-service` from `pr-551-d82648a-20250618135920` to `prod-da0e290-20250529100645`.