### PR TITLE
DTSPO-26431 - Revert to normal retention strategy

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -95,7 +95,8 @@ spec:
                         labels: "ubuntu"
                         maxVirtualMachinesLimit: 120
                         retentionStrategy:
-                          azureVMCloudOnceRetentionStrategy: {}
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
                         usageMode: "NORMAL"
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
@@ -110,7 +111,8 @@ spec:
                         labels: "daily"
                         maxVirtualMachinesLimit: 40
                         retentionStrategy:
-                          azureVMCloudOnceRetentionStrategy: {}
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
                         usageMode: "EXCLUSIVE"
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
@@ -125,7 +127,8 @@ spec:
                         labels: "civil"
                         maxVirtualMachinesLimit: 25
                         retentionStrategy:
-                          azureVMCloudOnceRetentionStrategy: {}
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
                         usageMode: "EXCLUSIVE"
                         virtualMachineSize: "Standard_D8ads_v5"
                         imageReference:


### PR DESCRIPTION
### Jira link

See [DTSPO-26431](https://tools.hmcts.net/jira/browse/DTSPO-26431)

### Change description

Reverting to normal retention strategy
All but 2 machines created with the new ssh key have been removed
Remaining machines are running very slow builds

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
- Changed retention strategy for different labels to `azureVMCloudRetentionStrategy` with `idleTerminationMinutes` set to 5.
- Updated `usageMode` to \"NORMAL\" for \"ubuntu\" label and \"EXCLUSIVE\" for \"daily\" and \"civil\" labels.
- Updated `virtualMachineSize` to \"Standard_D4ds_v5\" for \"ubuntu\" and \"daily\" labels, and to \"Standard_D8ads_v5\" for \"civil\" label.