### PR TITLE
ADOP-2865 Add North Somerset Council

### DIFF
--- a/apps/adoption/adoption-web/adoption-web.yaml
+++ b/apps/adoption/adoption-web/adoption-web.yaml
@@ -209,6 +209,7 @@ spec:
         WSC_VAL: 'Wiltshire Council'
         SBCO_VAL: 'Swindon Borough Council'
         SCCO_VAL: 'Somerset County Council'
+        NSC_VAL: 'North Somerset Council'
         BCPC_VAL: 'Bournemouth, Christchurch & Poole council (BCP)'
         DCCO_VAL: 'Dorset County Council'
         LBH_VAL: 'London Borough Hillingdon'


### PR DESCRIPTION
### Jira link
[ADOP-2865](https://tools.hmcts.net/jira/browse/ADOP-2865)

### Change description
Add North Somerset Council to all environments.
Should be deployed with https://github.com/hmcts/adoption-web/pull/1832

### Testing done
See jira.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [ ] Does this PR introduce a breaking change
