### PR TITLE
Add namespace to see if it fixes pod deployment

### DIFF
--- a/apps/ethos/aat/base/kustomization.yaml
+++ b/apps/ethos/aat/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../base/slack-provider/aat
   - ../../../base/docker-registry/aat
   - ../../ethos-migration/ethos-migration.yaml
+namespace: ethos
 patches:
   - path: ../../repl-docmosis-service/aat.yaml
   - path: ../../serviceaccount/aat.yaml


### PR DESCRIPTION
Try to fix ethos-repl-docmosis deployment on AAT as pods/replica set is not showing. This probably means nothing to the overall deployment as we have ecm-consumer running but maybe just to refresh it?

AAT is the only one missing the namespace and where the pods aren't deployed properly but doesn't make sense


<img width="698" height="312" alt="Screenshot 2025-10-28 at 14 59 46" src="https://github.com/user-attachments/assets/632751bb-a947-4849-8801-c8ce3d2da359" />
