### PR TITLE
CUIRA-480 explicit allowed services list on prod

### DIFF
--- a/apps/cui/cui-ra/prod.yaml
+++ b/apps/cui/cui-ra/prod.yaml
@@ -21,5 +21,6 @@ spec:
       spotInstances:
         enabled: false
       environment:
+        S2S_ALLOWED_SERVICES: "prl_citizen_frontend"
         DEMO_ENABLED: false
         IS_DEV: false


### PR DESCRIPTION
### Jira link
CUIRA-480

### Change description
Split prod s2s allowed services from other environments

