### PR TITLE
DTSAM-1034 REVERT after SRT in Demo of RAS with SB3

### DIFF
--- a/apps/am/am-role-assignment-service/demo-image-policy.yaml
+++ b/apps/am/am-role-assignment-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-2432-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSAM-1034 (was CME-56)](https://tools.hmcts.net/jira/browse/CME-56) _"Spring Boot 3 Upgrade and Java 21 Upgrade RAS"_
[DTSAM-891](https://tools.hmcts.net/jira/browse/DTSAM-891) _"SRT-Tracker for CME-56"_

### Change description ###

This is to REMOVE image of DTSAM-1034/CME-56 (hmcts/am-role-assignment-service#2432) in **Demo**, as SRT COMPLETED.