### PR TITLE
PAY-8054: Deploy to Demo

### DIFF
--- a/apps/fees-pay/fees-register-api/demo-image-policy.yaml
+++ b/apps/fees-pay/fees-register-api/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-fees-register-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-641-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: fees-register-api

--- a/apps/fees-pay/fees-register-api/demo.yaml
+++ b/apps/fees-pay/fees-register-api/demo.yaml
@@ -9,4 +9,4 @@ spec:
       image: hmctspublic.azurecr.io/fees-register/api:prod-011d761-20250819101227 #{"$imagepolicy": "flux-system:demo-fees-register-api"}
       imagePullPolicy: Always
       environment:
-        DUMMY_RESTART_VAR: true
+        DUMMY_RESTART_VAR: false


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PAY-8054

### Change description
Defaults the current version to always use the latest approved fee and tidies up the approved fees - this only now gives back the approved versions and not the draft versions.

### Testing done
Local testing, Unit testing, will require testing in the lower environments.

Developer testing completed.
1. approvedFees API - this now correctly brings back FEE0441 approved fees, if there is a draft version or not.
2. approvedFees API - this only contains fee versions which have been approved - no need to send Liberata draft fees.
3. Validated fees with draft versions can now be accessed from PayBubble.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
