### PR TITLE
Revert "Update dtsse aat job cron timer"

### DIFF
--- a/apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
+++ b/apps/dtsse/dtsse-dashboard-ingestion/aat/00.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     job:
       image: hmctsprod.azurecr.io/dtsse/dashboard-ingestion:pr-807-2bc00f0-20260602145619
-      schedule: "0,10,20,30,40,50 * * * *"
+      schedule: "0 * * * *"
       cpuRequests: "250m"
       memoryRequests: "1Gi"
       keyVaults:


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#45292

Continuing testing locally. Getting a couple of errors in the pods related to 502s and JSON formatting