### PR TITLE
SSCSCI: revert tribunals demo to prod image

### DIFF
--- a/apps/sscs/sscs-tribunals-api/demo-image-policy.yaml
+++ b/apps/sscs/sscs-tribunals-api/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
   name: demo-sscs-tribunals-api
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-4815-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: sscs-tribunals-api


### PR DESCRIPTION
### Change description

revert sscs-tribunals-api  demo to prod image

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **demo-image-policy.yaml**
  - Removed annotations for disabling prod-automated
  - Removed filterTags and extract fields
  - Removed the alphabetical policy and its order
  - Retained the imageRepositoryRef configuration