### PR TITLE
Dynatrace - reduce apiThreshold to 7mins from default 15 for all envs

### DIFF
--- a/apps/dynatrace/dynakube.yaml
+++ b/apps/dynatrace/dynakube.yaml
@@ -9,6 +9,7 @@ metadata:
     feature.dynatrace.com/automatic-kubernetes-api-monitoring-cluster-name: "cft-${CLUSTER_FULL_NAME}-aks"
 spec:
   apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
+  dynatraceApiRequestThreshold: 7
   networkZone: azure.cft
   metadataEnrichment:
     enabled: true


### PR DESCRIPTION
### Change description

- Louise Churchouse has been working with Dynatrace support to solve false-flag problems in Dynatrace when a node is deleted from the cluster
- Operator performs node reconciliation every 15 minutes by default, this could cause a conflict between the operator and the Dynatrace cluster, which is a theory for now. 
- Dynatrace support has suggested if we can reduce the operator reconciliation time to 7 minutes
- Testing in SDS - rolling to all envs
- [docs](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/reference/dynakube-parameters#api-versions--v1beta5)
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
