### PR TITLE
CCD-6575 - reverting demo deployment after testing completed

### DIFF
--- a/apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-case-document-am-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-736-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-document-am-api/demo.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/case-document-am-api:pr-736-79ad2af-20250701154434 #{"$imagepolicy": "flux-system:demo-ccd-case-document-am-api"}
+      image: hmctspublic.azurecr.io/ccd/case-document-am-api:prod-ffcde0d-20250707094048 #{"$imagepolicy": "flux-system:ccd-case-document-am-api"}
       environment:
         RESTART: 2
         CASE_DOCUMENT_S2S_AUTHORISED_SERVICES: ccd_case_document_am_api,ccd_gw,xui_webapp,ccd_data,bulk_scan_processor,sscs,probate_backend,iac,em_npa_app,dg_docassembly_api,em_stitching_api,em_ccd_orchestrator,cmc_claim_store,civil_service,bulk_scan_orchestrator,ethos_repl_service,divorce_document_generator,finrem_document_generator,finrem_case_orchestration,fpl_case_service,et_cos,prl_cos_api,prl_dgs_api,ds_ui,adoption_cos_api,adoption_web,et_sya_api,fis_cos_api,prl_citizen_frontend,nfdiv_case_api,divorce_frontend,sptribs_case_api,civil_general_applications


### PR DESCRIPTION
CCD-6575 - reverting demo deployment after testing completed

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
- Updated the `demo-image-policy.yaml` file to enable `hmcts.github.com/prod-automated`, changing `disabled` to `enabled`.
- Updated the `filterTags` pattern from `'^pr-736-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'^prod-[a-f0-9]+-(?P<ts>[0-9]+)'`.

### apps/ccd/ccd-case-document-am-api/demo.yaml
- Updated the image version from `pr-736-79ad2af-20250701154434` to `prod-ffcde0d-20250707094048` in the `demo.yaml` file for the `hmctspublic.azurecr.io/ccd/case-document-am-api` image.