### PR TITLE
VIBE-465: Add cath to CNP flux config (AAT + preview)

### DIFF
--- a/apps/cath/aat/00/kustomization.yaml
+++ b/apps/cath/aat/00/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cath
+resources:
+- ../base

--- a/apps/cath/aat/01/kustomization.yaml
+++ b/apps/cath/aat/01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cath
+resources:
+- ../base

--- a/apps/cath/aat/base/kustomization.yaml
+++ b/apps/cath/aat/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cath
+resources:
+  - ../../base
+  - ../../../rbac/nonprod-role.yaml
+  - ../../../rbac/db-query-job-role.yaml
+  - ../../cath-web/cath-web.yaml
+  - ../../cath-api/cath-api.yaml
+  - ../../cath-crons/cath-crons.yaml
+  - ../../cath-postgres/cath-postgres.yaml
+  - ../../../base/slack-provider/aat
+  - ../../../base/docker-registry/aat
+patches:
+  - path: ../../identity/aat.yaml
+  - path: ../../serviceaccount/aat.yaml

--- a/apps/cath/automation/kustomization.yaml
+++ b/apps/cath/automation/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../cath-web/image-repo.yaml
+  - ../cath-web/image-policy.yaml
+  - ../cath-api/image-repo.yaml
+  - ../cath-api/image-policy.yaml
+  - ../cath-crons/image-repo.yaml
+  - ../cath-crons/image-policy.yaml
+  - ../cath-postgres/image-repo.yaml
+  - ../cath-postgres/image-policy.yaml

--- a/apps/cath/base/kustomization.yaml
+++ b/apps/cath/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ../../base/workload-identity
+namespace: cath

--- a/apps/cath/base/kustomization.yaml
+++ b/apps/cath/base/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../identity/identity.yaml
   - ../../base/workload-identity
 namespace: cath

--- a/apps/cath/base/kustomize.yaml
+++ b/apps/cath/base/kustomize.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cath
+  namespace: flux-system
+spec:
+  path: ./apps/cath/${ENVIRONMENT}/${CLUSTER}
+  postBuild:
+    substitute:
+      NAMESPACE: "cath"
+      WI_NAME: "cath"
+      TEAM_NOTIFICATION_CHANNEL: "cath-builds"
+      TEAM_AAD_GROUP_ID: "b2a1773c-a5ae-48b5-b5fa-95b0e05eee05"

--- a/apps/cath/cath-api/cath-api.yaml
+++ b/apps/cath/cath-api/cath-api.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cath-api
+spec:
+  releaseName: cath-api
+  interval: 5m
+  values:
+    nodejs:
+      releaseNameOverride: cath-api
+      image: hmctspublic.azurecr.io/cath/cath-api:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-api"}
+  chart:
+    spec:
+      chart: cath-api
+      version: ">=0.0.1-0"
+      sourceRef:
+        kind: HelmRepository
+        name: hmctsprod-oci
+        namespace: flux-system
+      interval: 1m

--- a/apps/cath/cath-api/cath-api.yaml
+++ b/apps/cath/cath-api/cath-api.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       releaseNameOverride: cath-api
-      image: hmctspublic.azurecr.io/cath/cath-api:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-api"}
+      image: hmctsprod.azurecr.io/cath/cath-api:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-api"}
   chart:
     spec:
       chart: cath-api

--- a/apps/cath/cath-api/image-policy.yaml
+++ b/apps/cath/cath-api/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: cath-api
+spec:
+  imageRepositoryRef:
+    name: cath-api

--- a/apps/cath/cath-api/image-repo.yaml
+++ b/apps/cath/cath-api/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: cath-api
+spec:
+  image: hmctspublic.azurecr.io/cath/cath-api

--- a/apps/cath/cath-api/image-repo.yaml
+++ b/apps/cath/cath-api/image-repo.yaml
@@ -1,6 +1,8 @@
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
   name: cath-api
 spec:
-  image: hmctspublic.azurecr.io/cath/cath-api
+  image: hmctsprod.azurecr.io/cath/cath-api

--- a/apps/cath/cath-crons/cath-crons.yaml
+++ b/apps/cath/cath-crons/cath-crons.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     job:
       releaseNameOverride: cath-crons
-      image: hmctspublic.azurecr.io/cath/cath-crons:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-crons"}
+      image: hmctsprod.azurecr.io/cath/cath-crons:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-crons"}
       schedule: "*/5 * * * *"
   chart:
     spec:

