### PR TITLE
DTSPO-30107 Apply Jenkins environment agent managed identities

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -153,8 +153,8 @@ spec:
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.78"
-                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-preview-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-preview-mi
                       - templateName: "cnp-jenkins-ubuntu-aat"
                         templateDesc: "Jenkins build agents for CFT AAT environment"
                         labels: "ubuntu-aat"
@@ -187,8 +187,8 @@ spec:
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.78"
-                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ithc-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ithc-mi
                       - templateName: "cnp-jenkins-ubuntu-perftest"
                         templateDesc: "Jenkins build agents for CFT perftest environment"
                         labels: "ubuntu-perftest"
@@ -204,8 +204,8 @@ spec:
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.78"
-                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-perftest-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-perftest-mi
                       - templateName: "cnp-jenkins-ubuntu-demo"
                         templateDesc: "Jenkins build agents for CFT demo environment"
                         labels: "ubuntu-demo"
@@ -221,8 +221,8 @@ spec:
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.78"
-                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-demo-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-demo-mi
                       - templateName: "cnp-jenkins-ubuntu-prod"
                         templateDesc: "Jenkins build agents for CFT prod environment"
                         labels: "ubuntu-prod"
@@ -238,5 +238,5 @@ spec:
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.78"
-                        uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -170,8 +170,8 @@ spec:
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.78"
-                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
                       - templateName: "cnp-jenkins-ubuntu-ithc"
                         templateDesc: "Jenkins build agents for CFT ITHC environment"
                         labels: "ubuntu-ithc"

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -132,8 +132,8 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-sbox-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/managed-identities-sandbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-sbox-mi
                       - templateName: "cnp-jenkins-builders-preview"
                         templateDesc: "Jenkins build agents for CFT preview environment"
                         labels: "ubuntu-preview"

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -146,8 +146,8 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-preview-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-preview-mi
                       - templateName: "cnp-jenkins-builders-aat"
                         templateDesc: "Jenkins build agents for CFT AAT environment"
                         labels: "ubuntu-aat"
@@ -160,8 +160,8 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
                       - templateName: "cnp-jenkins-builders-ithc"
                         templateDesc: "Jenkins build agents for CFT ITHC environment"
                         labels: "ubuntu-ithc"
@@ -174,8 +174,8 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ithc-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ithc-mi
                       - templateName: "cnp-jenkins-builders-perftest"
                         templateDesc: "Jenkins build agents for CFT perftest environment"
                         labels: "ubuntu-perftest"
@@ -188,8 +188,8 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-perftest-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-perftest-mi
                       - templateName: "cnp-jenkins-builders-demo"
                         templateDesc: "Jenkins build agents for CFT demo environment"
                         labels: "ubuntu-demo"
@@ -202,8 +202,8 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-demo-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-demo-mi
                       - templateName: "cnp-jenkins-builders-prod"
                         templateDesc: "Jenkins build agents for CFT prod environment"
                         labels: "ubuntu-prod"
@@ -216,5 +216,5 @@ spec:
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
-                        uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi


### PR DESCRIPTION
## Context

DTSPO-30107 is validating environment-specific Jenkins agents before rolling out to development teams.

The Jenkins library is selecting environment-specific labels correctly, but [runtime debug output](https://build.hmcts.net/job/HMCTS_a_to_c/job/cnp-plum-frontend/job/master/346/console) showed the agents were still being provisioned with the shared Jenkins managed identity. This PR makes the existing environment-specific uamiID values take precedence over the shared YAML anchor value.

## Change

For environment-specific Jenkins templates, the YAML merge anchor is moved before the template-specific uamiID. This keeps the shared defaults while allowing the per-environment identity to win.
