### PR TITLE
Update RBAC for db query

### DIFF
--- a/apps/rbac/db-query-job-role.yaml
+++ b/apps/rbac/db-query-job-role.yaml
@@ -19,6 +19,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "list"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes error calling lookup: serviceaccounts "cnp" is forbidden: User "7c002cbc-f807-4866-9b0f-499f6dd5953d" cannot get resource "serviceaccounts" in API group "" in the namespace "cnp"

