### PR TITLE
SSCSCI-2440: Reschedule migration in demo to 13:30 BST with 6 case IDs

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/demo.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo.yaml
@@ -10,7 +10,7 @@ spec:
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "0 10 24 4 *"
+      schedule: "30 12 24 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs

--- a/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
@@ -11,7 +11,7 @@ spec:
       useInterpodAntiAffinity: true
       aadIdentityName: sscs
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "0 10 24 4 *"
+      schedule: "30 12 24 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs

--- a/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     job:
       image: hmctsprod.azurecr.io/sscs/ccd-case-migration:pr-145-7e3cc64-20260409152816 #{"$imagepolicy": "flux-system:demo-sscs-ccd-case-migration"}
-      schedule: "0 10 24 4 *"
+      schedule: "30 12 24 4 *"
       keyVaults:
         sscs:
           resourceGroup: sscs


### PR DESCRIPTION
### Jira link
See [SSCSCI-2440](https://tools.hmcts.net/jira/browse/SSCSCI-2440)

### Change description
Reschedule completedHearingsOutcomes migration in demo to 12:30 UTC (13:30 BST) 24 April 2026 with updated encoded case ID list (6 cases) to extend pod lifetime for AppInsights log flushing.

### Security Vulnerability Assessment
  * [ ] Yes
  * [x] No