### PR TITLE
***Release 27/10*** ADOP-2713 BST End change cron time

### DIFF
--- a/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
+++ b/apps/adoption/adoption-cron-multi-child-draft-application-alert/adoption-cron-multi-child-draft-application-alert.yaml
@@ -9,7 +9,7 @@ spec:
       image: hmctspublic.azurecr.io/adoption/cos-api:prod-78b247f-20250922145938 #{"$imagepolicy": "flux-system:adoption-cos-api"}
       environment:
         TASK_NAME: AlertMultiChildApplicationToSubmitTask
-      schedule: 0 21 * * *
+      schedule: 0 22 * * *
       keyVaults:
         adoption:
           secrets:


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/ADOP-2713

### Change description
Business requirement is for reminder emails to be sent at 10pm. This means the cron needs to be changed to run an hour earlier during BST.

### Testing done
BAU change

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [ ] Does this PR introduce a breaking change
