### PR TITLE
DTSPO-27351 - Disable data ingestion job in prod

### DIFF
--- a/apps/dtsse/prod/00/kustomization.yaml
+++ b/apps/dtsse/prod/00/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 namespace: dtsse
 resources:
 - ../base
-patches:
-- path: ../../dtsse-dashboard-ingestion/prod/00.yaml
+# patches:
+# - path: ../../dtsse-dashboard-ingestion/prod/00.yaml

--- a/apps/dtsse/prod/01/kustomization.yaml
+++ b/apps/dtsse/prod/01/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 namespace: dtsse
 resources:
 - ../base
-patches:
-- path: ../../dtsse-dashboard-ingestion/prod/01.yaml
+# patches:
+# - path: ../../dtsse-dashboard-ingestion/prod/01.yaml

--- a/apps/dtsse/prod/base/kustomization.yaml
+++ b/apps/dtsse/prod/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: dtsse
 resources:
   - ../../base
-  - ../../dtsse-dashboard-ingestion/dtsse-dashboard-ingestion.yaml
+  # - ../../dtsse-dashboard-ingestion/dtsse-dashboard-ingestion.yaml
   - ../../dtsse-ardoq-adapter/dtsse-ardoq-adapter.yaml
   - ../../../base/slack-provider/prod
   - ../../../base/docker-registry/prod


### PR DESCRIPTION
### Jira link

See [DTSPO-27351](https://tools.hmcts.net/jira/browse/DTSPO-27351)

### Change description

Disabling data ingestion job whilst grafana prod database is rebuilt

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
