### PR TITLE
removing impage policy from image

### DIFF
--- a/apps/xui/xui-mo-ogd-webapp/demo.yaml
+++ b/apps/xui/xui-mo-ogd-webapp/demo.yaml
@@ -25,4 +25,4 @@ spec:
         UNASSIGNED_CASE_TYPES: FT_CaseAccessGroups,true,true
         SERVICES_ROLE_ASSIGNMENT_MAPPING_API: http://am-org-role-mapping-service-demo.service.core-compute-demo.internal
         FEATURE_OGD_UPDATE_REFRESH_USER_ENABLED: false
-      image: hmctsprod.azurecr.io/xui/mo-webapp:pr-1527-92987e3-20260528100403 #{"$imagepolicy": "flux-system:demo-xui-mo-ogd-webapp"}
+      image: hmctsprod.azurecr.io/xui/mo-webapp:pr-1527-92987e3-20260528100403


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/POFCC-151

### Change description

Removing reference to image policy, this is preventing the pods from picking up the latest image. 

### Testing done

Have spoken to exui team to get confirmation that this is the likely issue of why pods aren't refreshing with the latest image. 

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
