### PR TITLE
civil: DTSCCI-5764 run index build soon in aat/demo/perftest (validate before prod)

### DIFF
--- a/apps/civil/aat/00/kustomization.yaml
+++ b/apps/civil/aat/00/kustomization.yaml
@@ -7,3 +7,13 @@ resources:
 namespace: civil
 patches:
   - path: ../../civil-sdt/aat-00.yaml
+  # DTSCCI-5764: run the index build soon in lower envs so aat/demo/perftest
+  # validate before prod's 02:00 run (prod schedule is unchanged). Idempotent, so
+  # the ~15-min re-runs are harmless no-ops until the cleanup PR removes the job.
+  - target:
+      kind: CronJob
+      name: dashboard-notif-index-builder
+    patch: |-
+      - op: replace
+        path: /spec/schedule
+        value: "*/15 * * * *"

--- a/apps/civil/demo/00/kustomization.yaml
+++ b/apps/civil/demo/00/kustomization.yaml
@@ -7,3 +7,13 @@ resources:
 - ../../civil-service/dashboard-notif-index-cronjob.yaml
 patches:
 - path: ../../civil-sdt/demo-00.yaml
+# DTSCCI-5764: run the index build soon in lower envs so aat/demo/perftest
+# validate before prod's 02:00 run (prod schedule is unchanged). Idempotent, so
+# the ~15-min re-runs are harmless no-ops until the cleanup PR removes the job.
+- target:
+    kind: CronJob
+    name: dashboard-notif-index-builder
+  patch: |-
+    - op: replace
+      path: /spec/schedule
+      value: "*/15 * * * *"

--- a/apps/civil/perftest/00/kustomization.yaml
+++ b/apps/civil/perftest/00/kustomization.yaml
@@ -7,3 +7,13 @@ resources:
 - ../../civil-service/dashboard-notif-index-cronjob.yaml
 patches:
 - path: ../../civil-sdt/perftest-00.yaml
+# DTSCCI-5764: run the index build soon in lower envs so aat/demo/perftest
+# validate before prod's 02:00 run (prod schedule is unchanged). Idempotent, so
+# the ~15-min re-runs are harmless no-ops until the cleanup PR removes the job.
+- target:
+    kind: CronJob
+    name: dashboard-notif-index-builder
+  patch: |-
+    - op: replace
+      path: /spec/schedule
+      value: "*/15 * * * *"


### PR DESCRIPTION
## What

Follow-up to #45957. Patches the `dashboard-notif-index-builder` CronJob **schedule to `*/15 * * * *` in aat, demo, and perftest only** (via a kustomize patch in each `<env>/00`). **Prod is unchanged** (`0 2 * * *`).

## Why

The index-build CronJob merged in #45957 with a `0 2 * * *` schedule in every env, so aat/demo/perftest would only run at the same time as prod — no chance to validate the lower envs first. Manual triggering (`kubectl create job --from=cronjob/...`) isn't available to us (read-only namespace RBAC; job creation is restricted to the DTS Auto DB Query tooling), so this brings the lower-env run forward via GitOps instead.

Once merged and Flux reconciles, the build runs within ~15 min in each lower env; we confirm `OK: index valid` / `pg_index.indisvalid = t`, then let prod run at 02:00 UTC with confidence.

## Safe because

- **Idempotent** — `CREATE INDEX CONCURRENTLY IF NOT EXISTS`; once built, the ~15-min re-runs are no-ops (they just re-verify and exit).
- **Self-healing** — drops an `INVALID` leftover from any aborted build before rebuilding.
- **Lower envs only** — prod stays on the deliberate 02:00 quiet-window schedule.

## Cleanup

The existing cleanup PR (removing the CronJob after prod is validated) also removes these schedule patches.