### PR TITLE
Neuvector var referencing fix

### DIFF
--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   values:
     neuvector:
+      serviceAccount: neuvector
       controller:
         configmap:
           data:

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -37,10 +37,10 @@ spec:
         azureFileShare:
           enabled: true
           secretName: nv-storage-secret
-          shareName: neuvector-data-{CLUSTER}
+          shareName: neuvector-data-${CLUSTER}
         ingress:
           path: "/"
-          host: cft-neuvector{CLUSTER}-api.{ENVIRONMENT}.platform.hmcts.net
+          host: cft-neuvector${CLUSTER}-api.${ENVIRONMENT}.platform.hmcts.net
           enabled: true
           annotations:
             kubernetes.io/ingress.class: traefik
@@ -65,7 +65,7 @@ spec:
                 - event
                 - security-event
                 - audit
-              Cluster_Name: {ENVIRONMENT}{CLUSTER}
+              Cluster_Name: ${ENVIRONMENT}${CLUSTER}
       enforcer:
         priorityClassName: system-node-critical
       manager:
@@ -74,7 +74,7 @@ spec:
         ingress:
           enabled: true
           httpredirect: false
-          host: cft-neuvector-{ENVIRONMENT}{CLUSTER}.hmcts.net
+          host: cft-neuvector-${ENVIRONMENT}${CLUSTER}.hmcts.net
           annotations:
             kubernetes.io/ingress.class: traefik
             traefik.ingress.kubernetes.io/router.tls: "false"

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -32,6 +32,7 @@ spec:
         limits:
           cpu: 1
           memory: 5Gi
+      serviceAccount: neuvector
       controller:
         replicas: 3
         azureFileShare:

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -32,7 +32,6 @@ spec:
         limits:
           cpu: 1
           memory: 5Gi
-      serviceAccount: neuvector
       controller:
         replicas: 3
         azureFileShare:


### PR DESCRIPTION
Neuvector var referencing fix

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### neuvector.yaml
- Changed the token from `{CLUSTER}` to `${CLUSTER}` and `${ENVIRONMENT}` to `{ENVIRONMENT}` for better variable substitution.
- Updated the host values from `cft-neuvector{CLUSTER}` to `cft-neuvector${CLUSTER}` and `cft-neuvector-{ENVIRONMENT}{CLUSTER}` to `cft-neuvector-${ENVIRONMENT}${CLUSTER}` for consistency.