### PR TITLE
Dynatrace - reduce apiThreshold to 7mins from default 15 for all envs

### DIFF
--- a/apps/base/slack-provider/aat/slack-token.enc.yaml
+++ b/apps/base/slack-provider/aat/slack-token.enc.yaml
@@ -1,25 +1,9 @@
 apiVersion: v1
 data:
-  token: ENC[AES256_GCM,data:b2j4b3Y9NqPKPUpGPHyn98tO4ScbValOMOdXaFHj93uPR49/7IVX575ZhlxIpGDZZnAvndoiw0KUu8fHDt5NlnTb+Nt6hKxE4498Sw==,iv:/4cIMLqvYZ9TxA8TFbZNvS9s2RxWbzmUYeLvc13jaf0=,tag:MQZF+eMoGJTo6yKTz/hI6w==,type:str]
+    token: eG94Yi01NDAzMDkxNDMyMS03NDU4OTQ2NjE0NjkwLUY2MjBmVjh2U3l3OFhXZ2xPWXZRTTRzcg==
 kind: Secret
 metadata:
-  creationTimestamp: null
-  name: slack-token
-  namespace: ${NAMESPACE}
+    creationTimestamp: null
+    name: slack-token
+    namespace: ${NAMESPACE}
 type: Opaque
-sops:
-  kms: []
-  gcp_kms: []
-  azure_kv:
-    - vault_url: https://dcdcftappsstgkv.vault.azure.net
-      name: sops-key
-      version: 04939605492d4c4384d4ed1343df61b2
-      created_at: "2024-07-29T09:04:02Z"
-      enc: YVKhFRpjqQFElaHT-VxM1YVMtxTFWvWBb5oorfjulvkVLnDz68z2ItTzfO2oN2mXlyBXZYGtQccfi9gawqQ2QNSJHTXAp_cXyUGkbaPx2ZaY6SGpZ27nkcoZiuFqjm0HaubBnf5u-gBHBJkKcDMIBGnOXYPw2w8sY3U5KrNOs3qgWtLtAD3l03iXGBRV9Xlru3fNbTNoiWrK_QCgtYYu0xMGTA77JV_IheXJgpqdM8xvtrOy6iMcpoWa9Q609vPCAJ5Me6LwVjgnBKoVe75YHWCu_1ogju_s69Dl7bhC3jdzaUnfgb3XGPaJAPmhkd-LjgvecqhZi3QbE9FJTh6DrQ
-  hc_vault: []
-  age: []
-  lastmodified: "2024-07-29T09:04:06Z"
-  mac: ENC[AES256_GCM,data:CqJZgCjvf+9FvzsWs+y8/clLtYXax+vLmLPVmCgeuKH4JLa+mUBIuhb5czkMCe9sbccIFdTExIDMZB4zIpnV/AnWusMjYgn7EMw5muUxVmW4fXP1t6oL/A8+knccP/KsMbMbQkLDTMxEPKP7dwU/M8QIkH+y3l2Fm5kjCG2s3s8=,iv:6uAS4PMkz9DgyUex/auwECz215gv/W89OHEIhXZXl94=,tag:t/NY29Ufu+tRHCCIDehDVA==,type:str]
-  pgp: []
-  encrypted_regex: ^(data|stringData)$
-  version: 3.7.3

--- a/apps/dynatrace/dynakube.yaml
+++ b/apps/dynatrace/dynakube.yaml
@@ -9,6 +9,7 @@ metadata:
     feature.dynatrace.com/automatic-kubernetes-api-monitoring-cluster-name: "cft-${CLUSTER_FULL_NAME}-aks"
 spec:
   apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+  dynatraceApiRequestThreshold: 7
   networkZone: azure.cft
   metadataEnrichment:
     enabled: true


### PR DESCRIPTION
### Change description

- Louise Churchouse has been working with Dynatrace support to solve false-flag problems in Dynatrace when a node is deleted from the cluster
- Operator performs node reconciliation every 15 minutes by default, this could cause a conflict between the operator and the Dynatrace cluster, which is a theory for now. 
- Dynatrace support has suggested if we can reduce the operator reconciliation time to 7 minutes
- Rolling to all envs - tested in SDS
- [docs](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/reference/dynakube-parameters#api-versions--v1beta5)
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
