### PR TITLE
fix: fixup sbox jenkins.yaml to set environment to be "sbox" which li…

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -32,7 +32,7 @@ spec:
         hostName: static-sandbox-build.hmcts.net
       containerEnv:
         - name: ENVIRONMENT
-          value: "sandbox"
+          value: "sbox"
         - name: AZURE_KEYVAULT_URL
           value: https://cftsbox-intsvc.vault.azure.net
       JCasC:


### PR DESCRIPTION
fix: fixup sbox jenkins.yaml to set environment to be "sbox" which lines up with the subscription and its prefixes which use sbox rather than "sandbox"
