### PR TITLE
Updating XUI perftest heap config

### DIFF
--- a/apps/xui/xui-webapp/perftest.yaml
+++ b/apps/xui/xui-webapp/perftest.yaml
@@ -11,7 +11,6 @@ spec:
       ingressHost: manage-case.perftest.platform.hmcts.net
       environment:
         DUMMY_VAR: false
-        NODE_OPTIONS: --max-old-space-size=2048
         JURISDICTIONS: DIVORCE,PROBATE,FR,PUBLICLAW,IA,SSCS,CMC,EMPLOYMENT,CIVIL,HRS,BEFTA_JURISDICTION_1,BEFTA_JURISDICTION_2,PRIVATELAW,BEFTA_JURISDICTION_3,DISPOSER_MASTER,ST_CIC,BEFTA_MASTER
         HEARINGS_JURISDICTIONS: SSCS,PRIVATELAW,CIVIL,IA,EMPLOYMENT,ST_CIC
         GLOBAL_SEARCH_SERVICES: IA,CIVIL,PRIVATELAW,PUBLICLAW,SSCS,ST_CIC,EMPLOYMENT
@@ -57,4 +56,4 @@ spec:
         SERVICES_TRANSLATION_API_URL: http://ts-translation-service-perftest.service.core-compute-perftest.internal
         SERVICES_NOTIFICATIONS_API_URL: http://ccpay-notifications-service-perftest.service.core-compute-perftest.internal
         SERVICES_PAYMENTS_URL: http://payment-api-perftest.service.core-compute-perftest.internal
-      image: hmctspublic.azurecr.io/xui/webapp:prod-9923f4e-20250624164950 #{"$imagepolicy": "flux-system:perftest-xui-webapp"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-9923f4e-20250624164950


### PR DESCRIPTION
Updating XUI perftest heap config

Planning to run a soak test with the current production memory configuration, to prove that setting the old space makes a difference.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- In perftest.yaml, the NODE_OPTIONS variable has been removed.
- The image version for the hmctspublic.azurecr.io/xui/webapp has been updated to prod-9923f4e-20250624164950.