### PR TITLE
Add postgres secrets to clear inactive DSS cron

### DIFF
--- a/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml
+++ b/apps/sptribs/sptribs-cron-clear-inactive-dss-draft-cases/sptribs-cron-clear-inactive-dss-draft-cases.yaml
@@ -24,6 +24,18 @@ spec:
               alias: IDAM_SYSTEM_UPDATE_PASSWORD
             - name: launchDarkly-sdk-key
               alias: LAUNCH_DARKLY_SDK_KEY
+            - name: sptribs-POSTGRES-HOST
+              alias: POSTGRES_HOST
+            - name: sptribs-POSTGRES-PORT
+              alias: POSTGRES_PORT
+            - name: sptribs-POSTGRES-DATABASE
+              alias: POSTGRES_NAME
+            - name: sptribs-POSTGRES-USER
+              alias: POSTGRES_USERNAME
+            - name: sptribs-POSTGRES-PASS
+              alias: POSTGRES_PASSWORD
+            - name: ccd-case-events-sendonly-connection-string
+              alias: AZURE_SERVICE_BUS_CONNECTION_STRING
       environment:
         TASK_NAME: SystemClearInactiveDssDraftCasesTask
       schedule: 0 17 * * 1-5


### PR DESCRIPTION
This adds the postgres Key Vault secret mappings to the SPTRIBS clear inactive DSS draft cases cron job.

The cron job currently starts without POSTGRES_HOST, POSTGRES_PORT, POSTGRES_NAME, POSTGRES_USERNAME and POSTGRES_PASSWORD, so the case API falls back to its local defaults and tries to connect to localhost:6432 during Flyway startup. The added mappings match the other SPTRIBS cron jobs that run the same case API image.

Validated by parsing the updated HelmRelease YAML locally.