### PR TITLE
ADOP-2724 remove from demo

### DIFF
--- a/apps/adoption/adoption-web/demo-image-policy.yaml
+++ b/apps/adoption/adoption-web/demo-image-policy.yaml
@@ -2,14 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: demo-adoption-web
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
-  filterTags:
-    pattern: '^pr-1752-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    alphabetical:
-      order: asc
   imageRepositoryRef:
     name: adoption-web


### PR DESCRIPTION
### Jira link
[ADOP-2724](https://tools.hmcts.net/jira/browse/ADOP-2724) / [ADOP-2815](https://tools.hmcts.net/jira/browse/ADOP-2815)

### Change description
Stop demo pointing at PR that has been merged into master.

### Testing done
BAU

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [ ] Does this PR introduce a breaking change
