### PR TITLE
feat: add initial flux config for apim-marketplace

### DIFF
--- a/apps/apim/base/kustomization.yaml
+++ b/apps/apim/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: apim

--- a/apps/apim/base/kustomize.yaml
+++ b/apps/apim/base/kustomize.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apim
+  namespace: flux-system
+spec:
+  path: ./apps/apim/${ENVIRONMENT}/base
+  postBuild:
+    substitute:
+      NAMESPACE: "apim"
+      WI_NAME: "apim"
+      TEAM_NOTIFICATION_CHANNEL: "api-marketplace-tech"
+      TEAM_AAD_GROUP_ID: "c338c04d-aeb8-44fb-8d66-d9cd01fc89fc"

--- a/apps/apim/preview/base/kustomization.yaml
+++ b/apps/apim/preview/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base
+namespace: apim

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -57,6 +57,7 @@ resources:
   - ../../../apps/enforcement/base/kustomize.yaml
   - ../../../apps/dynatrace/base/kustomize.yaml
   - ../../../apps/rota/base/kustomize.yaml
+  - ../../../apps/apim/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
i.e. After running
export AD_GROUP_ID="c33...9fc"
./bin/v2/add-namespace.sh --product apim --team-aad-group-id $AD_GROUP_ID

./bin/v2/add-namespace-to-env.sh apim preview

Stopped short of running add-wl-identity as this needs Microsoft.ManagedIdentity for apim which maybe needs a jenkins merge to run tf to create the MI

