### PR TITLE
DTSPO-26704 Fix neuvector patch for init container volumemounts

### DIFF
--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -90,8 +90,8 @@ spec:
                   name: longlived-token
                   readOnly: true
               - op: add
-                path: /spec/template/spec/initContainers/0/volumeMounts/-
+                path: /spec/template/spec/initContainers/0/volumeMounts
                 value:
-                  mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                  name: longlived-token
-                  readOnly: true
+                  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    name: longlived-token
+                    readOnly: true


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-26704

### Change description

There is no existing volumemounts for init to add to so it was failing. 
This should fix the issue.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### File changed: 00.yaml
- Added a new volume mount to the init container in the Kubernetes spec. This new volume mount has a mount path and specifies the name and read-only status.

