### PR TITLE
Revert "adoption-cos-api PR-1002"

### DIFF
--- a/apps/adoption/adoption-cos-api/demo-image-policy.yaml
+++ b/apps/adoption/adoption-cos-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-adoption-cos-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1002-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: adoption-cos-api


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#39203 (testing major upgrade to dependency)

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/adoption/adoption-cos-api/demo-image-policy.yaml
- Removed annotations for prod-automated
- Updated filterTags and extract fields
- Removed policy field from spec