### PR TITLE
PAY-7463: Civil - Add remission button not available on the second re…

### DIFF
--- a/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1818-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-1849-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -9,7 +9,7 @@ spec:
       image: hmctspublic.azurecr.io/payment/api:pr-1818-23ec882-20250722102412 #{"$imagepolicy": "flux-system:demo-ccpay-payment-app"}
       imagePullPolicy: Always
       environment:
-        DUMMY_RESTART_VAR: true
+        DUMMY_RESTART_VAR: false
         TRUSTED_S2S_SERVICE_NAMES: "refunds_api,cmc,cmc_claim_store,probate_frontend,divorce_frontend,ccd_gw,api_gw,finrem_payment_service,finrem_case_orchestration,ccpay_bubble,jui_webapp,xui_webapp,fpl_case_service,probate_backend,iac,nfdiv_case_api,civil_service,paymentoutcome_web,prl_cos_api,adoption_web,civil_general_applications,ccpay_gw"
         RETURNURL_ALLOWED_HOSTNAMES: hmcts.net,gov.uk
         PCI_PAL_CALLBACK_URL: https://cft-mtls-api-mgmt-appgw.demo.platform.hmcts.net/telephony-api/telephony/callback


### PR DESCRIPTION
  PAY-7463: Civil - Add remission button not available on the second remission
            [PAY-7463] (https://tools.hmcts.net/jira/browse/PAY-7463).


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fees-pay/ccpay-payment-api/demo-image-policy.yaml
- Updated the `pattern` under `metadata.spec.filterTags` from `^pr-1818-[a-f0-9]+-(?P<ts>[0-9]+)` to `^pr-1849-[a-f0-9]+-(?P<ts>[0-9]+)`.

### apps/fees-pay/ccpay-payment-api/demo.yaml
- Changed the value of `DUMMY_RESTART_VAR` from `true` to `false`.
- Updated the `TRUSTED_S2S_SERVICE_NAMES`, `RETURNURL_ALLOWED_HOSTNAMES`, and `PCI_PAL_CALLBACK_URL`.