### PR TITLE
HMAN-1089: Revert deployment of pull request image to demo

### DIFF
--- a/apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: demo-hmc-hmi-inbound-adapter
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-274-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: hmc-hmi-inbound-adapter

--- a/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
+++ b/apps/hmc/hmc-hmi-inbound-adapter/demo.yaml
@@ -5,10 +5,8 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprod.azurecr.io/hmc/hmi-inbound-adapter:pr-274-8a4fb62-20260527091545 #{"$imagepolicy": "flux-system:demo-hmc-hmi-inbound-adapter"}
+      image: hmctsprod.azurecr.io/hmc/hmi-inbound-adapter:prod-42746c3-20260527095037 #{"$imagepolicy": "flux-system:demo-hmc-hmi-inbound-adapter"}
       environment:
         LOGGING.LEVEL.UK.GOV.HMCTS.REFORM.HMC.CONFIG: DEBUG
         LOGGING.LEVEL.UK.GOV.HMCTS.REFORM.HMC.SERVICE: DEBUG
         HMC_SERVICE_BUS_QUEUE: hmc-from-hmi-demo-temp
-        IDAM_OIDC_URL: https://idam-web-public.demo.platform.hmcts.net
-        OIDC_ISSUER_FORGEROCK: https://forgerock-am.service.core-compute-idam-demo.internal:8443/openam/oauth2/realms/root/realms/hmcts


### PR DESCRIPTION
### Jira link

See [HMAN-1089](https://tools.hmcts.net/jira/browse/HMAN-1089)

### Change description

Changed hmc-hmi-inbound-adapter demo configuration to:
- Revert deployment of pull request image made in #44963
- Revert temporary setting of environment variables made in #44990

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
