### PR TITLE
CCD-6201-definition-store-api deployment on demo for testing

### DIFF
--- a/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-definition-store-api
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1535-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -14,7 +14,7 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-44db740-20250626115838 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
+      image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-1535-1462509-20250701191909 #{"$imagepolicy": "flux-system:demo-ccd-definition-store-api"}
       environment:
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"


### PR DESCRIPTION
CCD-6201-definition-store-api deployment on demo for testing

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


ℹ️ demo-image-policy.yaml
- Changed the annotation `hmcts.github.com/prod-automated` from enabled to disabled
- Updated the filterTags pattern from '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-1535-[a-f0-9]+-(?P<ts>[0-9]+)'

demo.yaml
- Updated the image tag from 'hmctspublic.azurecr.io/ccd/definition-store-api:prod-44db740-20250626115838' to 'hmctspublic.azurecr.io/ccd/definition-store-api:pr-1535-1462509-20250701191909'