### PR TITLE
Reverting Production deployment - Dynatrace

### DIFF
--- a/apps/dynatrace/aat/base/kustomization.yaml
+++ b/apps/dynatrace/aat/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: dynatrace
 patches:
 - path: dynakube.yaml
+- path: ../../dynatrace-operator-upgrade.yaml

--- a/apps/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.6.1/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.5.1/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator-upgrade.yaml
+++ b/apps/dynatrace/dynatrace-operator-upgrade.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dynatrace-operator
+  namespace: dynatrace
+spec:
+  releaseName: dynatrace-operator
+  interval: 5m
+  chart:
+    spec:
+      chart: dynatrace-operator
+      # update the CRDs in dynatrace-crds when changing this value
+      version: 1.6.1
+      sourceRef:
+        name: dynatrace-operator
+        kind: HelmRepository
+        namespace: dynatrace

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.6.1
+      version: 1.5.1
       sourceRef:
         name: dynatrace-operator
         kind: HelmRepository

--- a/apps/dynatrace/perftest/base/kustomization.yaml
+++ b/apps/dynatrace/perftest/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: dynatrace
 patches:
 - path: dynakube.yaml
+- path: ../../dynatrace-operator-upgrade.yaml

--- a/apps/dynatrace/preview/base/kustomization.yaml
+++ b/apps/dynatrace/preview/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: dynatrace
 patches:
 - path: dynakube.yaml
+- path: ../../dynatrace-operator-upgrade.yaml

--- a/clusters/aat/base/kustomization.yaml
+++ b/clusters/aat/base/kustomization.yaml
@@ -64,3 +64,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/aat/base/kustomize.yaml
   - path: ../../../apps/admin/aat/base/kustomize.yaml
+  - path: ../../../apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml

--- a/clusters/perftest/base/kustomization.yaml
+++ b/clusters/perftest/base/kustomization.yaml
@@ -57,3 +57,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/perftest/base/kustomize.yaml
+  - path: ../../../apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -63,3 +63,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/tax-tribunals/preview/base/kustomize.yaml
   - path: ../../../apps/admin/preview/base/kustomize.yaml
+  - path: ../../../apps/dynatrace/dynatrace-crds-upgrade/kustomize.yaml


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-26960

### Change description
Rolling back Production deployment due to false positives. Reverting Production deployment to allow testing and confirmation.