### PR TITLE
Fix sbox backstage image

### DIFF
--- a/apps/backstage/backstage/sbox-intsvc.yaml
+++ b/apps/backstage/backstage/sbox-intsvc.yaml
@@ -8,7 +8,6 @@ spec:
     ingress:
       host: backstage-sandbox.hmcts.net
     backend:
-      image: hmctsprod.azurecr.io/backstage-portal/backend:pr-69-5bdb1d6e-1780063769
       db:
         user: pgadmin
         host: hmcts-backstage-ptlsbox.postgres.database.azure.com


### PR DESCRIPTION
### Change description

Sandbox backstage isn't running due to `imagePullBackOff` error
Image it was using doesn't exist it seems

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
