### PR TITLE
Fix automated db query role

### DIFF
--- a/apps/rbac/db-query-job-clusterrole.yaml
+++ b/apps/rbac/db-query-job-clusterrole.yaml
@@ -9,7 +9,9 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["list", "get"]
-
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
For cleanup, https://github.com/hmcts/postgresql-cron-jobs/actions/runs/24560311803/job/71807020914 had this error when switching to use cronjobs rather than pods

