### PR TITLE
Add prod JVM startup args to perftest pr images

### DIFF
--- a/apps/hmc/hmc-cft-hearing-service/perftest.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/perftest.yaml
@@ -18,3 +18,4 @@ spec:
         HMI_BASE_URL: https://sds-api-mgmt.demo.platform.hmcts.net/hmi
         CFT_HEARING_SERVICE_S2S_AUTHORISED_SERVICES: xui_webapp,hmc_hmi_inbound_adapter,sscs,fis_hmc_api,et-hearings-api,civil_service,iac
         DUMMY_RESTART_VAR: true
+        JAVA_TOOL_OPTIONS: -XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -javaagent:/opt/app/applicationinsights-agent-3.5.4.jar


### PR DESCRIPTION
Override DEV_MODE JVM startup args being applied to pr- images in perftest
