### PR TITLE
CCD-6201-reverting definition-store-api deployment on demo after testing

### DIFF
--- a/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-definition-store-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-1535-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-definition-store-api/demo.yaml
+++ b/apps/ccd/ccd-definition-store-api/demo.yaml
@@ -14,7 +14,7 @@ spec:
       autoscaling:
         enabled: true
         maxReplicas: 4
-      image: hmctspublic.azurecr.io/ccd/definition-store-api:pr-1535-1462509-20250701191909 #{"$imagepolicy": "flux-system:demo-ccd-definition-store-api"}
+      image: hmctspublic.azurecr.io/ccd/definition-store-api:prod-44db740-20250626115838 #{"$imagepolicy": "flux-system:ccd-definition-store-api"}
       environment:
         IDAM_USER_URL: https://idam-web-public.demo.platform.hmcts.net
         DEFINITION_STORE_DB_OPTIONS: "?sslmode=require&gssEncMode=disable"


### PR DESCRIPTION
CCD-6201-reverting definition-store-api deployment on demo after testing

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated `demo-image-policy.yaml` in `apps/ccd/ccd-definition-store-api`:
  - Changed the `hmcts.github.com/prod-automated` annotation from 'disabled' to 'enabled'
  - Updated the `filterTags` pattern from `^pr-1535-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`

- Updated `demo.yaml` in `apps/ccd/ccd-definition-store-api`:
  - Modified the `image` value to `hmctspublic.azurecr.io/ccd/definition-store-api:prod-44db740-20250626115838`