### PR TITLE
DTSPO-32097 - Remove UAMI from sbox daily agents

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -66,7 +66,6 @@ spec:
               storageAccountType: "Standard_LRS"
               subnetName: "iaas"
               templateDisabled: false
-              uamiID: /subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftsbox-intsvc-mi
               usePrivateIP: true
               virtualNetworkName: "cft-ptlsbox-vnet"
               virtualNetworkResourceGroupName: "cft-ptlsbox-network-rg"
@@ -107,6 +106,7 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                         <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftsbox-intsvc-mi
                       - templateName: "cnp-jenkins-builders-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
                         labels: "daily"


### PR DESCRIPTION
### Jira link

See [DTSPO-32097](https://tools.hmcts.net/jira/browse/DTSPO-32097)

### Change description

Move default UAMI so the daily agent pool in sbox has none
Trying to test if nightly tests still work without an identity

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
