### PR TITLE
DTSAM-1134 Enable `publiclaw_wa_2_2` ORM flag in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -9,8 +9,8 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        DB_FEATURE_FLAG_ENABLE: iac_wa_1_5
-        REFRESH_JOB: LEGAL_OPERATIONS-IA-NEW-0-78
+        DB_FEATURE_FLAG_ENABLE: publiclaw_wa_2_2
+        # REFRESH_JOB: LEGAL_OPERATIONS-IA-NEW-0-78
         # always set 'REFRESH_JOB_ALLOW_UPDATE' to false before next refresh (i.e. only use when setting existing job to ABORTED)
         # REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-1134](https://tools.hmcts.net/jira/browse/DTSAM-1134) _"Enable 'publiclaw_wa_2_2' ORM flag in a lower environment and refresh users ready for PublicLaw to test "_

### Change description

Enable `publiclaw_wa_2_2` ORM flag in Demo ready for Employment to test.

> NB: This enables the following change in *Demo*:
> * hmcts/am-org-role-mapping-service#2580
> * hmcts/am-org-role-mapping-service#2589