### PR TITLE
HMAN-1089: Temporarily add OIDC env variables to hmc-hmi-inbound-adapter demo config

### DIFF
--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -10,3 +10,5 @@ spec:
         LOGGING.LEVEL.UK.GOV.HMCTS.REFORM.HMC.CONFIG: DEBUG
         LOGGING.LEVEL.UK.GOV.HMCTS.REFORM.HMC.SERVICE: DEBUG
         HMC_SERVICE_BUS_QUEUE: hmc-from-hmi-demo-temp
+        IDAM_OIDC_URL: https://idam-web-public.demo.platform.hmcts.net
+        OIDC_ISSUER_FORGEROCK: https://forgerock-am.service.core-compute-idam-demo.internal:8443/openam/oauth2/realms/root/realms/hmcts


### PR DESCRIPTION
### Jira link

See [HMAN-1089](https://tools.hmcts.net/jira/browse/HMAN-1089)

### Change description

Temporarily added IDAM_OIDC_URL and OIDC_ISSUER_FORGEROCK environment variables to hmc-hmi-inbound-adapter demo.yaml file.  These are needed to be able to test the HMAN-1089 changes in demo and will be removed once testing has been completed.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
