### PR TITLE
DTSPO-32204 - Update chart source and version in sbox.yaml

### DIFF
--- a/apps/cnp/plum-frontend/sbox.yaml
+++ b/apps/cnp/plum-frontend/sbox.yaml
@@ -5,12 +5,11 @@ metadata:
 spec:
   chart:
     spec:
-      chart: plum-frontend
-      version: 0.1.28
+      chart: ./stable/plum-frontend
       interval: 1m
       sourceRef:
-        kind: HelmRepository
-        name: hmctssbox-oci
+        kind: GitRepository
+        name: hmcts-charts
         namespace: flux-system
   values:
     nodejs:


### PR DESCRIPTION
Fixing sandbox issue so that it works with the latest plum-frontend chart.