### PR TITLE
Allow postgres_fdw ext in preview aso

### DIFF
--- a/apps/et/preview/aso/et-postgres-config.yaml
+++ b/apps/et/preview/aso/et-postgres-config.yaml
@@ -10,4 +10,4 @@ spec:
     name: ${NAMESPACE}-${ENVIRONMENT}
   azureName: azure.extensions
   source: user-override
-  value: "btree_gin"
+  value: "btree_gin,postgres_fdw"


### PR DESCRIPTION
### Jira link

See [CFTD-55](https://tools.hmcts.net/jira/browse/CFTD-55)

### Change description

Allows the postgres_fdw Postgres extension to be enabled so we can spike data migration from CCD to ET as part of the decentralisation work.