### PR TITLE
Revert "Revert to last known good image"

### DIFF
--- a/apps/xui/xui-webapp/xui-webapp.yaml
+++ b/apps/xui/xui-webapp/xui-webapp.yaml
@@ -8,7 +8,7 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/xui/webapp:prod-dbeffe2-20250617132719
+      image: hmctspublic.azurecr.io/xui/webapp:prod-9923f4e-20250624164950 #{"$imagepolicy": "flux-system:xui-webapp"}
       environment:
         FEATURE_COMPRESSION_ENABLED: false
   chart:

--- a/apps/xui/xui-webapp/xui-webapp.yaml
+++ b/apps/xui/xui-webapp/xui-webapp.yaml
@@ -8,7 +8,7 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctspublic.azurecr.io/xui/webapp:prod-9923f4e-20250624164950 #{"$imagepolicy": "flux-system:xui-webapp"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-dbeffe2-20250617132719 #{"$imagepolicy": "flux-system:xui-webapp"}
       environment:
         FEATURE_COMPRESSION_ENABLED: false
   chart:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#39137
This should cause the latest built image to be deployed per the image policy



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/xui/xui-webapp/xui-webapp.yaml
- Updated the `image` field to `hmctspublic.azurecr.io/xui/webapp:prod-dbeffe2-20250617132719` in the `spec` section.