### PR TITLE
SSCSCI-2440: Schedule completedHearingsOutcomes migration in demo 00 and 01 at 11:00 BST

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
@@ -11,7 +11,7 @@ spec:
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "55 15 26 02 *"
+      schedule: "0 10 24 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs
@@ -34,6 +34,8 @@ spec:
               alias: UPDATE_LISTING_REQS_MISSING_AMEND_REASON_ENCODED_STRING
             - name: encoded-string-processing-venue
               alias: VENUE_MIGRATION_ENCODED_STRING
+            - name: encoded-string-completed-hearings-outcomes
+              alias: COMPLETED_HEARINGS_OUTCOMES_ENCODED_DATA_STRING
       environment:
         CCD_DATA_STORE_API_BASE_URL: http://ccd-data-store-api-demo.service.core-compute-demo.internal
         IDAM_S2S_URL: http://rpe-service-auth-provider-demo.service.core-compute-demo.internal
@@ -45,6 +47,7 @@ spec:
         UPDATE_LISTING_REQS_MISSING_AMEND_REASON: false
         DUMMY: true
         VENUE_MIGRATION_ENABLED: false
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
     global:
       environment: demo
       enableKeyVaults: true

--- a/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     job:
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "55 15 26 02 *"
+      schedule: "0 10 24 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs
@@ -29,6 +29,8 @@ spec:
               alias: IDAM_SSCS_SYSTEMUPDATE_PASSWORD
             - name: encoded-string-processing-venue
               alias: VENUE_MIGRATION_ENCODED_STRING
+            - name: encoded-string-completed-hearings-outcomes
+              alias: COMPLETED_HEARINGS_OUTCOMES_ENCODED_DATA_STRING
       environment:
         CCD_DATA_STORE_API_BASE_URL: http://ccd-data-store-api-demo.service.core-compute-demo.internal
         IDAM_S2S_URL: http://rpe-service-auth-provider-demo.service.core-compute-demo.internal
@@ -38,6 +40,7 @@ spec:
         MIGRATION_QUERY_SIZE: 500
         MIGRATION_CASE_LIMIT: "1000"
         VENUE_MIGRATION_ENABLED: false
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
     global:
       environment: demo
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link
See [SSCSCI-2440](https://tools.hmcts.net/jira/browse/SSCSCI-2440)

### Change description
Update demo/00.yaml and demo/01.yaml to schedule completedHearingsOutcomes migration at 10:00 UTC (11:00 BST) 24 April 2026. Previous PRs only updated demo.yaml which was not sufficient to trigger the migration.

- Updated schedule to 10:00 UTC (11:00 BST)
- Added Key Vault secret encoded-string-completed-hearings-outcomes
- Enabled COMPLETED_HEARINGS_OUTCOMES_ENABLED

### Security Vulnerability Assessment
**CVE Suppression:** Are there any CVEs present in the codebase that are being intentionally suppressed or ignored?
  * [ ] Yes
  * [x] No