### PR TITLE
CCD-6602 - reverting demo deployment after sanity check

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-api-gateway-web
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-594-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-api-gateway-web
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccd/api-gateway-web:pr-594-3b70342-20250704102637 #{"$imagepolicy": "flux-system:demo-ccd-api-gateway-web"}
+      image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-72d893d-20250708115808 #{"$imagepolicy": "flux-system:ccd-api-gateway-web"}
       environment:
         CORS_ORIGIN_WHITELIST: "*"
         TIMING-ALLOW-ORIGIN: "https://www-ccd.demo.platform.hmcts.net"

--- a/apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-case-document-am-api
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-657-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-document-am-api/demo.yaml
+++ b/apps/ccd/ccd-case-document-am-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/case-document-am-api:pr-657-847a057-20250709123057 #{"$imagepolicy": "flux-system:demo-ccd-case-document-am-api"}
+      image: hmctspublic.azurecr.io/ccd/case-document-am-api:prod-ffcde0d-20250707094048 #{"$imagepolicy": "flux-system:ccd-case-document-am-api"}
       environment:
         RESTART: 1
         CASE_DOCUMENT_S2S_AUTHORISED_SERVICES: ccd_case_document_am_api,ccd_gw,xui_webapp,ccd_data,bulk_scan_processor,sscs,probate_backend,iac,em_npa_app,dg_docassembly_api,em_stitching_api,em_ccd_orchestrator,cmc_claim_store,civil_service,bulk_scan_orchestrator,ethos_repl_service,divorce_document_generator,finrem_document_generator,finrem_case_orchestration,fpl_case_service,et_cos,prl_cos_api,prl_dgs_api,ds_ui,adoption_cos_api,adoption_web,et_sya_api,fis_cos_api,prl_citizen_frontend,nfdiv_case_api,divorce_frontend,sptribs_case_api,civil_general_applications


### PR DESCRIPTION
CCD-6602 - reverting demo deployment after sanity check

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
- Changed the pattern in the `demo-image-policy.yaml` to enable `hmcts.github.com/prod-automated` and updated the filterTags pattern to match production image tags.

### apps/ccd/ccd-api-gateway-web/demo.yaml
- Updated the image tag for the `demo.yaml` file to use a production image tag instead of a pull request tag.

### apps/ccd/ccd-case-document-am-api/demo-image-policy.yaml
- Enabled `hmcts.github.com/prod-automated` in this file and updated the filterTags pattern to match production image tags in the `demo-image-policy.yaml`.

### apps/ccd/ccd-case-document-am-api/demo.yaml
- Updated the image tag for the `demo.yaml` file to use a production image tag instead of a pull request tag.