### PR TITLE
Add pcs-sb-preview SOPS secret for WA preview Service Bus

### DIFF
--- a/apps/pcs/preview/sops-secrets/kustomization.yaml
+++ b/apps/pcs/preview/sops-secrets/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - pcs-values.enc.yaml
+  - pcs-sb-preview.enc.yaml
 namespace: pcs

--- a/apps/pcs/preview/sops-secrets/pcs-sb-preview.enc.yaml
+++ b/apps/pcs/preview/sops-secrets/pcs-sb-preview.enc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  connectionString: ENC[AES256_GCM,data:Tfup5+ZJJIwxVxAZ4B89bi/QGbOmk0NOVxQyGpl9hqfzTq//FkskQufP5FQNjPtYhc47WxrVVc6fgI/V9eOD/zg9pZxYAJC/tdA67fggGQ66dcSzV7q5feakJw5kcb+mue9fvEkIVeUA3XiuCMFGddbhXbJKDCSUZbC+7C39bRZ77vtV6YRhA3OBjynfoRC8436ZzjidwnTAuwpFP4Us9uvIOXDxzeMPyGSpWpineB2XjHXjp09+KHP+hWk6SBd03ziA/JroSjq2I7MR0wDcMyVQ00M=,iv:+yZgtoWYSSeyK3FC32mrOPw9xWbjkm5MOD9Owr1bioA=,tag:FwFwFr6EKZ7dx88I127RnQ==,type:str]
+  primaryKey: ENC[AES256_GCM,data:4y9Lc5y9uHwRxYzPWPcYMRRHXKIsYLAGI8bEPQck7WwUQhepJyJ9BAZqGEq0EEAHXmLCfiB/vPdbuQNg,iv:+5GHQ9JIYJSaviV4DfU4SOHWkdNIbgJgI7HAOQS9248=,tag:4reYp9Tq3YO+wVvErP3Wiw==,type:str]
+kind: Secret
+metadata:
+  name: pcs-sb-preview
+  namespace: pcs
+type: Opaque
+sops:
+  azure_kv:
+    - created_at: "2026-06-04T12:47:32Z"
+      enc: kZQ8S_pZIo6QZAyL-Dl7-8t5t7IAQVqxwY5WfQ5niNSYY6AhCIyji56DKxpX52VXkPKP9LfASAk1aF71qkcdMjhsEdeEtXyLaolGqaUQ0ULNNn8xQ24gN_1el-PSy9HYIwgU1UMni9FP8rEWHaE2bYC8Jrq_EI3eWNPurQY__OQXSjiCx8QVARoAEBU5GSNf5jBEqpQ8mzKcTCe0HsxQG_JSvCqIN3Ph0oTeSemlIPf-NbEXNZA2ycgcXvQKnTs-XdIJMTmVAcBq07jNv1KjWndHteDw62b2XzL39NemmAVjwmTYsp97i1_AQg3D2uZcjTwJ0PyI_Ctj2qtvR4I2CA
+      name: sops-key
+      vault_url: https://dcdcftappsdevkv.vault.azure.net
+      version: aedb9ea38954430ca1d0a46ed589c049
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-04T12:47:33Z"
+  mac: ENC[AES256_GCM,data:hYgJCacMC+2ccPreaCX/G2ln5Eu/y1wzjkeBMg637D0fAKhs6VD0X8CXoi7+otwHa6Nu+gJs03KVgeOj/WSTsaqYDhjlReScJ1PNXOtwvBOLFK0fSvStLpH+xw01jmkVblpDdR348eJXI33zttoxJGuu3TmMq6r9fhVQSWKV9hg=,iv:2nFFgmqmQnUbrCpNC/JYqCF+tNK09ooQQIPKv83nSaU=,tag:WSofPUyQ2GM7TjgsxZSd8w==,type:str]
+  version: 3.13.1


### PR DESCRIPTION
## Summary
- Adds the `pcs-sb-preview` SOPS-encrypted secret (Service Bus `connectionString` + `primaryKey`) to `apps/pcs/preview/sops-secrets/`.
- Wires it into the pcs preview `sops-secrets/kustomization.yaml`.
