### PR TITLE
DTSPO-30107: add XUI environment Jenkins agents

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -358,3 +358,105 @@ spec:
                           galleryImageVersion: "24.04.82"
                         <<: *vm_template_values_anchor
                         uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-preview"
+                        templateDesc: "Jenkins build agents for XUI builds"
+                        labels: "xui-preview"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.82"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-preview-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-preview-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-aat"
+                        templateDesc: "Jenkins build agents for XUI builds"
+                        labels: "xui-aat"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.82"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-demo"
+                        templateDesc: "Jenkins build agents for XUI builds"
+                        labels: "xui-demo"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.82"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-demo-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-ithc"
+                        templateDesc: "Jenkins build agents for XUI builds"
+                        labels: "xui-ithc"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.82"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ithc-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-perftest"
+                        templateDesc: "Jenkins build agents for XUI builds"
+                        labels: "xui-perftest"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.82"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-perftest-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-prod"
+                        templateDesc: "Jenkins build agents for XUI builds"
+                        labels: "xui-prod"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.82"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -44,6 +44,8 @@ spec:
                         value: DTS-CFTPTL-INTSVC
                       - key: ENVIRONMENT_AGENT_LABEL_TEMPLATE_CIVIL
                         value: civil-{environment}
+                      - key: ENVIRONMENT_AGENT_LABEL_TEMPLATE_XUI
+                        value: xui-{environment}
                       - key: JAVA_OPTS
                         value: -Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
                       - key: GRADLE_OPTS


### PR DESCRIPTION
## What changed

- Adds `ENVIRONMENT_AGENT_LABEL_TEMPLATE_XUI=xui-{environment}` to Jenkins global env vars.
- Adds XUI environment-specific Azure VM agent templates for preview, AAT, demo, ITHC, perftest and prod.
- Uses the existing environment Jenkins managed identities for the corresponding XUI agent labels.

## Why

XUI jobs currently fall back to the generic `xui` Jenkins agent label. This allows migrated XUI pipelines to resolve to environment-specific labels such as `xui-aat`, `xui-preview` and `xui-prod`, matching the env-specific managed identity model.