### PR TITLE
Revert "disable telephony feature temp on demo"

### DIFF
--- a/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
@@ -8,6 +8,7 @@ spec:
     nodejs:
       image: hmctspublic.azurecr.io/ccpay/bubble-frontend:pr-965-a59d5ed-20250701133031 #{"$imagepolicy": "flux-system:demo-ccpay-bubble-frontend"}
       environment:
+        TELEPHONY_FEATURE: enabled
         PCIPAL_ANTENNA_URL: https://paybubble.demo.platform.hmcts.net/ccd-search
-        DUMMY_RESTART_VAR: false
+        DUMMY_RESTART_VAR: true
         CCPAY_REFUNDS_API_URL: http://ccpay-refunds-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#39420

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fees-pay/ccpay-bubble-frontend/demo.yaml
- Added a new environment variable `TELEPHONY_FEATURE` with the value `enabled`.
- Changed the value of the `DUMMY_RESTART_VAR` environment variable from `false` to `true`.