### PR TITLE
DTSPO-28646: Rollback jenkins agent image

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -104,7 +104,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
-                          galleryImageVersion: "24.04.54"
+                          galleryImageVersion: "24.04.53"
                         <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -100,7 +100,7 @@ spec:
                         virtualMachineSize: "Standard_D4ds_v5"
                         imageReference:
                           galleryImageDefinition: "jenkins-ubuntu-v2"
-                          galleryImageVersion: "24.04.54"
+                          galleryImageVersion: "24.04.53"
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"

--- a/renovate.json
+++ b/renovate.json
@@ -4,4 +4,8 @@
     "local>hmcts/.github:renovate-config",
     "local>hmcts/.github//renovate/flux"
   ]
+  ,"ignorePaths": [
+    "apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml",
+    "apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml"
+  ]
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-28646


### Change description

- Rollingback jenkins agent image from 24.04.54 to 24.04.53
- Current image is breaking integration tests due to docker env issue

### Testing done

- Rolledback locally in Jenkins UI and fixes issue


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