--- a/apps/cath/cath-crons/cath-crons.yaml
+++ b/apps/cath/cath-crons/cath-crons.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cath-crons
+spec:
+  releaseName: cath-crons
+  interval: 5m
+  values:
+    job:
+      releaseNameOverride: cath-crons
+      image: hmctspublic.azurecr.io/cath/cath-crons:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-crons"}
+      schedule: "*/5 * * * *"
+  chart:
+    spec:
+      chart: cath-crons
+      version: ">=0.0.1-0"
+      sourceRef:
+        kind: HelmRepository
+        name: hmctsprod-oci
+        namespace: flux-system
+      interval: 1m

--- a/apps/cath/cath-crons/image-policy.yaml
+++ b/apps/cath/cath-crons/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: cath-crons
+spec:
+  imageRepositoryRef:
+    name: cath-crons

--- a/apps/cath/cath-crons/image-repo.yaml
+++ b/apps/cath/cath-crons/image-repo.yaml
@@ -1,6 +1,8 @@
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
   name: cath-crons
 spec:
-  image: hmctspublic.azurecr.io/cath/cath-crons
+  image: hmctsprod.azurecr.io/cath/cath-crons

--- a/apps/cath/cath-crons/image-repo.yaml
+++ b/apps/cath/cath-crons/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: cath-crons
+spec:
+  image: hmctspublic.azurecr.io/cath/cath-crons

--- a/apps/cath/cath-postgres/cath-postgres.yaml
+++ b/apps/cath/cath-postgres/cath-postgres.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       releaseNameOverride: cath-postgres
-      image: hmctspublic.azurecr.io/cath/cath-postgres:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-postgres"}
+      image: hmctsprod.azurecr.io/cath/cath-postgres:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-postgres"}
   chart:
     spec:
       chart: cath-postgres

--- a/apps/cath/cath-postgres/cath-postgres.yaml
+++ b/apps/cath/cath-postgres/cath-postgres.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cath-postgres
+spec:
+  releaseName: cath-postgres
+  interval: 5m
+  values:
+    nodejs:
+      releaseNameOverride: cath-postgres
+      image: hmctspublic.azurecr.io/cath/cath-postgres:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-postgres"}
+  chart:
+    spec:
+      chart: cath-postgres
+      version: ">=0.0.1-0"
+      sourceRef:
+        kind: HelmRepository
+        name: hmctsprod-oci
+        namespace: flux-system
+      interval: 1m

--- a/apps/cath/cath-postgres/image-policy.yaml
+++ b/apps/cath/cath-postgres/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: cath-postgres
+spec:
+  imageRepositoryRef:
+    name: cath-postgres

--- a/apps/cath/cath-postgres/image-repo.yaml
+++ b/apps/cath/cath-postgres/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: cath-postgres
+spec:
+  image: hmctspublic.azurecr.io/cath/cath-postgres

--- a/apps/cath/cath-postgres/image-repo.yaml
+++ b/apps/cath/cath-postgres/image-repo.yaml
@@ -1,6 +1,8 @@
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
   name: cath-postgres
 spec:
-  image: hmctspublic.azurecr.io/cath/cath-postgres
+  image: hmctsprod.azurecr.io/cath/cath-postgres

--- a/apps/cath/cath-web/cath-web.yaml
+++ b/apps/cath/cath-web/cath-web.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cath-web
+spec:
+  releaseName: cath-web
+  interval: 5m
+  values:
+    nodejs:
+      releaseNameOverride: cath-web
+      image: hmctspublic.azurecr.io/cath/cath-web:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-web"}
+  chart:
+    spec:
+      chart: cath-web
+      version: ">=0.0.1-0"
+      sourceRef:
+        kind: HelmRepository
+        name: hmctsprod-oci
+        namespace: flux-system
+      interval: 1m

--- a/apps/cath/cath-web/cath-web.yaml
+++ b/apps/cath/cath-web/cath-web.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       releaseNameOverride: cath-web
-      image: hmctspublic.azurecr.io/cath/cath-web:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-web"}
+      image: hmctsprod.azurecr.io/cath/cath-web:prod-0000000-00000000000000 # {"$imagepolicy": "flux-system:cath-web"}
   chart:
     spec:
       chart: cath-web

--- a/apps/cath/cath-web/image-policy.yaml
+++ b/apps/cath/cath-web/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: cath-web
+spec:
+  imageRepositoryRef:
+    name: cath-web

--- a/apps/cath/cath-web/image-repo.yaml
+++ b/apps/cath/cath-web/image-repo.yaml
@@ -1,6 +1,8 @@
 apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
   name: cath-web
 spec:
-  image: hmctspublic.azurecr.io/cath/cath-web
+  image: hmctsprod.azurecr.io/cath/cath-web

--- a/apps/cath/cath-web/image-repo.yaml
+++ b/apps/cath/cath-web/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: cath-web
+spec:
+  image: hmctspublic.azurecr.io/cath/cath-web

