### PR TITLE
Disable COMPLETED_HEARINGS_OUTCOMES_ENABLED in demo after SSCSCI-2440 testing

### DIFF
--- a/apps/sscs/sscs-ccd-case-migration/demo.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo.yaml
@@ -46,7 +46,7 @@ spec:
         UPDATE_LISTING_REQS_MISSING_AMEND_REASON: false
         DUMMY: false
         VENUE_MIGRATION_ENABLED: false
-        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: false
     global:
       environment: demo
       enableKeyVaults: true

--- a/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
@@ -47,7 +47,7 @@ spec:
         UPDATE_LISTING_REQS_MISSING_AMEND_REASON: false
         DUMMY: true
         VENUE_MIGRATION_ENABLED: false
-        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: false
     global:
       environment: demo
       enableKeyVaults: true

--- a/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
@@ -40,7 +40,7 @@ spec:
         MIGRATION_QUERY_SIZE: 500
         MIGRATION_CASE_LIMIT: "1000"
         VENUE_MIGRATION_ENABLED: false
-        COMPLETED_HEARINGS_OUTCOMES_ENABLED: true
+        COMPLETED_HEARINGS_OUTCOMES_ENABLED: false
     global:
       environment: demo
       enableKeyVaults: true


### PR DESCRIPTION
## Summary
* Sets `COMPLETED_HEARINGS_OUTCOMES_ENABLED` back to `false` in `demo.yaml`, `demo/00.yaml` and `demo/01.yaml`
* Was temporarily enabled for SSCSCI-2440 runtime validation — testing is now complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)