### PR TITLE
DTSAM-1056 Enable `sscs_wa_1_1` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,8 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: st_cic_wa_1_2
-        REFRESH_JOB: LEGAL_OPERATIONS-ST_CIC-NEW-0-76
-        REFRESH_JOB_ALLOW_UPDATE: false
+        DB_FEATURE_FLAG_ENABLE: sscs_wa_1_1
+        # REFRESH_JOB: LEGAL_OPERATIONS-ST_CIC-NEW-0-76
+        # always set 'REFRESH_JOB_ALLOW_UPDATE' to false before next refresh (i.e. only use when setting existing job to ABORTED)
+        # REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-1056](https://tools.hmcts.net/jira/browse/DTSAM-1056) _"Enable 'sscs_wa_1_1' ORM flag in Demo environment ready for SSCS to test"_

### Change description

Enable `sscs_wa_1_1` ORM flag in Demo ready for SSCS to test.

> NB: This enables the following changes in *Demo*:
> * hmcts/am-org-role-mapping-service#1796
> * hmcts/am-org-role-mapping-service#1906