### PR TITLE
SSCSCI-2440: Schedule completedHearingsOutcomes migration in demo

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/demo.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo.yaml
@@ -10,7 +10,7 @@ spec:
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "45 15 23 4 *"
+      schedule: "45 16 23 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs

--- a/apps/sscs/sscs-ccd-case-migration/demo.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo.yaml
@@ -10,7 +10,7 @@ spec:
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "55 15 26 02 *"
+      schedule: "45 15 23 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs
@@ -33,6 +33,8 @@ spec:
               alias: UPDATE_LISTING_REQS_MISSING_AMEND_REASON_ENCODED_STRING
             - name: encoded-string-processing-venue
               alias: VENUE_MIGRATION_ENCODED_STRING
+            - name: encoded-string-completed-hearings-outcomes
+              alias: COMPLETED_HEARINGS_OUTCOMES_ENCODED_DATA_STRING
       environment:
         CCD_DATA_STORE_API_BASE_URL: http://ccd-data-store-api-demo.service.core-compute-demo.internal
         IDAM_S2S_URL: http://rpe-service-auth-provider-demo.service.core-compute-demo.internal
@@ -44,6 +46,7 @@ spec:
         UPDATE_LISTING_REQS_MISSING_AMEND_REASON: false
         DUMMY: false
         VENUE_MIGRATION_ENABLED: false
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
     global:
       environment: demo
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link
See [SSCSCI-2440](https://tools.hmcts.net/jira/browse/SSCSCI-2440)

### Change description
Schedule completedHearingsOutcomes migration in demo at 15:45 UTC to validate java-logging 8.0.0 upgrade (pr-145) runtime logging.

- Updated cron schedule to 15:45 UTC 23 April 2026
- Added Key Vault secret `encoded-string-completed-hearings-outcomes`
- Enabled `COMPLETED_HEARINGS_OUTCOMES_ENABLED`

### Security Vulnerability Assessment
**CVE Suppression:** Are there any CVEs present in the codebase that are being intentionally suppressed or ignored?
  * [ ] Yes
  * [x] No