### PR TITLE
Revert "DTSPO-27329 update sbox image to use same image as ptl"

### DIFF
--- a/apps/backstage/backstage/sbox-intsvc.yaml
+++ b/apps/backstage/backstage/sbox-intsvc.yaml
@@ -8,7 +8,7 @@ spec:
     ingress:
       host: backstage.sandbox.platform.hmcts.net
     backend:
-      image: hmctspublic.azurecr.io/backstage/backend:prod-2c7f1bf5-1738684519 # {"$imagepolicy": "flux-system:backstage-backend"}
+      image: hmctspublic.azurecr.io/backstage/backend:pr-116-3dcd4213-1739553613 # {"$imagepolicy": "flux-system:ptlsbox-backstage-backend"}
       db:
         user: pgadmin
         host: hmcts-backstage-flex-ptlsbox.postgres.database.azure.com


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#40229

need to revert image as it is using late build 