### PR TITLE
Frontend: Civil - Add remission button not available on the second re…

### DIFF
--- a/apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     nodejs:
       replicas: 2
-      useInterpodAntiAffinity: true
+      useInterpodAntiAffinity: false
       image: hmctspublic.azurecr.io/ccpay/bubble-frontend:prod-73dd0b4-20250721135646 #{"$imagepolicy": "flux-system:ccpay-bubble-frontend"}
   chart:
     spec:

--- a/apps/fees-pay/ccpay-bubble-frontend/demo-image-policy.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-965-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-969-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
+++ b/apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       replicas: 2
-      useInterpodAntiAffinity: true
+      useInterpodAntiAffinity: false
       image: hmctspublic.azurecr.io/payment/api:prod-8d7da69-20250722104456 #{"$imagepolicy": "flux-system:ccpay-payment-app"}
   chart:
     spec:

--- a/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1818-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1829-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
 Frontend: Civil - Add remission button not available on the second remission
    
    https://tools.hmcts.net/jira/browse/PAY-7868


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Changed file: ccpay-bubble-frontend.yaml
  - Changed the `useInterpodAntiAffinity` value from true to false.

- Changed file: demo-image-policy.yaml
  - Updated the `pattern` value from '^pr-965-' to '^pr-969-'.

- Changed file: ccpay-payment-api.yaml
  - Changed the `useInterpodAntiAffinity` value from true to false.

- Changed file: demo-image-policy.yaml
  - Updated the `pattern` value from '^pr-1818-' to '^pr-1829-'.