### PR TITLE
Refresh ITHC 01 to test new deployment with empty fileShare

### DIFF
--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -13,7 +13,8 @@ spec:
     neuvector:
       controller:
         azureFileShare:
-          shareName: neuvector-data-01
+          # shareName: neuvector-data-01
+          shareName: neuvector-data-01-refresh
         ingress:
           host: cft-neuvector01-api.ithc.platform.hmcts.net
         configmap:

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -50,7 +50,10 @@ spec:
     neuvector:
       serviceAccount: neuvector
       containerd:
-        enabled: true
+        enabled: false
+      internal:
+        autoGenerateCert: true  # controller spawns cert-upgrader job on fresh install to create neuvector-internal-certs
+        autoRotateCert: false   # cert-upgrader CronJob has no schedule (suspended); keep false to prevent accidental rotation on schedule change
       resources:
         requests:
           cpu: "100m"


### PR DESCRIPTION
Refresh ITHC 01 to test new deployment with empty fileShare
Add new values from upstream for internal certs