### PR TITLE
DTSAM-1104 Enable `disposer_1_1` RAS flag in Demo

### DIFF
--- a/apps/am/am-role-assignment-service/demo.yaml
+++ b/apps/am/am-role-assignment-service/demo.yaml
@@ -11,7 +11,7 @@ spec:
         APPLICATION_LOGGING_LEVEL: DEBUG
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 10
-        DB_FEATURE_FLAG_ENABLE: all_wa_services_case_allocator_1_0
+        DB_FEATURE_FLAG_ENABLE: disposer_1_1
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_management_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false


### PR DESCRIPTION
### Jira link

[DTSAM-1104](https://tools.hmcts.net/jira/browse/DTSAM-1104) _"Enable 'disposer_1_1' RAS flag in a lower environment ready for R&D team to test"_

### Change description

Enable `disposer_1_1` RAS flag in **Demo** ready for R&D to test.

> NB: This enables the following change in *Demo*:
> * hmcts/am-role-assignment-service#2614