### PR TITLE
DTSAM-1134 Refresh PublicLaw Staff Role-Assignments in Demo

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo.yaml
+++ b/apps/am/am-org-role-mapping-service/demo.yaml
@@ -10,7 +10,7 @@ spec:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
         DB_FEATURE_FLAG_ENABLE: publiclaw_wa_2_2
-        # REFRESH_JOB: LEGAL_OPERATIONS-IA-NEW-0-78
+        REFRESH_JOB: LEGAL_OPERATIONS-PUBLICLAW-NEW-0-79
         # always set 'REFRESH_JOB_ALLOW_UPDATE' to false before next refresh (i.e. only use when setting existing job to ABORTED)
         # REFRESH_JOB_ALLOW_UPDATE: false
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-1134](https://tools.hmcts.net/jira/browse/DTSAM-1134) _"Enable 'publiclaw_wa_2_2' ORM flag in a lower environment and refresh users ready for PublicLaw to test"_

### Change description

Refresh PublicLaw Staff Role-Assignments in Demo

> NB: This refreshes is to allow the testing of the following changes in *Demo*:
> * hmcts/am-org-role-mapping-service#2580
> * hmcts/am-org-role-mapping-service#2589