### PR TITLE
POFCC-236: Adding missing gov.uk auth secret for Possessions

### DIFF
--- a/apps/fees-pay/ccpay-payment-api/demo.yaml
+++ b/apps/fees-pay/ccpay-payment-api/demo.yaml
@@ -69,6 +69,8 @@ spec:
               alias: gov.pay.auth.key.adoption_web
             - name: gov-pay-keys-prl
               alias: gov.pay.auth.key.prl_cos_api
+            - name: gov-pay-keys-pcs
+              alias: gov.pay.auth.key.pcs_api
             - name: liberata-keys-oauth2-client-id
               alias: liberata.oauth2.client.id
             - name: liberata-keys-oauth2-client-secret


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/POFCC-236

### Change description
GOV.UK Auth secret mapping which is missing in the overriden Flux configuration


### Testing done
N/A this is already live, just the flux config has overriden it with the value missing.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
