### PR TITLE
CCD-6350 - demo deployment for sanity test

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-api-gateway-web
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-579-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-api-gateway-web
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccd/api-gateway-web:prod-c865f52-20250716160641 #{"$imagepolicy": "flux-system:ccd-api-gateway-web"}
+      image: hmctspublic.azurecr.io/ccd/api-gateway-web:pr-579-cb5aeba-20250722084058 #{"$imagepolicy": "flux-system:demo-ccd-api-gateway-web"}
       environment:
         CORS_ORIGIN_WHITELIST: "*"
         TIMING-ALLOW-ORIGIN: "https://www-ccd.demo.platform.hmcts.net"


### PR DESCRIPTION
CCD-6350 - demo deployment for sanity test

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/ccd/ccd-api-gateway-web/demo-image-policy.yaml
- The `demo-image-policy.yaml` file was modified to disable the `hmcts.github.com/prod-automated` annotation and update the filter tag pattern to use `pr-579` instead of `prod` for the demo image policy.

### apps/ccd/ccd-api-gateway-web/demo.yaml
- The `demo.yaml` file was updated to change the image tag from `prod` to `pr-579` for the `hmctspublic.azurecr.io/ccd/api-gateway-web` image.