### PR TITLE
CCD-6631 - ccd-print-service Deploying on demo for sanity test

### DIFF
--- a/apps/ccd/ccd-case-print-service/demo-image-policy.yaml
+++ b/apps/ccd/ccd-case-print-service/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-ccd-case-print-service
   annotations:
-    hmcts.github.com/prod-automated: enabled
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-573-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/ccd/ccd-case-print-service/demo.yaml
+++ b/apps/ccd/ccd-case-print-service/demo.yaml
@@ -6,6 +6,6 @@ spec:
   releaseName: ccd-case-print-service
   values:
     nodejs:
-      image: hmctspublic.azurecr.io/ccd/case-print-service:prod-2f1b924-20250721220630 #{"$imagepolicy": "flux-system:demo-ccd-case-print-service"}
+      image: hmctspublic.azurecr.io/ccd/case-print-service:pr-573-1e90d81-20250723113217 #{"$imagepolicy": "flux-system:demo-ccd-case-print-service"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1


### PR DESCRIPTION
CCD-6631 - ccd-print-service Deploying on demo for sanity test

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `demo-image-policy.yaml` 🔄 In the `demo-ccd-case-print-service` ImagePolicy, the annotation for `hmcts.github.com/prod-automated` has been changed from enabled to disabled, and the filterTags pattern has been updated from `'prod-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'pr-573-[a-f0-9]+-(?P<ts>[0-9]+)'`.
- `demo.yaml` 🔄 In the `ccd-case-print-service` demo deployment, the image reference for nodejs has been updated from `hmctspublic.azurecr.io/ccd/case-print-service:prod-2f1b924-20250721220630` to `hmctspublic.azurecr.io/ccd/case-print-service:pr-573-1e90d81-20250723113217`, and a new environment variable `DUMMY_VAR_TO_REDEPLOY: 1` has been added.