### PR TITLE
CCD-6541-reverting-srt-to-prod-code-def-store

### DIFF
--- a/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-definition-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-1512-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -14,7 +14,7 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-1512-9559ceb-20250620160544 #{"$imagepolicy": "flux-system:demo-ccd-definition-store-api"}
+      image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-44db740-20250626115838 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
       environment:
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"


### PR DESCRIPTION
CCD-6541-reverting-srt-to-prod-code-def-store

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


The pull request contains the following changes:

**demo-image-policy.yaml**
- The `demo-image-policy.yaml` file has been updated to enable the `prod-automated` annotation and change the filterTags pattern to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.

**demo.yaml**
- In the `demo.yaml` file, the image version has been updated to use `prod-44db740-20250626115838` instead of `pr-1512-9559ceb-20250620160544`.