### PR TITLE
CCD-6368: Revert perftest deployment of pull request 581 image

### DIFF
--- a/apps/aac/manage-case-assignment/perftest-image-policy.yaml
+++ b/apps/aac/manage-case-assignment/perftest-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: perftest-manage-case-assignment
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-581-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: manage-case-assignment

--- a/apps/aac/manage-case-assignment/perftest.yaml
+++ b/apps/aac/manage-case-assignment/perftest.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/aac/manage-case-assignment:pr-581-6de9d06-20250704143803 #{"$imagepolicy": "flux-system:perftest-manage-case-assignment"}
+      image: hmctspublic.azurecr.io/aac/manage-case-assignment:prod-321ecb9-20250703104513 #{"$imagepolicy": "flux-system:perftest-manage-case-assignment"}
       environment:
         MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,civil_service,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,fpl_case_service,prl_cos_api,et_cos,nfdiv_case_api,et_sya_api
         MCA_DS_PROXY_URLS_ALLOWED_LIST: /searchCases.*,/internal/searchCases.*,/internal/cases.*


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [CCD-6368](https://tools.hmcts.net/jira/browse/CCD-6368)

### Change description

Revert deployment of pull request 581 image to aac-manage-case-assignment perftest environment

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated the image tag in `perftest.yaml` from `pr-581-6de9d06-20250704143803` to `prod-321ecb9-20250703104513`.
- Removed annotations and filterTags in `perftest-image-policy.yaml`.