### PR TITLE
Revert "[NFDIV-4919] Suspend NFDIV crons in production"

### DIFF
--- a/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/prod/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-alert-application-not-reviewed/prod/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/prod/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-applicant-can-sts-after-intention-fo/prod/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "50 20-23,0-5 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-application-approved-reminder/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-application-approved-reminder/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-bulk-list-create/prod/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-bulk-list-create/prod/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0 4,5,6 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-eligible-for-switch-to-sole/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/prod-01.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     job:
       schedule: "0 12 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         NOTIFY_TEMPLATE_APPLICANT2_SIGN_IN_DISSOLUTION_URL: https://www.end-civil-partnership.service.gov.uk/applicant2

--- a/apps/nfdiv/nfdiv-cron-final-order-overdue/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-final-order-overdue/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0 9 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         NOTIFY_TEMPLATE_APPLICANT2_SIGN_IN_DISSOLUTION_URL: https://www.end-civil-partnership.service.gov.uk/applicant2

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod-01.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     job:
       schedule: 0 6,18 * * *
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         VAR_00: inc-2

--- a/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-find-cases-with-successful-payments/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: 0 6,18 * * *
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         VAR_00: inc-2

--- a/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-js-disputed-answer-overdue/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "50 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/prod/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-bulk-cases/prod/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 20-23,0-7 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod-00.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod-00.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     job:
       schedule: "50 20-23,0-7 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-migrate-cases/prod-01.yaml
+++ b/apps/nfdiv/nfdiv-cron-migrate-cases/prod-01.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     job:
       schedule: "0 20-23,0-7 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicant-dispute-form-overdue/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-applicants-apply-co/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 1-4 * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-notify-respondent-apply-final-order/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-partner-not-applied-for-final-order/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-cases-to-be-removed/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-pronounced-cases/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-scheduled-cases/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-process-failed-to-unlink-cases/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-cases-to-aos-overdue/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-progress-held-cases/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-held-cases/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-progress-to-awaiting-final-order/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-remind-applicant2/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicant2/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-applicants-apply-for-fo/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/prod/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-awaiting-joint-final-order/prod/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "50 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-remind-respondent-solicitor/prod.yaml
@@ -8,7 +8,6 @@ spec:
     job:
       disableActiveClusterCheck: false
       schedule: "0,20,40 * * * *"
-      suspend: true
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
         S2S_URL: "http://rpe-service-auth-provider-prod.service.core-compute-prod.internal"

--- a/apps/nfdiv/nfdiv-cron-states-report/prod.yaml
+++ b/apps/nfdiv/nfdiv-cron-states-report/prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     job:
-      suspend: true
+      suspend: false
       environment:
         IDAM_API_BASEURL: "https://idam-api.platform.hmcts.net"
     global:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#39132

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `nfdiv-cron-alert-application-not-reviewed/prod/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-applicant-can-sts-after-intention-fo/prod/prod.yaml`:
  - Updated the schedule from \"50 20-23,0-5 * * *\" to \"50 20-23,0-5 * *\", and removed the suspend attribute.

- `nfdiv-cron-application-approved-reminder/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-bulk-list-create/prod/prod.yaml`:
  - Updated the schedule from \"0 4,5,6 * * *\" to \"0 4,5,6 * *\", and removed the suspend attribute.

- `nfdiv-cron-eligible-for-switch-to-sole/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-final-order-overdue/prod-01.yaml`:
  - Updated the schedule from \"0 12 * * *\" to \"0 12 * *\", and removed the suspend attribute.

- `nfdiv-cron-final-order-overdue/prod.yaml`:
  - Updated the schedule from \"0 9 * * *\" to \"0 9 * *\", and removed the suspend attribute.

- `nfdiv-cron-find-cases-with-successful-payments/prod-01.yaml`:
  - Updated the schedule from \"0 6,18 * * *\" to \"0 6,18 * *\", and removed the suspend attribute.

- `nfdiv-cron-find-cases-with-successful-payments/prod.yaml`:
  - Updated the schedule from \"0 6,18 * *\" to \"0 6,18 * *\", and removed the suspend attribute.

- `nfdiv-cron-js-disputed-answer-overdue/prod.yaml`:
  - Updated the schedule from \"50 * * * *\" to \"50 * * *\", and removed the suspend attribute.

- `nfdiv-cron-migrate-bulk-cases/prod/prod.yaml`:
  - Updated the schedule from \"0,20,40 20-23,0-7 * * *\" to \"0,20,40 20-23,0-7 * *\", and removed the suspend attribute.

- `nfdiv-cron-migrate-cases/prod-00.yaml`:
  - Updated the schedule from \"50 20-23,0-7 * * *\" to \"50 20-23,0-7 * *\", and removed the suspend attribute.

- `nfdiv-cron-migrate-cases/prod-01.yaml`:
  - Updated the schedule from \"0 20-23,0-7 * * *\" to \"0 20-23,0-7 * *\", and removed the suspend attribute.

- `nfdiv-cron-notify-applicant-dispute-form-overdue/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-notify-applicants-apply-co/prod.yaml`:
  - Updated the schedule from \"0,20,40 1-4 * * *\" to \"0,20,40 1-4 * *\", and removed the suspend attribute.

- `nfdiv-cron-notify-respondent-apply-final-order/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-partner-not-applied-for-final-order/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-process-cases-to-be-removed/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-process-failed-pronounced-cases/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-process-failed-scheduled-cases/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-process-failed-to-unlink-cases/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-progress-cases-to-aos-overdue/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-progress-held-cases/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-progress-to-awaiting-final-order/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-remind-applicant2/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-remind-applicants-apply-for-fo/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-remind-awaiting-joint-final-order/prod/prod.yaml`:
  - Updated the schedule from \"50 * * * *\" to \"50 * * *\", and removed the suspend attribute.

- `nfdiv-cron-remind-respondent-solicitor/prod.yaml`:
  - Updated the schedule from \"0,20,40 * * * *\" to \"0,20,40 * * *\", and removed the suspend attribute.

- `nfdiv-cron-states-report/prod.yaml`:
  - Updated the suspend attribute from true to false.