### PR TITLE
HMAN-1089: Set hmc-hmi-inbound-adapter IDAM OIDC URL and allowed issuer

### DIFF
--- a/apps/hmc/hmc-hmi-inbound-adapter/aat.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/aat.yaml
@@ -17,5 +17,6 @@ spec:
       cpuRequests: '250m'
       cpuLimits: '1500m'
       environment:
+        OIDC_ISSUER_FORGEROCK: https://forgerock-am.service.core-compute-idam-aat2.internal:8443/openam/oauth2/realms/root/realms/hmcts
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_CONFIG: DEBUG
         LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_HMC_SERVICE: DEBUG

--- a/apps/hmc/hmc-hmi-inbound-adapter/prod.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/prod.yaml
@@ -7,5 +7,7 @@ spec:
     java:
       environment:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
+        IDAM_OIDC_URL: https://hmcts-access.service.gov.uk
+        OIDC_ISSUER_FORGEROCK: https://forgerock-am.service.core-compute-idam-prod2.internal:8443/openam/oauth2/realms/root/realms/hmcts
         DUMMY_VAR: 0
       memoryRequests: '1Gi'


### PR DESCRIPTION
### Jira link

See [HMAN-1089](https://tools.hmcts.net/jira/browse/HMAN-1089)

### Change description

Added IDAM_OIDC_URL and OIDC_ISSUER_FORGEROCK environment variables to hmc-hmi-inbound-adapter prod.yaml file.

Added OIDC_ISSUER_FORGEROCK environment variable to hmc-hmi-inbound-adapter aat.yaml file.

The ODIC_ISSUER_FORGEROCK entries are required as AAT and production forgerock services have URLs which don't adhere to standard pattern.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
