### PR TITLE
Hardcode replicas in AAT to spin up extra pod

### DIFF
--- a/apps/et/et-sya-api/aat.yaml
+++ b/apps/et/et-sya-api/aat.yaml
@@ -7,3 +7,4 @@ spec:
   releaseName: et-sya-api
   values:
     java:
+      replicas: 2


### PR DESCRIPTION
AAT only has 1 pod for et-sya-api, set replicas to 2 to force the second pod to spin up?

<img width="529" height="187" alt="Screenshot 2025-10-30 at 08 47 25" src="https://github.com/user-attachments/assets/fc541d12-2b15-476c-8784-20096b9a49c1" />
<img width="1148" height="351" alt="Screenshot 2025-10-30 at 08 47 53" src="https://github.com/user-attachments/assets/46a3e0b3-195a-43c0-b125-4b92d21cbba3" />
