### PR TITLE
ECM Pods

### DIFF
--- a/apps/ethos/repl-docmosis-service/aat.yaml
+++ b/apps/ethos/repl-docmosis-service/aat.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: repl-docmosis-service
   values:
     java:
+      replicas: 2
       environment:
         SECURE_DOC_STORE_FEATURE: false
         TRIGGER_RESTART: 3


### PR DESCRIPTION
No ECM pods in AAT for some reason?
Set replicas to 2 in AAT to force creation?

<img width="696" height="338" alt="Screenshot 2025-10-30 at 08 54 23" src="https://github.com/user-attachments/assets/41201c3b-da00-4302-ae3e-f6e331eb97f8" />
