### PR TITLE
fix(sbox-intsvc): take out migration jenkins

### DIFF
--- a/apps/jenkins/sbox-intsvc/base/kustomization.yaml
+++ b/apps/jenkins/sbox-intsvc/base/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - ../../jenkins/sbox-intsvc/temporary-ingress.yaml
 - ../../jenkins/sbox-intsvc/sonarqube-ingress.yaml
 - ../../jenkins-webhook-relay/sbox-intsvc/jenkins-webhook-relay.enc.yaml
-- ../../jenkins/sbox-intsvc/jenkins-azurefiles-pv.yaml
-- ../../jenkins/sbox-intsvc/migration-job.yaml
+#- ../../jenkins/sbox-intsvc/jenkins-azurefiles-pv.yaml
+#- ../../jenkins/sbox-intsvc/migration-job.yaml
 
 patches:
 - path: ../../jenkins/sbox-intsvc/disk.yaml


### PR DESCRIPTION
take out migration jenkins for sandbox jenkins not functioning properly in the upgrade process

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

we found out migration Jenkins shares the PVC "jenkins" with sandbox Jenkins and as a result somehow sandbox Jenkins become not accessible. 


output of describe migration Jenkins 

 Warning  FailedScheduling   22m (x2 over 23m)      default-scheduler   0/7 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 3 node(s) didn't match pod affinity rules, 3 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/7 nodes are available: 1 No preemption victims found for incoming pod, 6 Preemption is not helpful for scheduling.
  Warning  FailedScheduling   22m (x2 over 22m)      default-scheduler   0/7 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 1 node(s) were unschedulable, 2 node(s) had untolerated taint(s), 3 node(s) didn't match pod affinity rules. no new claims to deallocate, preemption: 0/7 nodes are available: 1 No preemption victims found for incoming pod, 6 Preemption is not helpful for scheduling.
  Warning  FailedScheduling   21m (x4 over 21m)      default-scheduler   0/8 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 1 node(s) were unschedulable, 3 node(s) didn't match pod affinity rules, 3 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/8 nodes are available: 1 No preemption victims found for incoming pod, 7 Preemption is not helpful for scheduling.
  Warning  FailedScheduling   21m (x4 over 21m)      default-scheduler   0/9 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 1 node(s) were unschedulable, 3 node(s) didn't match pod affinity rules, 4 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/9 nodes are available: 1 No preemption victims found for incoming pod, 8 Preemption is not helpful for scheduling.
  Normal   NotTriggerScaleUp  20m (x3 over 21m)      cluster-autoscaler  pod didn't trigger scale-up: 2 node(s) had untolerated taint(s), 1 node(s) didn't match pod affinity rules, 1 not ready for scale-up
  Warning  FailedScheduling   7m55s (x9 over 21m)    default-scheduler   0/8 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 3 node(s) didn't match pod affinity rules, 4 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/8 nodes are available: 1 No preemption victims found for incoming pod, 7 Preemption is not helpful for scheduling.
  Warning  FailedScheduling   6m11s (x6 over 7m24s)  default-scheduler   0/8 nodes are available: 1 node(s) didn't satisfy existing pods anti-affinity rules, 2 node(s) had untolerated taint(s), 2 node(s) were unschedulable, 3 node(s) didn't match pod affinity rules. no new claims to deallocate, preemption: 0/8 nodes are available: 1 No preemption victims found for incoming pod, 7 Preemption is not helpful for scheduling.
  Normal   NotTriggerScaleUp  5m53s (x63 over 23m)   cluster-autoscaler  pod didn't trigger scale-up: 3 node(s) had untolerated taint(s), 1 node(s) didn't match pod affinity rules
  Normal   NotTriggerScaleUp  52s (x34 over 23m)     cluster-autoscaler  pod didn't trigger scale-up: 1 node(s) didn't match pod affinity rules, 3 node(s) had untolerated taint(s)


<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
