### PR TITLE
PTSCCI-5052 Remove civil-camunda-bpmn-definition from Jenkins dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -274,7 +274,7 @@ spec:
                     title: Evidence Management
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(civil-service|civil-camunda-bpmn-definition|civil-ccd-definition|civil-citizen-ui|civil-wa-task-configuration|civil-performance)\/master
+                      ^HMCTS.*\/(civil-service|civil-ccd-definition|civil-citizen-ui|civil-wa-task-configuration|civil-performance)\/master
                     name: Civil
                     recurse: true
                     title: Civil Data Dashboard


### PR DESCRIPTION
### Jira link

PTSCCI-5052


### Change description
As we have merged [civil-camunda-bpmn-definition](https://github.com/hmcts/civil-camunda-bpmn-definition) into [civil-service](https://github.com/hmcts/civil-service). So removing this from jenkins dashboard of civil

