### PR TITLE
Deploy latest idam-web-public images to lower envs

### DIFF
--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-b4dabaf-20250630091544
+      image: hmctspublic.azurecr.io/idam/web-public:prod-cebda65-20250709121216
       ingressHost: idam-web-public.aat.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-b4dabaf-20250630091544
+      image: hmctspublic.azurecr.io/idam/web-public:prod-cebda65-20250709121216
       replicas: 1
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-b4dabaf-20250630091544
+      image: hmctspublic.azurecr.io/idam/web-public:prod-cebda65-20250709121216
       ingressHost: idam-web-public.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-b4dabaf-20250630091544
+      image: hmctspublic.azurecr.io/idam/web-public:prod-cebda65-20250709121216
       replicas: 2
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-b4dabaf-20250630091544
+      image: hmctspublic.azurecr.io/idam/web-public:prod-cebda65-20250709121216
       ingressHost: idam-web-public.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/projects/SIDM/versions/58814

### Change description
A bug fix that addresses SSO logins when using OpenID Connect PKCE flow.

### Testing done
Yes

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- The `aat.yaml`, `demo.yaml`, `ithc.yaml`, `perftest.yaml`, and `sbox.yaml` files in the `idam-web-public` directory have been updated to use a new version of the `hmctspublic.azurecr.io/idam/web-public` image with tag `prod-cebda65-20250709121216` instead of `prod-b4dabaf-20250630091544`. The replicas, ingressHost, and other environment settings have also been adjusted accordingly. 🔒🔄