### PR TITLE
civil: DTSCCI-5764 CronJob to build dashboard_notifications FK index (aat/demo/ithc/perftest/prod-00)

### DIFF
--- a/apps/civil/aat/00/kustomization.yaml
+++ b/apps/civil/aat/00/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  # DTSCCI-5764 one-off index build — aat-00 ONLY (test env; validate here first).
+  - ../../civil-service/dashboard-notif-index-cronjob.yaml
 namespace: civil
 patches:
   - path: ../../civil-sdt/aat-00.yaml

--- a/apps/civil/civil-service/dashboard-notif-index-cronjob.yaml
+++ b/apps/civil/civil-service/dashboard-notif-index-cronjob.yaml
@@ -1,0 +1,96 @@
+# DTSCCI-5764 — one-off, decoupled build of the missing FK index on
+# dbs.dashboard_notifications(notification_action_id), which is causing
+# multi-minute DELETEs on notification_action (and stuck DASHBOARD_NOTIFICATION_EVENT).
+#
+# Runs CONCURRENTLY (non-blocking) at 02:00 UTC — the only window with zero slow
+# deletes across the last week. Idempotent (IF NOT EXISTS) and self-healing
+# (drops an INVALID leftover from any aborted concurrent build before rebuilding).
+#
+# Referenced from the <env>/00 kustomization of each environment (aat, demo,
+# ithc, perftest, prod) — the "00" cluster ONLY. In prod the 00/01 clusters share
+# one database, so a single build avoids a race; in the lower envs civil-service
+# runs on cluster 00. (ithc is on-demand; the CronJob deploys when ithc is next
+# reconciled.) The
+# manifest is env-agnostic: it reuses SA "civil" + SecretProviderClass
+# "civil-service-java-civil", whose cmc-db-*-v15 secret files exist identically in
+# every env (only the backing keyvault differs, which the SPC handles).
+#
+# Test in aat and demo first: once Flux deploys the CronJob, trigger an immediate
+# run rather than waiting for 02:00 —
+#   kubectl -n civil create job --from=cronjob/dashboard-notif-index-builder dnib-test
+# then check the job log for "OK: index valid".
+#
+# One-off: delete this file and all three resources entries once the index is
+# confirmed valid in prod.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dashboard-notif-index-builder
+  namespace: civil
+  labels:
+    app: civil-service
+    jira: DTSCCI-5764
+spec:
+  schedule: "0 2 * * *"            # 02:00 UTC — quiet window
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0               # do not auto-retry a killed CONCURRENTLY build
+      activeDeadlineSeconds: 1800
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app: civil-service
+            azure.workload.identity/use: "true"
+        spec:
+          serviceAccountName: civil
+          restartPolicy: Never
+          nodeSelector:
+            agentpool: cronjob
+          tolerations:
+            - key: dedicated
+              effect: NoSchedule
+              operator: Equal
+              value: jobs
+          containers:
+            - name: idx
+              image: hmctsprod.azurecr.io/imported/bitnami/postgresql:16.5.0
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  export PGHOST="$(cat /mnt/secrets/civil/cmc-db-host-v15)"
+                  export PGUSER="$(cat /mnt/secrets/civil/cmc-db-username-v15)"
+                  export PGPASSWORD="$(cat /mnt/secrets/civil/cmc-db-password-v15)"
+                  export PGDATABASE=cmc PGPORT=5432 PGSSLMODE=require PGCONNECT_TIMEOUT=15
+                  export PGOPTIONS="-c lock_timeout=60000"   # NOT statement_timeout (would abort a concurrent build)
+                  IDX="dbs.idx_dashboard_notifications_notification_action_id"
+                  echo "Checking for an INVALID leftover index..."
+                  INVALID=$(psql -tAqc "SELECT NOT indisvalid FROM pg_index WHERE indexrelid = to_regclass('${IDX}');" || true)
+                  if [ "${INVALID}" = "t" ]; then
+                    echo "Found INVALID index -> dropping"
+                    psql -v ON_ERROR_STOP=1 -c "DROP INDEX CONCURRENTLY IF EXISTS ${IDX};"
+                  fi
+                  echo "Building index CONCURRENTLY (non-blocking)..."
+                  psql -v ON_ERROR_STOP=1 -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_notifications_notification_action_id ON dbs.dashboard_notifications(notification_action_id);"
+                  echo "Verifying index is valid..."
+                  psql -v ON_ERROR_STOP=1 -tAc "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass('${IDX}');" | grep -qx "t" \
+                    && echo "OK: index valid" || { echo "FAIL: index missing or invalid"; exit 1; }
+              volumeMounts:
+                - name: vault-civil
+                  mountPath: /mnt/secrets/civil
+                  readOnly: true
+              resources:
+                requests: { cpu: 50m, memory: 128Mi }
+                limits: { cpu: 250m, memory: 256Mi }
+          volumes:
+            - name: vault-civil
+              csi:
+                driver: secrets-store.csi.k8s.io
+                readOnly: true
+                volumeAttributes:
+                  secretProviderClass: civil-service-java-civil

