### PR TITLE
Updating service account client id post managed identity recreation

### DIFF
--- a/apps/idam/serviceaccount/sbox.yaml
+++ b/apps/idam/serviceaccount/sbox.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "2cccbebf-4ae3-495e-8960-c952b7fde81a"
+    azure.workload.identity/client-id: "1f7ad498-ebed-4adf-b4cd-c1fa83744ec3"


### PR DESCRIPTION
### Change description
Service account client ID has changed following the re-creation of managed identity in azure due to running and rebuilding idam-shared-infra, pods would need to pick up this new value. 

Pods would need to pick up the new value. 

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/serviceaccount/sbox.yaml
- Changed the `client-id` annotation from \"2cccbebf-4ae3-495e-8960-c952b7fde81a\" to \"1f7ad498-ebed-4adf-b4cd-c1fa83744ec3\" for the azure workload identity. 🔄