### PR TITLE
Changing CCD data hosts to ccd-data-1

### DIFF
--- a/apps/ccd/prod/base/logstash-secret.yaml
+++ b/apps/ccd/prod/base/logstash-secret.yaml
@@ -1,27 +1,22 @@
 apiVersion: v1
 data:
-    DATA_STORE_PASS: ENC[AES256_GCM,data:nPx5qpz/PAZOkSoM2eQ/O+/b7TzAJijVm0jHnw==,iv:rQ+2aWO59VUdk0jjqH2u4wXxVMyHpq58zCw+H8p0YWs=,tag:HoG1u4joc96nCagImzWMhw==,type:str]
-    DATA_STORE_URL: ENC[AES256_GCM,data:jsNY2ObS5AZHIogRYqIrCcID6zH8ZJx0C08nz0PwoC2uaxlvVhiuoQ2cqPqFzFbw+xGVuyGGybt1Gt64KYEbMFAWOxL3jAvWdS1a7CLgcwrPAGcidKohWMhzO7cr5D5Tu6vYSc1e5Vvy9zY8vF+86rQYl5ULpBoJQn+A9JEX7UQ3gBBPf9mlmG9GT+RwCfRbQAavTQ1cK7xpXtiAYr8QuDOQYjU=,iv:vclPQ14uLyMqcM1HP5sKBrij60x7LJb8/lMNPGUecf0=,tag:C232zHCf0nnHRBcOoDt6Pw==,type:str]
-    DATA_STORE_USER: ENC[AES256_GCM,data:cTz6E0MQl6FHNe2y,iv:NMwTCGPkdsBIXRN0Nme5MjtZnywD/ciT36Eq+dmocIM=,tag:f/aJ5OBpUhRjvL70nr4QjQ==,type:str]
-    ES_HOSTS: ENC[AES256_GCM,data:bE8r2uQ3fQjVLI5YJSjrMO21ja4plEH+ayO9ndIxnC6lAI5Vd002s8hYdTcJBtJb/TpQRQc9Je6rhjTVomOiZ/56g3rQ5G2b/7/NhA==,iv:H3I9CCGDDEDIJqzBUMpeiBTdD5+qQutp2T2QAHi/6mI=,tag:l2VoBdrrYkgCcvkqaqISQA==,type:str]
+    DATA_STORE_PASS: ENC[AES256_GCM,data:FJabouSYN3pn1Odr4HnOYDLHLzyb++9DX0o8nQ==,iv:j2uSiBHDKVzfGJQAfIO8mf7zvaLvIDUeEQCLYkuZfSk=,tag:42mKI+uCS1Ibtz2fGDq6Kg==,type:str]
+    DATA_STORE_URL: ENC[AES256_GCM,data:A0n355lV03JgLzQ9sZuVXt7xuUiuz7jX2qjlI4IinqPLsh71+8nNplKJSqRB3zDHkbjUIDAZQMT1TyoWZ2uHcMdcXIYPqiwyU6H7kyqTGpqz3jpUQNXQrBwDvb+U2JFpiiBkM454MCew/r4Y+2ahL4z9KHxIcNWeOwmpCrkKqZlOHaBLNYK4idgT/vHaApmufRPjUpT8IuofWRnObV/wpU6k+dM=,iv:jncQUmiiOkLUJYe/AhA/E/zLJn33MbktqqvUE7CLsuY=,tag:1H9fefL0KwCd9aqki2wHTw==,type:str]
+    DATA_STORE_USER: ENC[AES256_GCM,data:YZ9pNI6pFV5J5M2j,iv:UVOkWNxKGAYavRIfjSCNCVd68U3J2QoX1UOIL6SO7aE=,tag:3ZY7v8wKJa/xQ17OhEjEhA==,type:str]
+    ES_HOSTS: ENC[AES256_GCM,data:9NR6tBWysanVuOuboGP0x5VnGVrTg5ioI25ZE+AMIHeWGMipNr4CfaPdwMMHfG6h1Vl1pj5GkXmRJqOhPJ9M+NVoQCzp7c2tCNL68w==,iv:CQoRuv9y+P6XPXuzC/liff02+Pv664y91O5/tJEPQqM=,tag:dNiZRaFu3+NzFs19SxZpIQ==,type:str]
 kind: Secret
 metadata:
