### PR TITLE
Neuvector: change cluster in base values to Global value using helm templating

### DIFF
--- a/apps/base/kustomize.yaml
+++ b/apps/base/kustomize.yaml
@@ -33,6 +33,7 @@ spec:
               tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
               enableKeyVaults: true
               activeCronCluster: ${ACTIVE_CRON_CLUSTER}
+              cluster: ${CLUSTER}
             java:
               environment:
                 CLUSTER_NAME: "cft-${ENVIRONMENT}-${CLUSTER}-aks"

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -39,7 +39,7 @@ spec:
           secretName: nv-storage-secret
           shareName: neuvector-data-${CLUSTER}
         ingress:
-          host: cft-neuvector${CLUSTER}-api.${ENVIRONMENT}.platform.hmcts.net
+          host: cft-neuvector{{ .Values.Global.Cluster }}-api.${ENVIRONMENT}.platform.hmcts.net
           enabled: true
           path: "/"
           annotations:
@@ -65,7 +65,7 @@ spec:
                 - event
                 - security-event
                 - audit
-              Cluster_Name: ${ENVIRONMENT}${CLUSTER}
+              Cluster_Name: ${ENVIRONMENT}{{ .Values.Global.Cluster }}
             samlinitcfg.yaml: |
               SSO_URL: https://login.microsoftonline.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/saml2
               Issuer: https://sts.windows.net/531ff96d-0ae9-462a-8d2d-bec7c0b42082/
@@ -80,7 +80,7 @@ spec:
         env:
           ssl: false
         ingress:
-          host: cft-neuvector${CLUSTER}.${ENVIRONMENT}.platform.hmcts.net
+          host: cft-neuvector{{ .Values.Global.Cluster }}.${ENVIRONMENT}.platform.hmcts.net
           enabled: true
           httpredirect: true
           annotations:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-26365

### Change description

- Add new Global value for Cluster - i've checked across the hmcts repo and this should not clash with anything in use
- Update neuvector base values to use Helm templating using the var rather than post-build substitution
- This is needed as post-build substitution is keeping quotes around the value as its numeric - i don't want to alter this and remove the quotes for fear of affecting other things which consume this substitution


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/base/kustomize.yaml
- Added a new property `cluster` with value `${CLUSTER}`.

### apps/neuvector/neuvector/neuvector.yaml
- Updated value of `host` with `${CLUSTER}` to `{{ .Values.Global.Cluster }}`.
- Updated value of `Cluster_Name` with `${ENVIRONMENT}${CLUSTER}` to `${ENVIRONMENT}{{ .Values.Global.Cluster }}`.
- Updated value of `host` with `${CLUSTER}` to `{{ .Values.Global.Cluster }}`.
- Updated value of `host` with `${CLUSTER}` to `{{ .Values.Global.Cluster }}`.
- Updated value of `host` with `${CLUSTER}` to `{{ .Values.Global.Cluster }}`.
- Updated value of `host` with `${CLUSTER}` to `{{ .Values.Global.Cluster }}`.