### PR TITLE
DTSPO-32012 - Revert "Increase Time out default to 120"

### DIFF
--- a/apps/admin/traefik2/ithc/00.yaml
+++ b/apps/admin/traefik2/ithc/00.yaml
@@ -8,11 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.11.207.250"
-    additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=120"
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/ithc/01.yaml
+++ b/apps/admin/traefik2/ithc/01.yaml
@@ -8,11 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.11.223.250"
-    additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=120"
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/perftest/00.yaml
+++ b/apps/admin/traefik2/perftest/00.yaml
@@ -11,11 +11,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.48.79.250"
-    additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=120"
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/perftest/01.yaml
+++ b/apps/admin/traefik2/perftest/01.yaml
@@ -11,11 +11,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.48.95.250"
-    additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=120"
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/preview/00.yaml
+++ b/apps/admin/traefik2/preview/00.yaml
@@ -9,10 +9,10 @@ spec:
       spec:
         loadBalancerIP: "10.101.159.250"
     additionalArguments:
-      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=120"
-      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=120"
-      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=120"
+      - "--entryPoints.web.transport.respondingTimeouts.writeTimeout=180"
+      - "--entryPoints.websecure.transport.respondingTimeouts.writeTimeout=180"
+      - "--entryPoints.web.transport.respondingTimeouts.readTimeout=180"
+      - "--entryPoints.websecure.transport.respondingTimeouts.readTimeout=180"
     deployment:
       podLabels:
         useWorkloadIdentity: "true"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#44663
Fix for [DTSPO-32012](https://tools.hmcts.net/jira/browse/DTSPO-32012) on Perftest and ITHC
The previous change has overwritten our forwardedHeaders config