### PR TITLE
Allow WA reporting frontend in RAS S2S config

### DIFF
--- a/apps/am/am-role-assignment-service/aat.yaml
+++ b/apps/am/am-role-assignment-service/aat.yaml
@@ -16,6 +16,6 @@ spec:
         TESTING_SUPPORT_ENABLED: true
         BYPASS_ORG_DROOL_RULE: true
         DB_FEATURE_FLAG_ENABLE: disposer_1_1
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_task_monitor,wa_case_event_handler,iac,ccd_case_disposer,hmc_cft_hearing_service,rd_caseworker_ref_api,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api,wa_reporting_frontend
         MAX_POOL_SIZE: 20
         DUMMY_VAR: true

--- a/apps/am/am-role-assignment-service/demo.yaml
+++ b/apps/am/am-role-assignment-service/demo.yaml
@@ -12,6 +12,6 @@ spec:
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 10
         DB_FEATURE_FLAG_ENABLE: disposer_1_1
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_management_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_management_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,et_cos,disposer-idam-user,civil_service,prl_cos_api,pcs_api,wa_reporting_frontend
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false

--- a/apps/am/am-role-assignment-service/ithc.yaml
+++ b/apps/am/am-role-assignment-service/ithc.yaml
@@ -9,6 +9,6 @@ spec:
       environment:
         AM_INFO: true
         APPLICATION_LOGGING_LEVEL: DEBUG
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api,wa_reporting_frontend
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false

--- a/apps/am/am-role-assignment-service/perftest.yaml
+++ b/apps/am/am-role-assignment-service/perftest.yaml
@@ -11,6 +11,6 @@ spec:
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 20
         DB_FEATURE_FLAG_ENABLE: sscs_wa_1_0
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api,wa_reporting_frontend
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false

--- a/apps/am/am-role-assignment-service/prod.yaml
+++ b/apps/am/am-role-assignment-service/prod.yaml
@@ -13,7 +13,7 @@ spec:
         AM_INFO: false
         OPEN_ID_API_BASE_URI: https://hmcts-access.service.gov.uk/o
         IDAM_USER_URL: https://idam-api.platform.hmcts.net
-        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api
+        ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,wa_reporting_frontend
         APPLICATION_LOGGING_LEVEL: INFO
         BYPASS_ORG_DROOL_RULE: false
         MAX_POOL_SIZE: 20


### PR DESCRIPTION
## Summary
- Add `wa_reporting_frontend` to `ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES` for the RAS Flux overlays.
- Covers AAT, demo, ITHC, perftest, and prod where Flux overrides the RAS S2S allow-list.

## Related PRs
- WA Reporting frontend: https://github.com/hmcts/wa-reporting-frontend/pull/367
- RAS chart/default allow-list: https://github.com/hmcts/am-role-assignment-service/pull/2758
- Service Auth Provider S2S key mapping: https://github.com/hmcts/service-auth-provider-app/pull/1121

## Verification
- `git diff --check`
- Confirmed all five RAS environment overlays include `wa_reporting_frontend`.