### PR TITLE
Add workload identity to source-controller for hmctssbox ACR access

### DIFF
--- a/apps/flux-system/base/patches/workload-identity-source-controller-patch.yaml
+++ b/apps/flux-system/base/patches/workload-identity-source-controller-patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: helm-controller
+  name: source-controller
   namespace: flux-system
   labels:
     azure.workload.identity/use: "true"

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
   - ../../docker-regcreds/sbox
 patches:
   - path: ../../serviceaccount/sbox.yaml
-  - path: ../../serviceaccount/sbox-helm-controller.yaml
+  - path: ../../serviceaccount/sbox-source-controller.yaml
   - path: ../../base/patches/workload-identity-deployment-patch.yaml
-  - path: ../../base/patches/workload-identity-helm-controller-patch.yaml
+  - path: ../../base/patches/workload-identity-source-controller-patch.yaml

--- a/apps/flux-system/serviceaccount/sbox-source-controller.yaml
+++ b/apps/flux-system/serviceaccount/sbox-source-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: helm-controller
+  name: source-controller
   namespace: flux-system
   annotations:
     azure.workload.identity/client-id: "96775d73-e4f3-49ee-8bb6-f8660a19ba85"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-27732

Fix update source controller which is responsible to pull the chart not helm controller