### PR TITLE
Deploy latest idam-web-public images to lower envs

### DIFF
--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-133b3af-20250714115349
+      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
       ingressHost: idam-web-public.aat.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-133b3af-20250714115349
+      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
       replicas: 1
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-133b3af-20250714115349
+      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
       ingressHost: idam-web-public.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-133b3af-20250714115349
+      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
       replicas: 2
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-133b3af-20250714115349
+      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
       ingressHost: idam-web-public.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1


### PR DESCRIPTION
### Jira link
N/A

### Change description
CVE suppression only.

### Testing done
Yes

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

CVE-2025-46392 has been identified in Apache Commons Configuration 1.8 (last updated in 2013 and now moved into Commons Configuration2) - this is a transitive dependency of Spring Cloud Starter Netflix Zuul 2.2.10 which was last updated in 2021. 
The CVE is suppressed as:
* we cannot upgrade those dependencies in idam-web-public
* we cannot easily replace with an alternative library
* idam-web-public will be decommissioned in the coming months and replaced by idam-hmcts-access

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated aat.yaml, demo.yaml, ithc.yaml, perftest.yaml, and sbox.yaml in the idam-web-public directory to update the Java image to hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
- Updated the image version for different environments in the idam-web-public directory to match the new image version.