### PR TITLE
DTSPO-32266: Patch non-prod (ptl-sbox) artifactory to 107.146.17 [DO NOT MERGE until after 5PM]

### DIFF
--- a/apps/artifactory/artifactory/artifactory-sbox.yaml
+++ b/apps/artifactory/artifactory/artifactory-sbox.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: artifactory-oss
+  namespace: artifactory
+spec:
+  chart:
+    spec:
+      chart: artifactory-oss
+      version: 107.146.17

--- a/apps/artifactory/sbox-intsvc/base/kustomization.yaml
+++ b/apps/artifactory/sbox-intsvc/base/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
 
 patches:
   - path: ../ingress-patch.yaml
+patchesStrategicMerge:
+  - ../../artifactory/artifactory-sbox.yaml


### PR DESCRIPTION
## What
Patches Artifactory on the CFT PTLSBOX (sandbox / non-prod) cluster: 107.133.12 → 107.146.17.

- New `artifactory-sbox.yaml` — HelmRelease override pinning sbox to 107.146.17
- `sbox-intsvc/base/kustomization.yaml` — wires it in via patchesStrategicMerge

Production (CFT PTL) is unchanged on 107.133.12; promoted in a follow-up PR after sandbox is verified.

## Impact
Artifactory on PTLSBOX briefly unavailable while `artifactory-oss-0` redeploys. Flux applies ~1 min after merge.

## Notes
- DO NOT MERGE until after 5PM (quiet window) — the merge is the disruptive trigger.
- Ticket: DTSPO-32266