--- a/apps/cath/identity/aat.yaml
+++ b/apps/cath/identity/aat.yaml
@@ -1,0 +1,8 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: cath
+  namespace: cath
+spec:
+  resourceID: "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourcegroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cath-aat-mi"
+  clientID: "44cc0551-c274-4f95-a980-dba76fe70fda"

--- a/apps/cath/identity/identity.yaml
+++ b/apps/cath/identity/identity.yaml
@@ -1,0 +1,18 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: cath
+  namespace: cath
+spec:
+  type: 0
+
+---
+
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: cath-binding
+  namespace: cath
+spec:
+  azureIdentity: cath
+  selector: cath

--- a/apps/cath/preview/00/kustomization.yaml
+++ b/apps/cath/preview/00/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cath
+resources:
+  - ../base
+sortOptions:
+  order: fifo

--- a/apps/cath/preview/01/kustomization.yaml
+++ b/apps/cath/preview/01/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cath
+resources:
+  - ../base
+sortOptions:
+  order: fifo

--- a/apps/cath/preview/aso/cath-postgres.yaml
+++ b/apps/cath/preview/aso/cath-postgres.yaml
@@ -1,0 +1,10 @@
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+kind: FlexibleServer
+metadata:
+  name: ${NAMESPACE}-${ENVIRONMENT}
+  namespace: ${NAMESPACE}
+spec:
+  version: "16"
+  sku:
+    name: Standard_D2ds_v5
+    tier: GeneralPurpose

--- a/apps/cath/preview/base/kustomization.yaml
+++ b/apps/cath/preview/base/kustomization.yaml
@@ -4,10 +4,6 @@ resources:
   - ../../../base
   - ../../../base/workload-identity
   - ../../../base/docker-registry/dev
-  - ../../../azureserviceoperator-system/resources/resource-group.yaml
-  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
-  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
-  - ../sops-secrets
 namespace: cath
 patches:
   - path: ../../serviceaccount/aat.yaml

--- a/apps/cath/preview/base/kustomization.yaml
+++ b/apps/cath/preview/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base
+  - ../../../base/workload-identity
+  - ../../../base/docker-registry/dev
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
+  - ../sops-secrets
+namespace: cath
+patches:
+  - path: ../../serviceaccount/aat.yaml
+sortOptions:
+  order: fifo

--- a/apps/cath/preview/base/kustomization.yaml
+++ b/apps/cath/preview/base/kustomization.yaml
@@ -4,8 +4,15 @@ resources:
   - ../../../base
   - ../../../base/workload-identity
   - ../../../base/docker-registry/dev
+  - ../../identity/identity.yaml
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
+  - ../sops-secrets
 namespace: cath
 patches:
+  - path: ../../identity/aat.yaml
   - path: ../../serviceaccount/aat.yaml
+  - path: ../aso/cath-postgres.yaml
 sortOptions:
   order: fifo

