### PR TITLE
DTSPO-32018: mount Azure Managed Redis secret for plum-recipe-backend in aat

### DIFF
--- a/apps/cnp/plum-recipe-backend/aat.yaml
+++ b/apps/cnp/plum-recipe-backend/aat.yaml
@@ -12,3 +12,9 @@ spec:
           TEST_URL: http://plum-recipe-backend-java
           SLACK_CHANNEL: "platops-build-notices"
           SLACK_NOTIFY_SUCCESS: "false"
+      keyVaults:
+        plumsi:
+          secrets:
+            - name: "azure-managed-redis-connection-string"
+              alias: "redis-connection-string" # Maps to /mnt/secrets/redis-connection-string
+            - name: appInsights-InstrumentationKey


### PR DESCRIPTION
# DTSPO-32018: mount Azure Managed Redis secret for plum-recipe-backend in aat

> **Skill demonstration PR — draft only.** Raised by the [`azure-managed-redis-migration`](https://github.com/hmcts/platops-agent-skills/blob/master/.github/skills/azure-managed-redis-migration/SKILL.md) skill to validate the workflow end-to-end. Do not merge.

### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32018

### Change description

Adds a `keyVaults` block to `apps/cnp/plum-recipe-backend/aat.yaml` mounting the new Azure Managed Redis connection string from the `plumsi-aat` Key Vault.

Pattern is identical to the reference example PR [hmcts/cnp-flux-config#45044](https://github.com/hmcts/cnp-flux-config/pull/45044/files). The secret `azure-managed-redis-connection-string` is **aliased** to `redis-connection-string` so the application code does not need to change — it continues to read from `/mnt/secrets/redis-connection-string`, but the file now points at the Azure Managed Redis instance instead of any classic Azure Cache for Redis.

### Migration context

| Field | Value |
|---|---|
| Source Redis | Classic `azurerm_redis_cache` (if any) in the product's shared infrastructure |
| Target Redis | Azure Managed Redis (`Balanced_B0`+ depending on env) — provisioned by the companion Terraform PR in `cnp-plum-recipes-service` using [`terraform-module-azure-managed-redis`](https://github.com/hmcts/terraform-module-azure-managed-redis) |
| Key Vault (logical) | `plumsi` (resolves to `plumsi-aat`) |
| New secret | `azure-managed-redis-connection-string` |
| App-visible name (alias) | `redis-connection-string` (unchanged) |
| Data migration approach | TBC with team |

### Promotion plan

This PR is **aat only**. Per the `azure-managed-redis-migration` skill, each environment is promoted in its own PR:

- [ ] sbox
- [ ] preview / dev
- [ ] ithc
- [ ] demo
- [x] **aat** (this PR)
- [ ] prod

### Pre-cutover checklist

- [ ] Terraform PR merged in `cnp-plum-recipes-service` adding the `managed_redis` module
- [ ] Managed Redis visible in Azure Portal, `provisioningState = Succeeded`
- [ ] `azure-managed-redis-connection-string` secret present in `plumsi-aat`
- [ ] Connection-string smoke test from a pod returns `PONG`

### Cutover

1. Merge this PR.
2. Watch Flux reconcile: `flux get helmreleases -n plum --watch`
3. Verify pods restart and `/mnt/secrets/redis-connection-string` now contains the Managed Redis FQDN (port `10000`, scheme `rediss://`).
4. Application smoke tests.
5. Confirm new instance shows `ConnectedClients > 0` and any old cache `OperationsPerSecond` drops to ~0.

### Rollback

Revert this PR. Flux will reconcile and the pod will remount the **original** secret pointing at the previous Redis (still present — not removed by this PR).

### Testing done

YAML patch validated locally; matches the shape of the reference PR #45044. No application or infrastructure deployment performed by this PR — Flux reconciliation only takes effect once merged.

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

- [ ] Yes
- [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed) — n/a
- [ ] tests have been updated / new tests has been added (if needed) — n/a, Flux config only
- [ ] Does this PR introduce a breaking change — no, additive only
