### PR TITLE
DTSAM-1104 Enable `disposer_1_1` RAS flag in AAT

### DIFF
--- a/apps/am/am-role-assignment-service/aat.yaml
+++ b/apps/am/am-role-assignment-service/aat.yaml
@@ -15,7 +15,7 @@ spec:
         APPLICATION_LOGGING_LEVEL: INFO
         TESTING_SUPPORT_ENABLED: true
         BYPASS_ORG_DROOL_RULE: true
-        DB_FEATURE_FLAG_ENABLE: probate_wa_1_0
+        DB_FEATURE_FLAG_ENABLE: disposer_1_1
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api
         MAX_POOL_SIZE: 20
         DUMMY_VAR: true


### PR DESCRIPTION
### Jira link

[DTSAM-1104](https://tools.hmcts.net/jira/browse/DTSAM-1104) _"Enable 'disposer_1_1' RAS flag in a lower environment ready for R&D team to test"_

### Change description

Enable `disposer_1_1` RAS flag in **AAT** ready for R&D to test.

> NB: This enables the following change in *AAT*:
> * hmcts/am-role-assignment-service#2614