### PR TITLE
DTSPO-27918 Update aat AKS cluster to 01 for cluster upgrade

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -53,9 +53,9 @@ spec:
                       - key: PTL_AKS_RESOURCE_GROUP
                         value: cft-ptl-00-rg
                       - key: AAT_AKS_CLUSTER_NAME
-                        value: cft-aat-00-aks
+                        value: cft-aat-01-aks
                       - key: AAT_AKS_RESOURCE_GROUP
-                        value: cft-aat-00-rg
+                        value: cft-aat-01-rg
                       - key: PREVIEW_AKS_CLUSTER_NAME
                         value : cft-preview-01-aks
                       - key : PREVIEW_AKS_RESOURCE_GROUP


### PR DESCRIPTION
### Jira link

[DTSPO-27918](https://tools.hmcts.net/jira/browse/DTSPO-27918)

### Change description

updating aat cluster for jenkins to 01 as aat-00 is due to be upgraded
