### PR TITLE
Revert "update time out 90"

### DIFF
--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -70,10 +70,10 @@ spec:
     additionalArguments:
       - "--entryPoints.web.forwardedHeaders.insecure=true"
       - "--entryPoints.websecure.forwardedHeaders.insecure=true"
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=90"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=90"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=90"
+      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=30"
+      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=30"
+      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=30"
+      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=30"
     service:
       annotations:
         service.beta.kubernetes.io/azure-load-balancer-internal: "true"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#44545

We should not be doing this / applying this timeout to all envs.