### PR TITLE
RBAC extension for db query

### DIFF
--- a/apps/rbac/db-query-job-role.yaml
+++ b/apps/rbac/db-query-job-role.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: ["secrets-store.csi.x-k8s.io"]
   resources: ["secretproviderclasses"]
   verbs: ["create", "get", "list", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes Error: query: failed to query with labels: secrets is forbidden: User "7c002cbc-f807-4866-9b0f-499f6dd5953d" cannot list resource "secrets" in API group "" in the namespace "cnp"