--- a/apps/cath/preview/sops-secrets/cath-postgres-values.enc.yaml
+++ b/apps/cath/preview/sops-secrets/cath-postgres-values.enc.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: postgres
+  namespace: cath
+type: Opaque
+stringData:
+  PASSWORD: ENC[AES256_GCM,data:GUoXHbqgOeVwtdoeRrDk7Xhax1Jqe5EH,iv:kDzv6kJBoSe/XnWYYlTn9M3b0E8uCUEf5W/JVCiI1no=,tag:/xZyveL04HB4HgRkw11bAg==,type:str]
+  HOST: ENC[AES256_GCM,data:6t0hpAGAKcnqryvftsR5Bby/3cicClpm1qmlGKlgMqjPHIXV5LS+nQ==,iv:y1RfquKJhIOBFPpAyuk1FB0ZTQ00uULZKNHj3a7jg1E=,tag:WvnlGtmAZkocVudgGSFPzQ==,type:str]
+  USER: ENC[AES256_GCM,data:UygUAMU=,iv:+fnzO5cwXThMrO0gIEd4BlEaz7vvpLypoY0QmgmYkoQ=,tag:2B+i843+M/4mTU4L+qGVSA==,type:str]
+  PORT: ENC[AES256_GCM,data:MqZ9Fw==,iv:BNAyrjEdnPr6wrKNk9Hzf3r3mcsAXUbxJRtQ4OW2gC4=,tag:XxkKxHkPdu+PQzll+bhRww==,type:str]
+sops:
+  azure_kv:
+    - created_at: "2026-06-18T11:41:33Z"
+      enc: WT6esWWwu_HiYMXT2_lGN8fznz24RruaFWpEtSiAGodop99CQh7Do7bjaFeeZkpop0PgRoiLGQoRKp_3rkwJ1JgVZecRh4jds65LheuAAMazF4VfZ4lpoqRj5XS4cKY0VB3WAD5dCuePJOuC48iD9Xc3d6ObARgCYtelhf6uNPkjQxedtr7oo_47xL-2y6skorULBst9Z1SglA-dcbHMjT9itOO5CbsFNURf2IsvNp8-AuG5MkCQaWDDe8gaL2MY7476oIY26jS7uQWEoluCwao-DNUdWK6VAYEI1PzNLBUKmgG7nTTO4OCmOi0pfT0iilr9aqZBhZPllNe5PihoVQ
+      name: sops-key
+      vault_url: https://dcdcftappsdevkv.vault.azure.net
+      version: aedb9ea38954430ca1d0a46ed589c049
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-18T11:41:33Z"
+  mac: ENC[AES256_GCM,data:8haT1Y1vAmE/gDhAcPiEIBJpNmi+Xlmy/6gRrUlZ/RcoiSWzY9XuCkm6O3KIAQWhm+2qafdQOh1bISBq4zzToShvfcxu1dZZ2E4z9KdyXekN5q+//XZXGRJXplDwLYejqpPznBJG+KMuyRgJx93A0ZzSf90Cure++346eOVZ9ds=,iv:JmeshEwuV13z6enIL67EkAZ/zj+K0clgKTJ3EqONvOk=,tag:8EVGykH1e9Vrdt/l++dWjg==,type:str]
+  version: 3.13.1

--- a/apps/cath/preview/sops-secrets/kustomization.yaml
+++ b/apps/cath/preview/sops-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cath-postgres-values.enc.yaml
+namespace: cath

--- a/apps/cath/preview/sops-secrets/kustomization.yaml
+++ b/apps/cath/preview/sops-secrets/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - cath-postgres-values.enc.yaml
-namespace: cath

--- a/apps/cath/serviceaccount/aat.yaml
+++ b/apps/cath/serviceaccount/aat.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "44cc0551-c274-4f95-a980-dba76fe70fda"

--- a/apps/flux-system/automation/kustomization.yaml
+++ b/apps/flux-system/automation/kustomization.yaml
@@ -57,6 +57,7 @@ resources:
   - ../../tax-tribunals/automation
   - ../../help-with-fees/automation
   - ../../pcs/automation
+  - ../../cath/automation
   - ../../enforcement/automation
   - ../../rota/automation
   - ../../labs/automation

--- a/clusters/aat/base/kustomization.yaml
+++ b/clusters/aat/base/kustomization.yaml
@@ -58,6 +58,7 @@ resources:
   - ../../../apps/et-pet/base/kustomize.yaml
   - ../../../apps/help-with-fees/base/kustomize.yaml
   - ../../../apps/pcs/base/kustomize.yaml
+  - ../../../apps/cath/base/kustomize.yaml
   - ../../../apps/enforcement/base/kustomize.yaml
   - ../../../apps/apim/base/kustomize.yaml
   - ../../../apps/coe/base/kustomize.yaml

--- a/clusters/preview/base/kustomization.yaml
+++ b/clusters/preview/base/kustomization.yaml
@@ -54,6 +54,7 @@ resources:
   - ../../../apps/keda/base/kustomize.yaml
   - ../../../apps/et-pet/base/kustomize.yaml
   - ../../../apps/pcs/base/kustomize.yaml
+  - ../../../apps/cath/base/kustomize.yaml
   - ../../../apps/enforcement/base/kustomize.yaml
   - ../../../apps/dynatrace/base/kustomize.yaml
   - ../../../apps/dynatrace/dynakube/kustomize.yaml


### PR DESCRIPTION
## Summary

- Adds `apps/cath/` kustomization structure for AAT and preview clusters
- Wires four HelmReleases (cath-web, cath-api, cath-crons, cath-postgres) sourced from `hmctsprod-oci`
- Registers image repos and policies for flux image automation
- Adds cath to `clusters/aat/base/kustomization.yaml`, `clusters/preview/base/kustomization.yaml`, and `apps/flux-system/automation/kustomization.yaml`
- Part of SDS → CNP migration (VIBE-465)

## Notes

- Managed identity client ID `44cc0551-c274-4f95-a980-dba76fe70fda` is the existing `cath-aat-mi` — will be preserved after terraform apply recreates it under the new module address
- `preview/sops-secrets/cath-postgres-values.enc.yaml` still needs generating with CNP SOPS key before preview deploys will work
- HelmRelease image tags are placeholder `prod-0000000-*` — image automation will update them on first reconcile