### PR TITLE
Updating service account client id post managed identity recreation

### DIFF
--- a/apps/idam/identity/sbox.yaml
+++ b/apps/idam/identity/sbox.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: idam
 spec:
   resourceID: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/idam-sandbox-mi
-  clientID: ba3dc98d-c96e-4c8c-a654-67f56205c655
+  clientID: 428e93aa-9143-4035-9cb0-a1a177ab0452

--- a/apps/idam/serviceaccount/sbox.yaml
+++ b/apps/idam/serviceaccount/sbox.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "1f7ad498-ebed-4adf-b4cd-c1fa83744ec3"
+    azure.workload.identity/client-id: "428e93aa-9143-4035-9cb0-a1a177ab0452"


### PR DESCRIPTION
Service account client ID has changed following the re-creation of managed identity in azure due to running and rebuilding idam-shared-infra, pods would need to pick up this new value.

Pods would need to pick up the new value.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/idam/identity/sbox.yaml`
  - Updated the `clientID` from `ba3dc98d-c96e-4c8c-a654-67f56205c655` to `428e93aa-9143-4035-9cb0-a1a177ab0452`.

- `apps/idam/serviceaccount/sbox.yaml`
  - Updated the `azure.workload.identity/client-id` from `\"1f7ad498-ebed-4adf-b4cd-c1fa83744ec3\"` to `\"428e93aa-9143-4035-9cb0-a1a177ab0452\"`.