### PR TITLE
Sptribs logstash external versioning

### DIFF
--- a/apps/sptribs/sptribs-logstash/sptribs-logstash.yaml
+++ b/apps/sptribs/sptribs-logstash/sptribs-logstash.yaml
@@ -72,7 +72,7 @@ spec:
                       SELECT reference, case_revision
                       FROM ccd.es_queue
                       ORDER BY enqueued_at
-                      LIMIT 1000
+                      LIMIT 100
                       FOR UPDATE SKIP LOCKED
                     ),
                     deleted AS (


### PR DESCRIPTION
Use external_gte versioning for sptribs-logstash to prevent stale writes whilst allowing reindexing of existing documents.