### PR TITLE
SSCSCI-2440: Reschedule completedHearingsOutcomes migration in demo to 11:00 BST

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/demo.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo.yaml
@@ -10,7 +10,7 @@ spec:
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "45 16 23 4 *"
+      schedule: "0 10 24 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs


### PR DESCRIPTION
### Jira link
See [SSCSCI-2440](https://tools.hmcts.net/jira/browse/SSCSCI-2440)

### Change description
Reschedule completedHearingsOutcomes migration in demo to 10:00 UTC (11:00 BST) 24 April 2026 to validate java-logging 8.0.0 upgrade (pr-145) runtime logging.

### Security Vulnerability Assessment
**CVE Suppression:** Are there any CVEs present in the codebase that are being intentionally suppressed or ignored?
  * [ ] Yes
  * [x] No