### PR TITLE
Updating service account client id post managed identity recreation

### DIFF
--- a/apps/idam/identity/sbox.yaml
+++ b/apps/idam/identity/sbox.yaml
@@ -6,4 +6,4 @@ metadata:
   namespace: idam
 spec:
   resourceID: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/idam-sandbox-mi
-  clientID: 395d9486-4ce9-411b-a05f-199aa9f52dda
+  clientID: e6e58661-8dc1-4b2e-a193-d2a5d1bf261f

--- a/apps/idam/serviceaccount/sbox.yaml
+++ b/apps/idam/serviceaccount/sbox.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "9a9cf40f-fa54-4245-98ce-ee593c014905"
+    azure.workload.identity/client-id: "e6e58661-8dc1-4b2e-a193-d2a5d1bf261f"


### PR DESCRIPTION
### Change description 

Service account client ID has changed following the re-creation of managed identity in azure due to running and rebuilding idam-shared-infra, pods would need to pick up this new value.

