### PR TITLE
DFR-3989: Update HPA config

### DIFF
--- a/apps/financial-remedy/finrem-cos/finrem-cos.yaml
+++ b/apps/financial-remedy/finrem-cos/finrem-cos.yaml
@@ -8,6 +8,13 @@ spec:
   values:
     java:
       replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: '1536Mi'
+      memoryLimits: '2048Mi'
+      cpuRequests: '250m'
+      cpuLimits: '1500m'
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/finrem/cos:prod-e43ecd3-20250904161816 #{"$imagepolicy": "flux-system:finrem-cos"}
       environment:

--- a/apps/financial-remedy/finrem-cos/ithc.yaml
+++ b/apps/financial-remedy/finrem-cos/ithc.yaml
@@ -10,10 +10,6 @@ spec:
         enabled: true
         minReplicas: 1
         maxReplicas: 2
-      memoryRequests: '1536Mi'
-      memoryLimits: '2048Mi'
-      cpuRequests: '250m'
-      cpuLimits: '1500m'
       environment:
         SECURE_DOC_ENABLED: true
         FEATURE_PBA_CASE_TYPE: true

--- a/apps/financial-remedy/finrem-cos/perftest.yaml
+++ b/apps/financial-remedy/finrem-cos/perftest.yaml
@@ -6,16 +6,6 @@ metadata:
 spec:
   values:
     java:
-      replicas: 2
-      autoscaling:
-        enabled: true
-        maxReplicas: 4
-      memoryRequests: '1536Mi'
-      memoryLimits: '2048Mi'
-      cpuRequests: '250m'
-      cpuLimits: '1500m'
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 80
       environment:
         FEATURE_PBA_CASE_TYPE: false
         SECURE_DOC_ENABLED: true


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DFR-3989

### Change description

Update HPA config to make all environments the same except ITHC which is configured to use min:1 max:2
All other environments should scale down to 2 pods with normal usage. They are currently always scaled up to using 4 pods

