### PR TITLE
Disable kustomize defaults in opentelemetry-collector

### DIFF
--- a/apps/monitoring/opentelemetry-collector/opentelemetry-collector.yaml
+++ b/apps/monitoring/opentelemetry-collector/opentelemetry-collector.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: monitoring
   annotations:
     kustomize.toolkit.fluxcd.io/substitute: disabled
+    # These additional fields are not allowed anymore
+    hmcts.github.com/kustomize-defaults: disabled
 spec:
   releaseName: opentelemetry-collector
   interval: 10m


### PR DESCRIPTION
### Change description

Injection of default fields is breaking this helm release
Specifically these values need to be removed:
https://github.com/hmcts/cnp-flux-config/blob/7f0c9e75772a5c617d25909e2a66e19af8598bc0/apps/base/kustomize.yaml#L36-L44
This is preventing Jenkins metrics from working in dynatrace

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
