### PR TITLE
DTSPO-30107: keep XUI PTL jobs on generic agent

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -44,6 +44,8 @@ spec:
                         value: DTS-CFTPTL-INTSVC
                       - key: ENVIRONMENT_AGENT_LABEL_TEMPLATE_CIVIL
                         value: civil-{environment}
+                      - key: ENVIRONMENT_AGENT_LABEL_XUI_PTL
+                        value: xui
                       - key: ENVIRONMENT_AGENT_LABEL_TEMPLATE_XUI
                         value: xui-{environment}
                       - key: JAVA_OPTS


### PR DESCRIPTION
## What changed

Adds `ENVIRONMENT_AGENT_LABEL_XUI_PTL=xui` so XUI PTL/control-plane stages continue to use the existing generic XUI agent instead of resolving `xui-{environment}` to the non-existent `xui-ptl` label.

## Why

The XUI environment-agent template added in #45311 correctly routes deployment environments to labels like `xui-aat` and `xui-prod`, but PTL is not backed by an `xui-ptl` VM template. This prevents jobs getting stuck waiting for a label that does not exist.