### PR TITLE
IDAM 9.15.2: Updates to Probate Privacy Policy

### DIFF
--- a/apps/idam/idam-web-public/aat.yaml
+++ b/apps/idam/idam-web-public/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
+      image: hmctspublic.azurecr.io/idam/web-public:prod-f3909f5-20250724105705
       ingressHost: idam-web-public.aat.platform.hmcts.net
       environment:
         STRATEGIC_SERVICE_URL: https://idam-api.aat.platform.hmcts.net

--- a/apps/idam/idam-web-public/demo.yaml
+++ b/apps/idam/idam-web-public/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
+      image: hmctspublic.azurecr.io/idam/web-public:prod-f3909f5-20250724105705
       replicas: 1
       ingressHost: idam-web-public.demo.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/ithc.yaml
+++ b/apps/idam/idam-web-public/ithc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
+      image: hmctspublic.azurecr.io/idam/web-public:prod-f3909f5-20250724105705
       ingressHost: idam-web-public.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-web-public/perftest.yaml
+++ b/apps/idam/idam-web-public/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
+      image: hmctspublic.azurecr.io/idam/web-public:prod-f3909f5-20250724105705
       replicas: 2
       ingressHost: idam-web-public.perftest.platform.hmcts.net
       environment:

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/idam/web-public:prod-3980b92-20250717104129
+      image: hmctspublic.azurecr.io/idam/web-public:prod-f3909f5-20250724105705
       ingressHost: idam-web-public.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1


### PR DESCRIPTION
### Jira link
N/A

### Change description
Deploying latest idam-web-public images to non-prod.
The only change is a content update in Probate's Privacy Policy.

### Testing done
Yes

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/idam-web-public/aat.yaml
- Updated the image version of the Java service to prod-f3909f5-20250724105705.

### apps/idam/idam-web-public/demo.yaml
- Updated the image version of the Java service to prod-f3909f5-20250724105705.
- Changed the number of replicas to 1.

### apps/idam/idam-web-public/ithc.yaml
- Updated the image version of the Java service to prod-f3909f5-20250724105705.
- Changed the number of replicas to 1.

### apps/idam/idam-web-public/perftest.yaml
- Updated the image version of the Java service to prod-f3909f5-20250724105705.
- Changed the number of replicas to 2.

### apps/idam/idam-web-public/sbox.yaml
- Updated the image version of the Java service to prod-f3909f5-20250724105705.
- Disabled Traefik TLS.
- Changed the number of replicas to 1.