### PR TITLE
removing redundant www-ccd entry

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/perftest.yaml
+++ b/apps/ccd/ccd-api-gateway-web/perftest.yaml
@@ -10,7 +10,6 @@ spec:
       autoscaling:
         enabled: false
       environment:
-        CORS_ORIGIN_WHITELIST: "https://manage-case.perftest.platform.hmcts.net,https://www-ccd.perftest.platform.hmcts.net"
-        TIMING-ALLOW-ORIGIN: "https://www-ccd.perftest.platform.hmcts.net"
+        CORS_ORIGIN_WHITELIST: "https://manage-case.perftest.platform.hmcts.net"
         UV_THREADPOOL_SIZE: 128
         DUMMY_VAR: 0


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CME-912

### Change description

After initial release, it was advised that www.ccd was the app prior to manage case and is now no longer needed, as such this is a pr to tidy up and remove this url.

### Testing done


### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
