### PR TITLE
PAY-7463: Refund Remission Test failing

### DIFF
--- a/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
+++ b/apps/fees-pay/ccpay-bubble-frontend/demo.yaml
@@ -8,7 +8,6 @@ spec:
     nodejs:
       image: hmctspublic.azurecr.io/ccpay/bubble-frontend:pr-965-1e8e668-20250806103714 #{"$imagepolicy": "flux-system:demo-ccpay-bubble-frontend"}
       environment:
-        TELEPHONY_FEATURE: enabled
         PCIPAL_ANTENNA_URL: https://paybubble.demo.platform.hmcts.net/ccd-search
-        DUMMY_RESTART_VAR: false
+        DUMMY_RESTART_VAR: true
         CCPAY_REFUNDS_API_URL: http://ccpay-refunds-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
 PAY-7463: Refund Remission Test failing
         [PAY-7463] (https://tools.hmcts.net/jira/browse/PAY-7463).

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/fees-pay/ccpay-bubble-frontend/demo.yaml
- Changed the value of DUMMY_RESTART_VAR from false to true.
- Updated the CCPAY_REFUNDS_API_URL to http://ccpay-refunds-api-demo.service.core-compute-demo.internal.