### PR TITLE
DTSAM-1056 Enable sscs_wa_1_1 ORM flag in AAT

### DIFF
--- a/apps/am/am-org-role-mapping-service/aat.yaml
+++ b/apps/am/am-org-role-mapping-service/aat.yaml
@@ -10,10 +10,11 @@ spec:
         APPLICATION_LOGGING_LEVEL: INFO
         SPRING_DATASOURCE_HIKARI_CONNECTIONTIMEOUT: 10000
         TESTING_SUPPORT_ENABLED: true
-        DB_FEATURE_FLAG_ENABLE: privatelaw_wa_1_7
+        DB_FEATURE_FLAG_ENABLE: sscs_wa_1_1
         AMQP_JRD_NEW_ASB_ENABLED: true
         AMQP_CRD_NEW_ASB_ENABLED: true
         DUMMY_VAR: true
         REFRESH_JUDICIAL_FILTER_SOFT_DELETED_USERS: true
-        REFRESH_JOB: LEGAL_OPERATIONS-ST_CIC-NEW-0-1951
-        REFRESH_JOB_ALLOW_UPDATE: false
+        # REFRESH_JOB: LEGAL_OPERATIONS-ST_CIC-NEW-0-1951
+        # always set 'REFRESH_JOB_ALLOW_UPDATE' to false before next refresh (i.e. only use when setting existing job to ABORTED)
+        # REFRESH_JOB_ALLOW_UPDATE: false


### PR DESCRIPTION
### Jira link

[DTSAM-1056](https://tools.hmcts.net/jira/browse/DTSAM-1056) _"Enable 'sscs_wa_1_1' ORM flag in Demo environment ready for SSCS to test"_

### Change description

Enable `sscs_wa_1_1` ORM flag in AAT ready for SSCS to test.

> NB: This enables the following changes in *AAT*:
> * hmcts/am-org-role-mapping-service#1796
> * hmcts/am-org-role-mapping-service#1906