### PR TITLE
Dfr 4078 div cfs replicas never scale down to minpods

### DIFF
--- a/apps/divorce/div-cfs/div-cfs.yaml
+++ b/apps/divorce/div-cfs/div-cfs.yaml
@@ -8,15 +8,8 @@ spec:
   values:
     java:
       replicas: 2
-      autoscaling:
-        enabled: true
-        maxReplicas: 4
-      memoryRequests: "1536Mi"
       memoryLimits: "2Gi"
-      cpuRequests: "250m"
       cpuLimits: "2500m"
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 80
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15

--- a/apps/divorce/div-cfs/div-cfs.yaml
+++ b/apps/divorce/div-cfs/div-cfs.yaml
@@ -8,8 +8,15 @@ spec:
   values:
     java:
       replicas: 2
+      autoscaling:
+        enabled: true
+        maxReplicas: 4
+      memoryRequests: "1536Mi"
       memoryLimits: "2Gi"
+      cpuRequests: "250m"
       cpuLimits: "2500m"
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
       readinessDelay: 45
       readinessTimeout: 5
       readinessPeriod: 15

--- a/apps/divorce/div-cfs/ithc.yaml
+++ b/apps/divorce/div-cfs/ithc.yaml
@@ -12,3 +12,10 @@ spec:
         VAR_FV2: ithc1
       prometheus:
         enabled: true
+      replicas: 1
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 2
+      cpuRequests: "250m"
+      memoryRequests: "1536Mi"


### PR DESCRIPTION
### Jira link
[DFR-4078](https://tools.hmcts.net/jira/browse/DFR-4078)

### Change description
- replicas set to 1.
- HPA now enabled with minReplicas: 1, maxReplicas: 2
- Targets are default 80% for both CPU and Memory.

Metrics show div-cfs is at around 530540 and 2m CPU.
HPA reports 52% memory utilisation. 
replicas is set to 1 so it can go to one pod when quiet and 2 for the max.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
