### PR TITLE
DTSPO-28757: Enable router.tls for demo xui manage-case-int1

### DIFF
--- a/apps/xui/xui-webapp-integration1/demo.yaml
+++ b/apps/xui/xui-webapp-integration1/demo.yaml
@@ -6,6 +6,7 @@ spec:
   values:
     nodejs:
       ingressHost: manage-case-int1.demo.platform.hmcts.net
+      disableTraefikTls: false
       environment:
         DUMMY_VAR: 1
         FEATURE_SECURE_COOKIE_ENABLED: false


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-28757

### Change description

- enable router tls in traefik ingress for xui manage-case-int1
- hoping this will fix web socket termination as wss:// is a secure protocol and requires a handshake from server endpoint
- default wildcard cert should be enough
- App Gateway access logs show /socket.io polling requests reach the backend but returning 401, so logically has to be cluster config and not intermiediate steps in the chain

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
