### PR TITLE
DTSAM-1301 Prep for Deploy of GA ORM (Part 2)

### DIFF
--- a/apps/am/am-org-role-mapping-service/demo-image-policy.yaml
+++ b/apps/am/am-org-role-mapping-service/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1737-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/am/am-org-role-mapping-service/perftest-image-policy.yaml
+++ b/apps/am/am-org-role-mapping-service/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-1737-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:


### PR DESCRIPTION
### Jira link

[DTSAM-1301](https://tools.hmcts.net/jira/browse/DTSAM-1301) _"GA PRM Deploy to PROD but disabled"_

### Change description

 Prep for Deploy of GA ORM into PROD (Part 2)

This is to revert images on Demo and PerfTest back to PROD: i.e. reverting elements of:
* #44528
* #44517