### PR TITLE
idam-sandbox-client-id-update

### DIFF
--- a/apps/idam/identity/sbox.yaml
+++ b/apps/idam/identity/sbox.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: idam
 spec:
   resourceID: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/idam-sandbox-mi
-  clientID: 428e93aa-9143-4035-9cb0-a1a177ab0452
+  clientID: 395d9486-4ce9-411b-a05f-199aa9f52dda

--- a/apps/idam/serviceaccount/sbox.yaml
+++ b/apps/idam/serviceaccount/sbox.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "428e93aa-9143-4035-9cb0-a1a177ab0452"
+    azure.workload.identity/client-id: "395d9486-4ce9-411b-a05f-199aa9f52dda"


### PR DESCRIPTION

### Change description

Service account client ID has changed following the re-creation of managed identity in azure due to running and rebuilding idam-shared-infra, pods would need to pick up this new value.



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/idam/identity/sbox.yaml
- Changed the clientID value from \"428e93aa-9143-4035-9cb0-a1a177ab0452\" to \"395d9486-4ce9-411b-a05f-199aa9f52dda.\"

### apps/idam/serviceaccount/sbox.yaml
- Updated the azure.workload.identity client-id from \"428e93aa-9143-4035-9cb0-a1a177ab0452\" to \"395d9486-4ce9-411b-a05f-199aa9f52dda.\"