### PR TITLE
DTSPO-26431 - Update retention strategy in ptl

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -95,8 +95,7 @@ spec:
                         labels: "ubuntu"
                         maxVirtualMachinesLimit: 120
                         retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
+                          azureVMCloudOnceRetentionStrategy: {}
                         usageMode: "NORMAL"
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
@@ -111,8 +110,7 @@ spec:
                         labels: "daily"
                         maxVirtualMachinesLimit: 40
                         retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
+                          azureVMCloudOnceRetentionStrategy: {}
                         usageMode: "EXCLUSIVE"
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
@@ -127,8 +125,7 @@ spec:
                         labels: "civil"
                         maxVirtualMachinesLimit: 25
                         retentionStrategy:
-                          azureVMCloudRetentionStrategy:
-                            idleTerminationMinutes: 5
+                          azureVMCloudOnceRetentionStrategy: {}
                         usageMode: "EXCLUSIVE"
                         virtualMachineSize: "Standard_D8ads_v5"
                         imageReference:


### PR DESCRIPTION
### Jira link

See [DTSPO-26431](https://tools.hmcts.net/jira/browse/DTSPO-26431)

### Change description

Enable once retention strategy to remove agents after one use to clear down agents with issues in ssh keys

### Testing done

Tested in sbox already #39139

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The file `jenkins-azure-vm-agent.yaml` has been updated.
- The `azureVMCloudRetentionStrategy` section has been replaced with `azureVMCloudOnceRetentionStrategy` in three places, replacing `idleTerminationMinutes: 5` with an empty object.
- The `usageMode` has been updated to \"NORMAL\" for the \"ubuntu\" label, \"EXCLUSIVE\" for the \"daily\" label, and \"EXCLUSIVE\" for the \"civil\" label.