### PR TITLE
Revert "Update dependency hmcts/jenkins-packer to v24.04.27 in ptl-intsvc"

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -104,7 +104,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
-                          galleryImageVersion: "24.04.27"
+                          galleryImageVersion: "24.04.4"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
@@ -120,7 +120,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
-                          galleryImageVersion: "24.04.27"
+                          galleryImageVersion: "24.04.4"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-civil"
                         templateDesc: "Jenkins build agents for Civil builds"
@@ -136,5 +136,5 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
-                          galleryImageVersion: "24.04.27"
+                          galleryImageVersion: "24.04.4"
                         <<: *vm_template_values_anchor


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#37843

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
- Updated the `galleryImageVersion` from \"24.04.27\" to \"24.04.4\" for multiple template configurations.