### PR TITLE
Update ET preview PostgreSQL to 15

### DIFF
--- a/apps/et/preview/aso/et-postgres.yaml
+++ b/apps/et/preview/aso/et-postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
-  version: "14"
+  version: "15"
   sku:
     name: Standard_D2ds_v5
     tier: GeneralPurpose


### PR DESCRIPTION
Updates the ET preview flexible server from PostgreSQL 14 to 15 so preview matches the ET database version used outside preview. This is needed for CCD SDK queries that use PostgreSQL MERGE.