### PR TITLE
Adding prod patch for divorce logstash

### DIFF
--- a/apps/ccd/ccd-logstash-divorce/prod.yaml
+++ b/apps/ccd/ccd-logstash-divorce/prod.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ccd-logstash-divorce
+  namespace: ccd
+spec:
+  releaseName: ccd-logstash-divorce
+  values:
+    replicas: 1

--- a/apps/ccd/prod/base/kustomization.yaml
+++ b/apps/ccd/prod/base/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
   - path: ../../ccd-next-hearing-date-updater/prod/prod.yaml
   - path: ../../ccd-logstash/prod.yaml
   - path: ../../ccd-logstash-ethos/prod.yaml
+  - path: ../../ccd-logstash-divorce/prod.yaml


### PR DESCRIPTION
### Jira link
Halo change: CHG-0014147

### Change description

For tonights re-indexing release for divorce we need to bring the logstash pod down, adding in prod file so i can lower replicas to 0. 

### Testing done


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **apps/ccd/ccd-logstash-divorce/prod.yaml**
  - Added new file `prod.yaml` for `ccd-logstash-divorce` HelmRelease configuration
  - Specifies the HelmRelease kind, metadata, release name, namespace, and replica values

- **apps/ccd/prod/base/kustomization.yaml**
  - Added a new path to include `ccd-logstash-divorce/prod.yaml` in the base kustomization fixed this file's change.