### PR TITLE
CCD-6575-deploying on demo for testing

### DIFF
--- a/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-data-store-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-data-store-api
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2604-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-data-store-api/demo.yaml
+++ b/apps/ccd/ccd-data-store-api/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-data-store-api
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/data-store-api:prod-bb9e0fe-20250703092754 #{"$imagepolicy": "flux-system:ccd-data-store-api"}
+      image: hmctspublic.azurecr.io/ccd/data-store-api:pr-2604-2cb8e8f-20250703125102 #{"$imagepolicy": "flux-system:demo-ccd-data-store-api"}
       replicas: 4
       autoscaling:
         enabled: true


### PR DESCRIPTION
CCD-6575-deploying on demo for testing

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo-image-policy.yaml` 🔄 The `demo-ccd-data-store-api` image policy's `prod-automated` annotation has been disabled and the `filterTags` pattern has been updated to `^pr-2604-[a-f0-9]+-(?P<ts>[0-9]+)`.
- `demo.yaml` 🔄 The `ccd-data-store-api` demo release's image has been updated to `hmctspublic.azurecr.io/ccd/data-store-api:pr-2604-2cb8e8f-20250703125102` and the number of replicas has been set to 4 with autoscaling enabled.