### PR TITLE
DTSPO-28423: Increase Helm size limit to 200MB to unblock civil-citizen-ui aat

### DIFF
--- a/apps/flux-system/aat/base/kustomization.yaml
+++ b/apps/flux-system/aat/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 patches:
 - path: ../../serviceaccount/aat.yaml
 - path: ../../base/patches/workload-identity-deployment-patch.yaml
+- path: ../../base/patches/helm-controller-size-limit-patch.yaml

--- a/apps/flux-system/base/patches/helm-controller-size-limit-patch.yaml
+++ b/apps/flux-system/base/patches/helm-controller-size-limit-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: HELM_MAX_FILE_SIZE
+          value: "209715200"  # 200MB


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-28423

### Change description

-  Increase Helm size limit to 200MB to unblock civil-citizen-ui
- Trial in AAT before Prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
