### PR TITLE
Update prod.yaml

### DIFF
--- a/apps/xui/xui-webapp/prod.yaml
+++ b/apps/xui/xui-webapp/prod.yaml
@@ -19,7 +19,7 @@ spec:
         SERVICES_IDAM_OAUTH_CALLBACK_URL: /oauth2/callback
         FEATURE_OIDC_ENABLED: true
         DEBUG: xuiNode:*,-xuiNode:auth:s2s
-        SERVICES_IDAM_ISS_URL: https://hmcts-access.service.gov.uk/o
+        SERVICES_IDAM_ISS_URL: https://forgerock-am.service.core-compute-idam-prod2.internal:8443/openam/oauth2/realms/root/realms/hmcts
         JURISDICTIONS: DIVORCE,PROBATE,FR,PUBLICLAW,SSCS,IA,EMPLOYMENT,CMC,HRS,CIVIL,PRIVATELAW,ST_CIC,ADOPTION
         FEATURE_ACCESS_MANAGEMENT_ENABLED: true
         FEATURE_LAU_SPECIFIC_CHALLENGED_ENABLED: true
@@ -27,4 +27,3 @@ spec:
         DUMMY_VAR_TO_RESTART: 1
         SERVICES_HEARINGS_COMPONENT_API_SSCS: http://sscs-tribunals-api-prod.service.core-compute-prod.internal
         SERVICES_ICP_API: https://em-icp.platform.hmcts.net
-        SERVICES_IDAM_SERVICE_OVERRIDE: false


### PR DESCRIPTION
revert iss change, remove idam override

## 🤖AEP PR SUMMARY🤖

_I'm a bot that generates AI summaries of pull requests, see [AEP](https://kainossoftwareltd.github.io/ai-enhanced-platform/) for more details_


- `prod.yaml`
  - Updated `SERVICES_IDAM_ISS_URL` from `https://hmcts-access.service.gov.uk/o` to `https://forgerock-am.service.core-compute-idam-prod2.internal:8443/openam/oauth2/realms/root/realms/hmcts`
  - Removed `SERVICES_IDAM_SERVICE_OVERRIDE` key with value `false`