### PR TITLE
DTSAM-1028 Update RAS non-PROD S2S list for `pcs_frontend`

### DIFF
--- a/apps/am/am-role-assignment-service/aat.yaml
+++ b/apps/am/am-role-assignment-service/aat.yaml
@@ -16,6 +16,6 @@ spec:
         TESTING_SUPPORT_ENABLED: true
         BYPASS_ORG_DROOL_RULE: true
         DB_FEATURE_FLAG_ENABLE: all_wa_services_case_allocator_1_0
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api,pcs_frontend
         MAX_POOL_SIZE: 20
         DUMMY_VAR: true

--- a/apps/am/am-role-assignment-service/demo.yaml
+++ b/apps/am/am-role-assignment-service/demo.yaml
@@ -12,6 +12,6 @@ spec:
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 10
         DB_FEATURE_FLAG_ENABLE: all_wa_services_case_allocator_1_0
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_management_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_management_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api,pcs_frontend
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false

--- a/apps/am/am-role-assignment-service/ithc.yaml
+++ b/apps/am/am-role-assignment-service/ithc.yaml
@@ -9,6 +9,6 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api,pcs_frontend
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false

--- a/apps/am/am-role-assignment-service/perftest.yaml
+++ b/apps/am/am-role-assignment-service/perftest.yaml
@@ -11,6 +11,6 @@ spec:
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 20
         DB_FEATURE_FLAG_ENABLE: sscs_wa_1_0
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api,pcs_frontend
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false


### PR DESCRIPTION
### Jira link

[DTSAM-1028](https://tools.hmcts.net/jira/browse/DTSAM-1028) _"Whitelist Possession services for AM"_

### Change description

Update RAS non-PROD S2S list to accept: `pcs_frontend`.

NB: `pcs_api` was enabled for non-PROD under [DTSAM-863](https://tools.hmcts.net/jira/browse/DTSAM-863).
