### PR TITLE
Fix: DB query role cannot remove helm release

### DIFF
--- a/apps/rbac/db-query-job-role.yaml
+++ b/apps/rbac/db-query-job-role.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ${NAMESPACE}
 rules:
 - apiGroups: [""]
-  resources: ["pods", "configmaps"]
+  resources: ["pods", "configmaps", "secrets"]
   verbs: ["create", "get", "list", "update", "patch", "delete"]
 - apiGroups: ["batch"]
   resources: ["jobs", "cronjobs"]


### PR DESCRIPTION
Aims to fix this error;
```

Uninstalling helm release: sql-job-cnp-238 from namespace: cnp
Error: uninstallation completed with 1 error(s): uninstall: Failed to purge the release: secrets "sh.helm.release.v1.sql-job-cnp-238.v1" is forbidden: User "7c002cbc-f807-4866-9b0f-499f6dd5953d" cannot delete resource "secrets" in API group "" in the namespace "cnp"

```
When db query is scheduled for removal