### PR TITLE
HMAN-1084: Configure production allowed issuers

### DIFF
--- a/apps/hmc/hmc-cft-hearing-service/prod.yaml
+++ b/apps/hmc/hmc-cft-hearing-service/prod.yaml
@@ -13,4 +13,6 @@ spec:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_OIDC_URL: https://hmcts-access.service.gov.uk
         HMI_BASE_URL: https://sds-api-mgmt.platform.hmcts.net/hmi
+        IDAM_SECURITY_ALLOWED_ISSUERS_0: https://hmcts-access.service.gov.uk/o
+        IDAM_SECURITY_ALLOWED_ISSUERS_1: https://forgerock-am.service.core-compute-idam-prod2.internal:8443/openam/oauth2/realms/root/realms/hmcts
         DUMMY_VAR: 2


### PR DESCRIPTION
### Jira link

See [HMAN-1084](https://tools.hmcts.net/jira/browse/HMAN-1084)

### Change description

Updated hmc-cft-hearing-service prod.yaml file.  Added production allowed issuers to environment section.

### Testing done

Tested setting of allowed issuers locally.  Confirmed that setting IDAM_SECURITY_ALLOWED_ISSUERS_0, 1, etc. overrides the idam.security.allowed-issuers list in application.yaml.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
