### PR TITLE
Moving Service Account into main neuvector.yaml file for common usage

### DIFF
--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   values:
     neuvector:
-      serviceAccount: neuvector
       controller:
         azureFileShare:
           shareName: neuvector-data-00

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -23,6 +23,7 @@ spec:
           - '{"insert":{"after":5,"rules":[{"group":null,"conditions":[{"type":"name","value":"Container.Quarantined"}],"actions":["webhook"],"event":"event","disable":false}]}}'
           - '{"insert":{"after":6,"rules":[{"group":null,"conditions":[{"type":"name","value":"5.4"}],"actions":["webhook"],"event":"compliance","disable":true}]}}'
     neuvector:
+      serviceAccount: neuvector
       containerd:
         enabled: true
       resources:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-26562

### Change description
Moving Service Account into main neuvector.yaml file for common usage
SA needs to be set to Neuvector to make permissions work correctly in AKS.

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_



- Changed file: apps/neuvector/neuvector/ithc/00.yaml
  - Removed a value from the neuvector spec.
  - Updated the traefik ingress class for neuvector.

- Changed file: apps/neuvector/neuvector/neuvector.yaml
  - Added a serviceAccount field to the neuvector spec.
  - Updated the Containerd enabled field to true.
