### PR TITLE
Revert "DTSPO-32097 - Remove UAMI from sbox daily agents"

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -66,6 +66,7 @@ spec:
               storageAccountType: "Standard_LRS"
               subnetName: "iaas"
               templateDisabled: false
+              uamiID: /subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftsbox-intsvc-mi
               usePrivateIP: true
               virtualNetworkName: "cft-ptlsbox-vnet"
               virtualNetworkResourceGroupName: "cft-ptlsbox-network-rg"
@@ -106,7 +107,6 @@ spec:
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
                         <<: *vm_template_values_anchor
-                        uamiID: /subscriptions/1497c3d7-ab6d-4bb7-8a10-b51d03189ee3/resourceGroups/managed-identities-cftsbox-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftsbox-intsvc-mi
                       - templateName: "cnp-jenkins-builders-daily"
                         templateDesc: "Jenkins build agents for HMCTS daily builds"
                         labels: "daily"


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#44780

The builds need to be able to access the cosmos db to send metrics so identities will be needed but we can use the same one for all the nightly builds in this case.