### PR TITLE
DTSRD-6134- Update elinks scheduler job time to 8AM

### DIFF
--- a/apps/rd/rd-judicial-api/perftest.yaml
+++ b/apps/rd/rd-judicial-api/perftest.yaml
@@ -16,7 +16,7 @@ spec:
         ELINKS_URL: https://gateway.staging.elinks.judiciary.uk/elinks/api/v5
         LAST_UPDATED: 1900-01-01
         SCHEDULER_ENABLED: true
-        CRON_EXPRESSION: "* 00 05 * * *"
+        CRON_EXPRESSION: "* 00 08 * * *"
         PER_PAGE: 200
         INCLUDE_PREVIOUS_APPOINTMENT: true
         THREAD_PAUSE_TIME: 2000


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSRD-6134


### Change description
Currently, the elinks scheduler job is not running in perf test. We want to update the job time to 8 AM and monitor it.
