### PR TITLE
Frontend: Civil - Add remission button not available on the second re…

### DIFF
--- a/apps/fees-pay/ccpay-payment-api-int/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api-int/demo.yaml
@@ -9,7 +9,7 @@ spec:
       image: hmctspublic.azurecr.io/payment/api:pr-1811-0c691f5-20250717165131 #{"$imagepolicy": "flux-system:demo-int-ccpay-payment-app"}
       imagePullPolicy: Always
       environment:
-        DUMMY_RESTART_VAR: true
+        DUMMY_RESTART_VAR: false
         POSTGRES_NAME: postgresqldb2
         TRUSTED_S2S_SERVICE_NAMES: "refunds_api,cmc,cmc_claim_store,probate_frontend,divorce_frontend,ccd_gw,api_gw,finrem_payment_service,ccpay_bubble,jui_webapp,xui_webapp,fpl_case_service,probate_backend,iac,nfdiv_case_api,civil_service,paymentoutcome_web,prl_cos_api,adoption_web,civil_general_applicationsccpay_gw"
         RETURNURL_ALLOWED_HOSTNAMES: hmcts.net,gov.uk

--- a/apps/fees-pay/ccpay-payment-api/demo-int-image-policy.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo-int-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1811-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1829-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
 Frontend: Civil - Add remission button not available on the second remission
    
    https://tools.hmcts.net/jira/browse/PAY-7868



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fees-pay/ccpay-payment-api-int/demo.yaml
- Changed the value of DUMMY_RESTART_VAR from true to false.
- Updated the TRUSTED_S2S_SERVICE_NAMES environment variable.

### apps/fees-pay/ccpay-payment-api/demo-int-image-policy.yaml
- Updated the filterTags pattern from '^pr-1811-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-1829-[a-f0-9]+-(?P<ts>[0-9]+)'.