### PR TITLE
removing redundant www.ccd link

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/demo.yaml
+++ b/apps/ccd/ccd-api-gateway-web/demo.yaml
@@ -8,6 +8,5 @@ spec:
     nodejs:
       image: hmctsprod.azurecr.io/ccd/api-gateway-web:prod-78126c8-20260629170117 #{"$imagepolicy": "flux-system:demo-ccd-api-gateway-web"}
       environment:
-        CORS_ORIGIN_WHITELIST: "https://manage-case.demo.platform.hmcts.net,https://www-ccd.demo.platform.hmcts.net"
-        TIMING-ALLOW-ORIGIN: "https://www-ccd.demo.platform.hmcts.net"
+        CORS_ORIGIN_WHITELIST: "https://manage-case.demo.platform.hmcts.net"
         DUMMY_VAR_TO_REDEPLOY: 1


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CME-912

### Change description

After initial release, it was advised that www.ccd was the app prior to manage case and is now no longer needed, as such this is a pr to tidy up and remove this url.

### Testing done


### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
* [ ] Yes
* [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
