### PR TITLE
DTSAM-962 Enable`privatelaw_wa_1_8` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: publiclaw_wa_2_0
+        DB_FEATURE_FLAG_ENABLE: privatelaw_wa_1_8
         REFRESH_JOB: LEGAL_OPERATIONS-CIVIL-NEW-0-75
         REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-962](https://tools.hmcts.net/jira/browse/DTSAM-962) _"Enable 'privatelaw_wa_1_8' ORM flag in lower environment and refresh users ready for PRIVATELAW to test"_

### Change description

Enable `privatelaw_wa_1_8` ORM flag in Demo ready for PRL to test.


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/am/am-org-role-mapping-service/demo.yaml
- Updated the `DB_FEATURE_FLAG_ENABLE` from `publiclaw_wa_2_0` to `privatelaw_wa_1_8`.