### PR TITLE
CHG-0026310: CFT IDAM 9.15.1: Fix: SSO Failure with OpenID Connect PKCE flow

### DIFF
--- a/apps/idam/idam-web-public/idam-web-public.yaml
+++ b/apps/idam/idam-web-public/idam-web-public.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-web-public
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-b4dabaf-20250630091544
+      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
       replicas: 2
       cpuRequests: '60m'
       cpuLimits: '1500m'


### PR DESCRIPTION
### Jira link
[CHG0026310](https://hmcts.haloitsm.com/ticket?id=26310)

### Change description
Fix for SSO failures when using PKCE flow.
Tomcat upgrade.
Library upgrades.

### Testing done
Yes

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No
CVE-2025-46392 has been identified in Apache Commons Configuration 1.8 (last updated in 2013 and now moved into Commons Configuration2) - this is a transitive dependency of Spring Cloud Starter Netflix Zuul 2.2.10 which was last updated in 2021.
The CVE is suppressed as:
* we cannot upgrade those dependencies in idam-web-public
* we cannot easily replace with an alternative library
* idam-web-public will be decommissioned in the coming months and replaced by idam-hmcts-access

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
