### PR TITLE
RBAC extension for db query

### DIFF
--- a/apps/rbac/db-query-job-role.yaml
+++ b/apps/rbac/db-query-job-role.yaml
@@ -18,7 +18,7 @@ rules:
   verbs: ["create", "get", "list", "update", "patch", "delete"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "create"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["get", "list"]


### PR DESCRIPTION
User "7c002cbc-f807-4866-9b0f-499f6dd5953d" cannot create resource "secrets" in API group "" in the namespace "cnp"