### PR TITLE
Add .internal cert for use in demo

### DIFF
--- a/apps/admin/traefik2/demo/secret-provider-internal.yaml
+++ b/apps/admin/traefik2/demo/secret-provider-internal.yaml
@@ -1,0 +1,27 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-internal-cert
+  namespace: admin
+spec:
+  provider: azure
+  secretObjects:
+  - secretName: traefik-internal-cert
+    type: kubernetes.io/tls
+    data:
+    - objectName: tls-cert
+      key: tls.crt
+    - objectName: tls-cert
+      key: tls.key
+  parameters:
+    usePodIdentity: "false"
+    clientID: ${WORKLOAD_IDENTITY_ID}
+    tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
+    keyvaultName: acmedcdcftappsdev
+    objects: |
+      array:
+        - |
+          objectName: wildcard-service-core-compute-internal
+          objectType: secret
+          objectAlias: tls-cert
+          objectVersion: ""


### PR DESCRIPTION
We are trying to get end to end TLS for new websocket connection in demo but it's stuck in pending - believe the issue is related to no TLS handshake being completed since we are missing cert for internal hostname in demo, see;
```
curl: (60) SSL: no alternative certificate subject name matches target host name 'ccd-case-activity-api-demo.service.core-compute-demo.internal'
More details here: https://curl.se/docs/sslcerts.html
```

For more context - this works in preview, and that uses the *.platform endpoint
