### PR TITLE
DTSPO-26704 Moving neuvector patch to main helmrelease as its now tested

### DIFF
--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -66,32 +66,3 @@ spec:
           annotations:
             kubernetes.io/ingress.class: traefik
             traefik.ingress.kubernetes.io/router.tls: "false"
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: neuvector-controller-pod
-            patch: |
-              - op: add
-                path: /spec/template/spec/automountServiceAccountToken
-                value: false
-              - op: add
-                path: /spec/template/spec/volumes/-
-                value:
-                  name: longlived-token
-                  secret:
-                    secretName: neuvector-longlived-token
-                    defaultMode: 420
-              - op: add
-                path: /spec/template/spec/containers/0/volumeMounts/-
-                value:
-                  mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                  name: longlived-token
-                  readOnly: true
-              - op: add
-                path: /spec/template/spec/initContainers/0/volumeMounts
-                value:
-                  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                    name: longlived-token
-                    readOnly: true

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -61,3 +61,32 @@ spec:
         kind: HelmRepository
         name: hmctspublic-oci
         namespace: flux-system
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: neuvector-controller-pod
+            patch: |
+              - op: add
+                path: /spec/template/spec/automountServiceAccountToken
+                value: false
+              - op: add
+                path: /spec/template/spec/volumes/-
+                value:
+                  name: longlived-token
+                  secret:
+                    secretName: neuvector-longlived-token
+                    defaultMode: 420
+              - op: add
+                path: /spec/template/spec/containers/0/volumeMounts/-
+                value:
+                  mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                  name: longlived-token
+                  readOnly: true
+              - op: add
+                path: /spec/template/spec/initContainers/0/volumeMounts
+                value:
+                  - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                    name: longlived-token
+                    readOnly: true


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-26704

### Change description

Move Neuvector patch to main helmrelease as testing is completed on itch 00 cluster

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### neuvector/ithc/00.yaml
- Remove postRenderers block and its content.

### neuvector/neuvector.yaml
- Add postRenderers block with kustomize patches for neuvector-controller-pod deployment to disable automounting of service account token and add a secret volume and volume mount for longlived-token.