### PR TITLE
DTSAM-1082 Enable`iac_wa_1_5` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,7 +9,7 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: employment_wa_3_0
+        DB_FEATURE_FLAG_ENABLE: iac_wa_1_5
         # REFRESH_JOB: LEGAL_OPERATIONS-IA-NEW-0-77
         # always set 'REFRESH_JOB_ALLOW_UPDATE' to false before next refresh (i.e. only use when setting existing job to ABORTED)
         # REFRESH_JOB_ALLOW_UPDATE: false


### PR DESCRIPTION
### Jira link

[DTSAM-1082](https://tools.hmcts.net/jira/browse/DTSAM-1082) _"Enable 'iac_wa_1_5' ORM flag in a lower environment and refresh users ready for IAC to test "_

### Change description

Enable `iac_wa_1_5` ORM flag in Demo ready for Employment to test.

> NB: This enables the following change in *Demo*:
> * hmcts/am-org-role-mapping-service#2551