### PR TITLE
removing redundant www-ccd links

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/ithc.yaml
+++ b/apps/ccd/ccd-api-gateway-web/ithc.yaml
@@ -11,4 +11,3 @@ spec:
       image: hmctsprod.azurecr.io/ccd/api-gateway-web:prod-78126c8-20260629170117 #{"$imagepolicy": "flux-system:ithc-ccd-api-gateway-web"}
       environment:
         CORS_ORIGIN_WHITELIST: "https://xui-webapp-ithc.service.core-compute-ithc.internal,https://manage-case.ithc.platform.hmcts.net"
-        TIMING-ALLOW-ORIGIN: "https://www-ccd.ithc.platform.hmcts.net"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CME-912

### Change description

After initial release, it was advised that www.ccd was the app prior to manage case and is now no longer needed, as such this is a pr to tidy up and remove this url.

### Testing done


### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
* [ ] Yes
* [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
