### PR TITLE
Adding xui image policy back to perftest

### DIFF
--- a/apps/xui/xui-webapp/perftest.yaml
+++ b/apps/xui/xui-webapp/perftest.yaml
@@ -56,4 +56,4 @@ spec:
         SERVICES_TRANSLATION_API_URL: http://ts-translation-service-perftest.service.core-compute-perftest.internal
         SERVICES_NOTIFICATIONS_API_URL: http://ccpay-notifications-service-perftest.service.core-compute-perftest.internal
         SERVICES_PAYMENTS_URL: http://payment-api-perftest.service.core-compute-perftest.internal
-      image: hmctspublic.azurecr.io/xui/webapp:prod-31c3c1e-20250723125210
+      image: hmctspublic.azurecr.io/xui/webapp:prod-31c3c1e-20250723125210  #{"$imagepolicy": "flux-system:perftest-xui-webapp"}


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- Updated the image version in `perftest.yaml` from `hmctspublic.azurecr.io/xui/webapp:prod-31c3c1e-20250723125210` to `hmctspublic.azurecr.io/xui/webapp:prod-31c3c1e-20250723125210` 🔄