--- a/apps/civil/demo/00/kustomization.yaml
+++ b/apps/civil/demo/00/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: civil
 resources:
 - ../base
+# DTSCCI-5764 one-off index build — demo-00 ONLY (test env; validate here first).
+- ../../civil-service/dashboard-notif-index-cronjob.yaml
 patches:
 - path: ../../civil-sdt/demo-00.yaml

--- a/apps/civil/ithc/00/kustomization.yaml
+++ b/apps/civil/ithc/00/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: civil
 resources:
 - ../base
+# DTSCCI-5764 one-off index build — ithc-00 ONLY (civil-service runs on 00).
+- ../../civil-service/dashboard-notif-index-cronjob.yaml
 patches:
 - path: ../../civil-sdt/ithc-00.yaml

--- a/apps/civil/perftest/00/kustomization.yaml
+++ b/apps/civil/perftest/00/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: civil
 resources:
 - ../base
+# DTSCCI-5764 one-off index build — perftest-00 ONLY (civil-service runs on 00).
+- ../../civil-service/dashboard-notif-index-cronjob.yaml
 patches:
 - path: ../../civil-sdt/perftest-00.yaml

--- a/apps/civil/prod/00/kustomization.yaml
+++ b/apps/civil/prod/00/kustomization.yaml
@@ -3,5 +3,9 @@ kind: Kustomization
 namespace: civil
 resources:
 - ../base
+# DTSCCI-5764 one-off index build — 00 cluster ONLY (00/01 share one DB;
+# a single CronJob avoids two concurrent builds racing on the same index). Remove
+# once the index is confirmed valid in prod.
+- ../../civil-service/dashboard-notif-index-cronjob.yaml
 patches:
 - path: ../../civil-sdt/prod-00.yaml


### PR DESCRIPTION
## What

One-off CronJob that builds the missing index:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_notifications_notification_action_id
    ON dbs.dashboard_notifications(notification_action_id);
```

Rolled out to **aat, demo, ithc, perftest, and prod** — each referenced from its **`00` cluster only** (in prod the 00/01 clusters share one DB, so a single CronJob avoids two concurrent builds racing on the same index; in the lower envs civil-service runs on cluster 00). ithc is on-demand, so its CronJob deploys when ithc is next reconciled.

## Why

`dbs.dashboard_notifications.notification_action_id` is a FK to `notification_action(id)` with **no index**, so every `DELETE` from `notification_action` full-scans `dashboard_notifications` (~700k rows in prod) to enforce the FK → **5–8 minute deletes** that stall `DASHBOARD_NOTIFICATION_EVENT` (DTSCCI-5764) and pressure the connection pool. The index turns the per-delete full scan into an index lookup. Diagnosis: **DTSCCI-5764**.

## Test in lower envs first (aat / demo / perftest / ithc)

Once Flux reconciles, don't wait for 02:00 — trigger an immediate run:

```bash
kubectl -n civil create job --from=cronjob/dashboard-notif-index-builder dnib-test
kubectl -n civil logs job/dnib-test        # expect: "OK: index valid"
```

Confirm `pg_index.indisvalid = t` and that the job completes, then promote confidence to prod.

## Design

- **`CONCURRENTLY`** — never blocks writes; built out-of-band so the app deploy stays a no-op (Flyway migration is `IF NOT EXISTS`). Kept even at the quiet 02:00 window as cheap insurance against any scheduled/batch write coinciding.
- **02:00 UTC** (prod) — the only window with zero slow deletes over the last 7 days. In lower envs the schedule is immaterial (tiny DBs); use the manual trigger above.
- **Idempotent + self-healing** — `IF NOT EXISTS`; drops an `INVALID` leftover from any aborted build before rebuilding. `backoffLimit: 0`; no `statement_timeout` (would abort a concurrent build).
- **Env-agnostic manifest** — reuses SA `civil` + SecretProviderClass `civil-service-java-civil`; the `cmc-db-*-v15` secret files exist identically in every env (only the backing keyvault differs, handled by the SPC). Verified against live aat/demo/perftest/prod deployments; ithc matches by config (env was not up to live-check).

## One-off cleanup

Delete `apps/civil/civil-service/dashboard-notif-index-cronjob.yaml` and the five `resources` entries once the index is confirmed valid in prod (follow-up PR).

## Alternative considered

The `automated-db-queries` / DTS Auto DB Query tooling (already RBAC'd into the civil namespace) could run this interactively as a one-shot instead of a scheduled CronJob — flagged for reviewers.