### PR TITLE
removing redundant www.ccd addresses

### DIFF
--- a/apps/ccd/ccd-api-gateway-web/prod.yaml
+++ b/apps/ccd/ccd-api-gateway-web/prod.yaml
@@ -15,5 +15,4 @@ spec:
         IDAM_OAUTH2_LOGOUT_ENDPOINT: https://idam-api.platform.hmcts.net/session/:token
         IDAM_OAUTH2_TOKEN_ENDPOINT: https://idam-api.platform.hmcts.net/oauth2/token
         DUMMY_VAR_TO_REDEPLOY: 1000
-        CORS_ORIGIN_WHITELIST: "https://www.ccd.platform.hmcts.net,https://ccd.platform.hmcts.net,https://manage-case.platform.hmcts.net"
-        TIMING-ALLOW-ORIGIN: "https://www.ccd.platform.hmcts.net"
+        CORS_ORIGIN_WHITELIST: "https://manage-case.platform.hmcts.net"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/CME-912

### Change description

After initial release, it was advised that www.ccd was the app prior to manage case and is now no longer needed, as such this is a pr to tidy up and remove this url.

### Testing done


### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
* [ ] Yes
* [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
