### PR TITLE
Tech/xui revert pr images 14 07 25

### DIFF
--- a/apps/xui/xui-webapp-ac-integration/demo-image-policy.yaml
+++ b/apps/xui/xui-webapp-ac-integration/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-4539-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/xui/xui-webapp-ac-integration/demo.yaml
+++ b/apps/xui/xui-webapp-ac-integration/demo.yaml
@@ -52,4 +52,4 @@ spec:
         SESSION_TIMEOUTS: >-
           [{"idleModalDisplayTime": 2, "pattern": ".*", "totalIdleTime": 4}]
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
-      image: hmctspublic.azurecr.io/xui/webapp:pr-4539-57c9292-20250710141718 #{"$imagepolicy": "flux-system:demo-xui-webapp-ac-integration"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752 #{"$imagepolicy": "flux-system:demo-xui-webapp-ac-integration"}

--- a/apps/xui/xui-webapp-integration/demo-image-policy.yaml
+++ b/apps/xui/xui-webapp-integration/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-4508-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/xui/xui-webapp-integration/demo.yaml
+++ b/apps/xui/xui-webapp-integration/demo.yaml
@@ -54,4 +54,4 @@ spec:
         SERVICES_NOTIFICATIONS_API_URL: http://ccpay-notifications-service-demo.service.core-compute-demo.internal
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
         WA_SUPPORTED_JURISDICTIONS: IA,CIVIL,PRIVATELAW,PUBLICLAW,ST_CIC,EMPLOYMENT,SSCS
-      image: hmctspublic.azurecr.io/xui/webapp:pr-4508-7423c02-20250708153539 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration"}

--- a/apps/xui/xui-webapp-integration2/demo-image-policy.yaml
+++ b/apps/xui/xui-webapp-integration2/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-4508-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/xui/xui-webapp-integration2/demo.yaml
+++ b/apps/xui/xui-webapp-integration2/demo.yaml
@@ -43,4 +43,4 @@ spec:
         SERVICES_PAYMENTS_URL: http://payment-api-demo.service.core-compute-demo.internal
         SERVICES_ROLE_ASSIGNMENT_MAPPING_API: http://am-org-role-mapping-service-demo.service.core-compute-demo.internal
         WA_SUPPORTED_JURISDICTIONS: IA,CIVIL,PRIVATELAW,PUBLICLAW,ST_CIC,EMPLOYMENT,SSCS
-      image: hmctspublic.azurecr.io/xui/webapp:pr-4508-7423c02-20250708153539 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration2"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752 #{"$imagepolicy": "flux-system:demo-xui-webapp-integration2"}

--- a/apps/xui/xui-webapp-wa-integration/demo-image-policy.yaml
+++ b/apps/xui/xui-webapp-wa-integration/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-4527-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/xui/xui-webapp-wa-integration/demo.yaml
+++ b/apps/xui/xui-webapp-wa-integration/demo.yaml
@@ -46,4 +46,4 @@ spec:
         WA_SUPPORTED_JURISDICTIONS: IA,CIVIL,PRIVATELAW,PUBLICLAW,ST_CIC,EMPLOYMENT,SSCS
         STAFF_SUPPORTED_JURISDICTIONS: ST_CIC,CIVIL,EMPLOYMENT,PRIVATELAW,PUBLICLAW,IA,SSCS,FR,DIVORCE
         HEARINGS_JURISDICTIONS: SSCS,PRIVATELAW,CIVIL,IA,EMPLOYMENT,ST_CIC
-      image: hmctspublic.azurecr.io/xui/webapp:pr-4527-f3fe5ed-20250709153000 #{"$imagepolicy": "flux-system:demo-xui-webapp-wa-integration"}
+      image: hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752 #{"$imagepolicy": "flux-system:demo-xui-webapp-wa-integration"}


### PR DESCRIPTION
### Jira link

N/A

### Change description

Point currently down environments back at prod

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ x ] No


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo-image-policy.yaml`:
  - Changed filter tag pattern from `^pr-4539-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
- `demo.yaml`:
  - Updated image from `hmctspublic.azurecr.io/xui/webapp:pr-4539-57c9292-20250710141718` to `hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752`.
- `demo-image-policy.yaml`:
  - Changed filter tag pattern from `^pr-4508-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
- `demo.yaml`:
  - Updated image from `hmctspublic.azurecr.io/xui/webapp:pr-4508-7423c02-20250708153539` to `hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752`.
- `demo-image-policy.yaml`:
  - Changed filter tag pattern from `^pr-4508-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
- `demo.yaml`:
  - Updated image from `hmctspublic.azurecr.io/xui/webapp:pr-4508-7423c02-20250708153539` to `hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752`.
- `demo-image-policy.yaml`:
  - Changed filter tag pattern from `^pr-4527-[a-f0-9]+-(?P<ts>[0-9]+)` to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
- `demo.yaml`:
  - Updated image from `hmctspublic.azurecr.io/xui/webapp:pr-4527-f3fe5ed-20250709153000` to `hmctspublic.azurecr.io/xui/webapp:prod-b54e7d0-20250710163752`.