### PR TITLE
codeowners: update owners of the sdt services

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -120,6 +120,11 @@ apps/cui/ @hmcts/lau-admins
 ### Civil
 apps/civil/ @hmcts/civil-admins
 
+### Civil SDT
+apps/civil-sdt/ @hmcts/cgi-cloud-ready
+apps/civil-sdt-commissioning/ @hmcts/cgi-cloud-ready
+apps/civil-sdt-gateway/ @hmcts/cgi-cloud-ready
+
 ### WORK ALLOCATION
 apps/wa/ @hmcts/work-allocation
 apps/slack-help-bot/wa-slack-help-bot/ @hmcts/work-allocation


### PR DESCRIPTION
### Change description

currently at the moment the team respoonsible for civil-sdt applications need to contact the civil-admins despite SDT not being under their apps, updating codeowners to reflect this.

