### PR TITLE
Patch Prod Jenkins Controller to 2.564-1098, Jenkins Helm chart to 59.18 and auto-reload sidecar to 1.30.9

### DIFF
--- a/apps/jenkins/jenkins/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/jenkins-controller-version.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     controller:
       image:
-        tag: 2.553-1063
+        tag: 2.564-1098

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -323,7 +323,7 @@ spec:
           image:
             registry: hmctsprod.azurecr.io
             repository: imported/kiwigrid/k8s-sidecar
-            tag: 1.27.4
+            tag: 1.30.9
           # If enabled: true, Jenkins Configuration as Code will be reloaded on-the-fly without a reboot.  If false or not-specified,
           # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the Jenkins CLI
           # over SSH to reapply config when changes to the configScripts are detected.  The admin user (or account you specify in
@@ -390,7 +390,7 @@ spec:
   chart:
     spec:
       chart: jenkins
-      version: 5.9.4
+      version: 5.9.18
       sourceRef:
         kind: HelmRepository
         name: jenkins

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -35,10 +35,6 @@ spec:
           value: "sandbox"
         - name: AZURE_KEYVAULT_URL
           value: https://cftsbox-intsvc.vault.azure.net
-      sidecars:
-        configAutoReload:
-          image:
-            tag: 1.30.9
       JCasC:
         configScripts:
           welcome-message: |
@@ -382,11 +378,3 @@ spec:
                             emptyDir:
                           - name: volume-4
                             emptyDir:
-  chart:
-    spec:
-      chart: jenkins
-      version: 5.9.18
-      sourceRef:
-        kind: HelmRepository
-        name: jenkins
-        namespace: jenkins


### PR DESCRIPTION
Will be merged tomorrow before 8AM

### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32257

### Change description

Patching Jenkins according to [rota chedule](https://silver-giggle-pr729mk.pages.github.io/)

### Testing done

Both CFT and SDS sandbox instances have been patched to these versions last week and have not seen. any issues.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
