### PR TITLE
Update perftest-image-policy.yaml

### DIFF
--- a/apps/xui/xui-webapp/perftest-image-policy.yaml
+++ b/apps/xui/xui-webapp/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-4532-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
Revert perftest image back to prod


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/xui/xui-webapp/perftest-image-policy.yaml
- Changed the filter tag pattern from `'pr-4532-[a-f0-9]+-(?P<ts>[0-9]+)'` to `'prod-[a-f0-9]+-(?P<ts>[0-9]+)'`.