### PR TITLE
Update SPTribunals demo image

### DIFF
--- a/apps/sptribs/sptribs-case-api/demo-image-policy.yaml
+++ b/apps/sptribs/sptribs-case-api/demo-image-policy.yaml
@@ -8,7 +8,7 @@ spec:
   imageRepositoryRef:
     name: sptribs-case-api
   filterTags:
-    pattern: '^pr-2467-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-2534-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/sptribs/sptribs-case-api/demo.yaml
+++ b/apps/sptribs/sptribs-case-api/demo.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprod.azurecr.io/sptribs/case-api:pr-2467-d05c43c-20260512125424 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
+      image: hmctsprod.azurecr.io/sptribs/case-api:pr-2534-4c60d68-20260609171937 #{"$imagepolicy": "flux-system:demo-sptribs-case-api"}
       environment:
         S2S_AUTHORISED_SERVICES: ccd_definition,ccd_data,xui_webapp,sptribs_case_api,ccd_gw,sptribs_frontend,sptribs_dss_update_case_web
         WA_FEATURE_ENABLED: true


### PR DESCRIPTION
Updates SPTribunals demo to use the pr-2534 case-api image.

Also updates the demo image policy pattern to pr-2534 so flux image automation does not revert it back to pr-2467.