### PR TITLE
revert traefik timeouts to default 30s

### DIFF
--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -13,6 +13,3 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"

--- a/apps/admin/traefik2/aat/00.yaml
+++ b/apps/admin/traefik2/aat/00.yaml
@@ -14,9 +14,5 @@ spec:
     serviceAccount:
       name: admin
     additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"
       - "--entryPoints.web.forwardedHeaders.insecure=true"
       - "--entryPoints.websecure.forwardedHeaders.insecure=true"

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -16,7 +16,3 @@ spec:
     additionalArguments:
       - "--entryPoints.web.forwardedHeaders.insecure=true"
       - "--entryPoints.websecure.forwardedHeaders.insecure=true"
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=180"

--- a/apps/admin/traefik2/demo/00.yaml
+++ b/apps/admin/traefik2/demo/00.yaml
@@ -13,6 +13,3 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -16,7 +16,3 @@ spec:
     additionalArguments:
       - "--entryPoints.web.forwardedHeaders.insecure=true"
       - "--entryPoints.websecure.forwardedHeaders.insecure=true"
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=180"

--- a/apps/admin/traefik2/demo/01.yaml
+++ b/apps/admin/traefik2/demo/01.yaml
@@ -13,6 +13,3 @@ spec:
         useWorkloadIdentity: "true"
     serviceAccount:
       name: admin
-    additionalArguments:
-      - "--entryPoints.web.forwardedHeaders.insecure=true"
-      - "--entryPoints.websecure.forwardedHeaders.insecure=true"


### PR DESCRIPTION
### Change description
revert traefik timeouts to default 30s
- should be using default 30s



## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `apps/admin/traefik2/aat/00.yaml`:
  - Removed additional arguments for entry points web and websecure related to timeouts and headers.

- `apps/admin/traefik2/demo/00.yaml`, `apps/admin/traefik2/demo/01.yaml`:
  - Updated additional arguments for entry points web and websecure related to timeouts and headers, increasing the write and read timeouts.