### PR TITLE
 Frontend: Civil - Add remission button not available on the second r…

### DIFF
--- a/apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     nodejs:
       replicas: 2
-      useInterpodAntiAffinity: false
+      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/ccpay/bubble-frontend:prod-9f96c70-20250722144849 #{"$imagepolicy": "flux-system:ccpay-bubble-frontend"}
   chart:
     spec:

--- a/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
@@ -10,5 +10,5 @@ spec:
       environment:
         TELEPHONY_FEATURE: enabled
         PCIPAL_ANTENNA_URL: https://paybubble.demo.platform.hmcts.net/ccd-search
-        DUMMY_RESTART_VAR: true
+        DUMMY_RESTART_VAR: false
         CCPAY_REFUNDS_API_URL: http://ccpay-refunds-api-demo.service.core-compute-demo.internal

--- a/apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
+++ b/apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     java:
       replicas: 2
-      useInterpodAntiAffinity: false
+      useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/payment/api:prod-8d7da69-20250722104456 #{"$imagepolicy": "flux-system:ccpay-payment-app"}
   chart:
     spec:

--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -9,7 +9,7 @@ spec:
       image: hmctspublic.azurecr.io/payment/api:pr-1829-2bff298-20250722104334 #{"$imagepolicy": "flux-system:demo-ccpay-payment-app"}
       imagePullPolicy: Always
       environment:
-        DUMMY_RESTART_VAR: false
+        DUMMY_RESTART_VAR: true
         TRUSTED_S2S_SERVICE_NAMES: "refunds_api,cmc,cmc_claim_store,probate_frontend,divorce_frontend,ccd_gw,api_gw,finrem_payment_service,finrem_case_orchestration,ccpay_bubble,jui_webapp,xui_webapp,fpl_case_service,probate_backend,iac,nfdiv_case_api,civil_service,paymentoutcome_web,prl_cos_api,adoption_web,civil_general_applications,ccpay_gw"
         RETURNURL_ALLOWED_HOSTNAMES: hmcts.net,gov.uk
         PCI_PAL_CALLBACK_URL: https://cft-mtls-api-mgmt-appgw.demo.platform.hmcts.net/telephony-api/telephony/callback


### PR DESCRIPTION
 Frontend: Civil - Add remission button not available on the second remission
    
        https://tools.hmcts.net/jira/browse/PAY-7868



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fees-pay/ccpay-bubble-frontend/ccpay-bubble-frontend.yaml
- Changed `useInterpodAntiAffinity` from `false` to `true`.

### apps/fees-pay/ccpay-bubble-frontend/demo.yaml
- Changed `DUMMY_RESTART_VAR` from `true` to `false`.

### apps/fees-pay/ccpay-payment-api/ccpay-payment-api.yaml
- Changed `useInterpodAntiAffinity` from `false` to `true`.

### apps/fees-pay/ccpay-payment-api/demo.yaml
- Changed `DUMMY_RESTART_VAR` from `false` to `true`.