### PR TITLE
DTSCCI-0000 Update gov-notify-pretends-api-key  in aat

### DIFF
--- a/apps/civil/civil-service/aat.yaml
+++ b/apps/civil/civil-service/aat.yaml
@@ -39,7 +39,7 @@ spec:
               alias: CMC_DB_USERNAME
             - name: cmc-db-host-v15
               alias: CMC_DB_HOST
-            - name: gov-notify-guest-list-api-key
+            - name: gov-notify-pretends-api-key
               alias: GOV_NOTIFY_API_KEY
             - name: sendgrid-api-key
               alias: SENDGRID_API_KEY


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


### apps/civil/civil-service/aat.yaml
- Replaced `gov-notify-guest-list-api-key` with `gov-notify-pretends-api-key` alias
- Updated the alias `CMC_DB_HOST` from `cmc-db-host-v15` to `CMC_DB_HOST`