### PR TITLE
Revert "Enable TLS and switch sandbox host to new plum recipe backend domain"

### DIFF
--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -17,5 +17,3 @@ spec:
       replicas: 2
       autoscaling:
         minReplicas: 1
-      environment:
-        RECIPE_BACKEND_URL: https://cft-api-mgmt.sandbox.platform.hmcts.net/plum-recipes-api

--- a/apps/cnp/plum-recipe-backend/sbox.yaml
+++ b/apps/cnp/plum-recipe-backend/sbox.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   values:
     java:
-      ingressHost: plum-recipe-backend.sandbox.platform.hmcts.net
-      disableTraefikTls: false
+      ingressHost: plum-recipe-backend-sandbox.service.core-compute-sandbox.internal


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#41990