### PR TITLE
Update ccd-admin-web image in demo to latest prod

### DIFF
--- a/apps/ccd/ccd-admin-web/demo.yaml
+++ b/apps/ccd/ccd-admin-web/demo.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: ccd-admin-web
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/ccd/admin-web:pr-753-7ff69fb-20260407081553 #{"$imagepolicy": "flux-system:demo-ccd-admin-web"}
+      image: hmctsprod.azurecr.io/ccd/admin-web:prod-61a8403-20260413103953 #{"$imagepolicy": "flux-system:demo-ccd-admin-web"}
       environment:
         ADMINWEB_ELASTIC_CASE_TYPES_URL: http://ccd-definition-store-api-demo.service.core-compute-demo.internal/elastic-support/case-types
         DUMMY_RESTART_VAR: 2


### PR DESCRIPTION
Reverting the ccd-admin-web image to latest prod in demo, because the definition store pr image is not there to support it, so it's caused issues when someone has presumably tried to trigger a PRL reindex from admin web and it's now applied a read lock on the index, but failed to reindex, so it's now stuck in a read-only state.