### PR TITLE
Pin civil-citizen-ui perftest to PR #7833 (idempotent check-and-send)

### DIFF
--- a/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: perftest-civil-citizen-ui
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^pr-7833-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
   imageRepositoryRef:
     name: civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/perftest.yaml
+++ b/apps/civil/civil-citizen-ui/perftest.yaml
@@ -35,4 +35,4 @@ spec:
             - name: launch-darkly-sdk-key-non-prod
               alias: LAUNCH_DARKLY_SDK_KEY
       environment:
-        DUMMY_RESTART_VAR: true
+        DUMMY_RESTART_VAR: 1


### PR DESCRIPTION
## What
Pin the **civil-citizen-ui perftest** ImagePolicy to the PR #7833 build so the defensive fix can be validated under load before merge.

```yaml
filterTags:
  pattern: '^pr-7833-[a-f0-9]+-(?P<ts>[0-9]+)'
```
Selects ACR image `pr-7833-d6c077f-20260625131428` (latest PR #7833 build).

## Why
hmcts/civil-citizen-ui PR #7833 makes `/claim/check-and-send` idempotent (redirect to dashboard when the draft is already submitted, instead of a 500 `Case not found`). Root cause is confirmed under load on perftest (DTSCCI-5714). Deploying the PR build to perftest lets us verify the 500s are replaced by clean redirects before merging to master.

Mirrors the existing pin pattern used for `demo` (pr-7820) and civil-service perftest (pr-7867).

## Revert
Once PR #7833 is merged to master, this policy should be reverted to bare (no `filterTags`) so perftest resumes tracking master builds.