-    creationTimestamp: null
     name: logstash-secret
     namespace: ccd
+type: Opaque
 sops:
-    kms: []
-    gcp_kms: []
     azure_kv:
         - vault_url: https://dcdcftappsprodkv.vault.azure.net
           name: sops-key
           version: 44f7be9dc801456688ba4ddea9d552e8
-          created_at: "2024-03-10T10:59:34Z"
-          enc: 2-GUADLCHm5G6mwNqbu6doHi_ExYpr3471UgFKu6EL__wTPLCaFxa-MAItff900zJ5ZQOAYU_t2i7XdOz1mt70v-FiQQIfJCR6IE6D9t5JKB88K94SzjAQFLMld5UzP-RIHpEwt_m4GzrPdPGgyDdULimxOEbwP0jz-RVortKYAt1E4Cq64pLxYakpUYyGXyR19JA7w6ECK8ZN9bhhz46tgrV2vi4FUjg_vg-cZQTXbEZEAcIptp9fe3G5WQ5OhimrwoLvgWKaovWkoWjdbAn5u2dC0SewrjDzYTJgMKUuJjzBnFurP1Keh74ghr_-8urFdhtTEeLxWSdtNpPE1GvQ
-    hc_vault: []
-    age: []
-    lastmodified: "2024-03-10T10:59:40Z"
-    mac: ENC[AES256_GCM,data:hmYaEb7Sj9GBuX7Bf1g+CA6yan1MvsTCirq0b2CGnR9y6fre8EU3u91xQj0Z+X8AqNKWkEp7VN6aa7+b2bXbDeFo6x8fGod4kiuqyF2PJbhSwoNu/swIfIVH0zcLcuFdTtaKKqbGqV2f9BtvdKcmHL1QLWQ4+Mq7UdXOpb8ZqEI=,iv:m++La3YBDD99x2ymeogo0IAR+hU96qX704IycS599yc=,tag:LdG9IN4WRk87BJp2DbF8MA==,type:str]
-    pgp: []
+          created_at: "2025-09-19T09:22:05Z"
+          enc: 0NxPWPftzMOXJrbKRICRwwrnYWNUjosySfVqRjHUoOplIy8-zSezuQtPpcr94sKvoKCkKreOkkQ12qI_nrWx-P38GGt9dvxcUlY7_5-L2WRzid0CoFPY4vPhSa_Fa9kpufjd2WLEeMz7DXZuKxmsOudCoLgh4PcoXWCP-t-1lZhX4CAJgoxj75vQbOWpf2O7o_YtuBuLZiJJMTlZfStxxcI_BCUAKMQu5B6OOOPRDR5zARCpU-LriMjjYtuGOjuFsGsFzwXH294eaijjWZvwGPTw6q_xoi___-TBhkxFFpBMvEXFardRWvFIKutpT-3_eJ5WFNosRJ93Hn_EY_MrFw
+    lastmodified: "2025-09-19T09:22:08Z"
+    mac: ENC[AES256_GCM,data:Lba3m4LtPnUxEiERkNjN/OKDSoOZugjcv+1OTF97b900hkuEE/bDKkYqH14igkyeTk2bxA2zDJwaxPd/h66YYPgkb5au6crcevk4r3XescjbaEt6yv+8Rg5l49tikwIWkI0NvfA/e0RXjdQdXXNMho8lSGSZtKXxwl7YZ4v0FwA=,iv:7LixEW0CGvr5gDW11TiJcwSnWoLHlB51+hg6iuaX5fM=,tag:luSbMUNIcjsa+dIWp2Oxmw==,type:str]
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    version: 3.10.2


### PR DESCRIPTION
Issue with ccd-data-0 and ccd-data-3 are offline at the moment so changing the host to point to ccd-data-1 on the logstash secret.