### PR TITLE
HDPI-4276: Temporarily disable the DB scheduler in AAT

### DIFF
--- a/apps/pcs/pcs-api/aat.yaml
+++ b/apps/pcs/pcs-api/aat.yaml
@@ -7,3 +7,4 @@ spec:
     java:
       environment:
         HASH_PINS_ENABLED: "false"
+        DB_SCHEDULER_EXECUTOR_ENABLED: "false"


### PR DESCRIPTION
### Jira link

See [HDPI-4276](https://tools.hmcts.net/jira/browse/HDPI-4276)

### Change description

Temporarily disable the DB scheduler in AAT because the scheduled task serialisation has been changed and the AAT pods are picking up, (and failing), some of the tasks from the Staging build pods.

This is a temporary change, and the service is not in prod yet so the change in serialisation should not be an issue in other non-prod environments.

### Testing done

Tested locally with the env var override

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
