### PR TITLE
SSCSCI-2440: revert lower env images to prod

### DIFF
--- a/apps/sscs/sscs-case-loader/aat-image-policy.yaml
+++ b/apps/sscs/sscs-case-loader/aat-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: aat-sscs-case-loader
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1680-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: sscs-case-loader

--- a/apps/sscs/sscs-ccd-case-migration/demo-image-policy.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: demo-sscs-ccd-case-migration
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-145-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: sscs-ccd-case-migration

--- a/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/00.yaml
@@ -47,7 +47,6 @@ spec:
         UPDATE_LISTING_REQS_MISSING_AMEND_REASON: false
         DUMMY: true
         VENUE_MIGRATION_ENABLED: false
-        COMPLETED_HEARINGS_OUTCOMES_ENABLED: false
     global:
       environment: demo
       enableKeyVaults: true

--- a/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
+++ b/apps/sscs/sscs-ccd-case-migration/demo/01.yaml
@@ -40,7 +40,6 @@ spec:
         MIGRATION_QUERY_SIZE: 500
         MIGRATION_CASE_LIMIT: "1000"
         VENUE_MIGRATION_ENABLED: false
-        COMPLETED_HEARINGS_OUTCOMES_ENABLED: false
     global:
       environment: demo
       enableKeyVaults: true


### PR DESCRIPTION
### Jira link

See [SSCSCI-2440](https://tools.hmcts.net/jira/browse/SSCSCI-2440)

### Change description

Reverting sscs-case-migration image to prod in Demo and sscs-case-loader image in AAT to prod

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
