### PR TITLE
HDPI-7083: Enable testing support in lower envs

### DIFF
--- a/apps/pcs/pcs-api/aat.yaml
+++ b/apps/pcs/pcs-api/aat.yaml
@@ -7,3 +7,4 @@ spec:
     java:
       environment:
         HASH_PINS_ENABLED: "false"
+        ENABLE_TESTING_SUPPORT: "true"

--- a/apps/pcs/pcs-api/demo.yaml
+++ b/apps/pcs/pcs-api/demo.yaml
@@ -7,3 +7,4 @@ spec:
     java:
       environment:
         HASH_PINS_ENABLED: "false"
+        ENABLE_TESTING_SUPPORT: "true"

--- a/apps/pcs/pcs-api/perftest.yaml
+++ b/apps/pcs/pcs-api/perftest.yaml
@@ -7,3 +7,4 @@ spec:
     java:
       environment:
         HASH_PINS_ENABLED: "false"
+        ENABLE_TESTING_SUPPORT: "true"


### PR DESCRIPTION
### Jira link

See [HDPI-7083](https://tools.hmcts.net/jira/browse/HDPI-7083)

### Change description

Enable testing support in lower envs. This is ahead of changing the default in pcs-api to be false, to make this an opt-in feature rather than opt-out.

Note that ITHC has intentionally been left out.

### Testing done

n/a

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
