### PR TITLE
Revert "point AAT to PR image (#4819)"

### DIFF
--- a/apps/sscs/sscs-tribunals-api/aat-image-policy.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat-image-policy.yaml
@@ -1,12 +1,10 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
-  annotations:
-    hmcts.github.com/prod-automated: disabled
   name: aat-sscs-tribunals-api
 spec:
   filterTags:
-    pattern: '^pr-4819-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/sscs/sscs-tribunals-api/aat.yaml
+++ b/apps/sscs/sscs-tribunals-api/aat.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/sscs/tribunals-api:pr-4819-832c337-20250724113846 #{"$imagepolicy": "flux-system:aat-sscs-tribunals-api"}
+      image: hmctspublic.azurecr.io/sscs/tribunals-api:prod-27da7b3-20250721161747 #{"$imagepolicy": "flux-system:sscs-tribunals-api"}
       aadIdentityName: sscs
       environment:
         CREATE_CCD_ENDPOINT: true


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#39645

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- **aat-image-policy.yaml**
  - Changed the pattern from '^pr-4819-[a-f0-9]+-(?P<ts>[0-9]+)' to '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
- **aat.yaml**
  - Updated the image from 'hmctspublic.azurecr.io/sscs/tribunals-api:pr-4819-832c337-20250724113846' to 'hmctspublic.azurecr.io/sscs/tribunals-api:prod-27da7b3-20250721161747'