### PR TITLE
Setting Barrister flag to false, to enable running a baseline performance test

### DIFF
--- a/apps/private-law/prl-cos/perftest.yaml
+++ b/apps/private-law/prl-cos/perftest.yaml
@@ -65,6 +65,7 @@ spec:
       useInterpodAntiAffinity: true
       image: hmctspublic.azurecr.io/prl/cos:prod-6794370-20250909105721 #{"$imagepolicy": "flux-system:prl-cos"}
       environment:
+        BARRISTER_FEATURE_ENABLED: false
         FEATURE_EXAMPLE: true
         PRD_API_BASEURL: http://rd-professional-api-perftest.service.core-compute-perftest.internal
         IDAM_CLIENT_REDIRECT_URI: https://prl-cos-perftest.service.core-compute-perftest.internal/oauth2/callback


### PR DESCRIPTION
Setting Barrister flag to false, to enable running a baseline performance test


