### PR TITLE
civil: DTSCCI-5764 fix secret filenames in index CronJob (objectAlias)

### DIFF
--- a/apps/civil/civil-service/dashboard-notif-index-cronjob.yaml
+++ b/apps/civil/civil-service/dashboard-notif-index-cronjob.yaml
@@ -63,9 +63,11 @@ spec:
               args:
                 - |
                   set -euo pipefail
-                  export PGHOST="$(cat /mnt/secrets/civil/cmc-db-host-v15)"
-                  export PGUSER="$(cat /mnt/secrets/civil/cmc-db-username-v15)"
-                  export PGPASSWORD="$(cat /mnt/secrets/civil/cmc-db-password-v15)"
+                  # NB: SecretProviderClass civil-service-java-civil mounts each secret
+                  # under its objectAlias, so the files are CMC_DB_* not cmc-db-*-v15.
+                  export PGHOST="$(cat /mnt/secrets/civil/CMC_DB_HOST)"
+                  export PGUSER="$(cat /mnt/secrets/civil/CMC_DB_USERNAME)"
+                  export PGPASSWORD="$(cat /mnt/secrets/civil/CMC_DB_PASSWORD)"
                   export PGDATABASE=cmc PGPORT=5432 PGSSLMODE=require PGCONNECT_TIMEOUT=15
                   export PGOPTIONS="-c lock_timeout=60000"   # NOT statement_timeout (would abort a concurrent build)
                   IDX="dbs.idx_dashboard_notifications_notification_action_id"


### PR DESCRIPTION
## Fix

Follow-up to #45957 / #45963. The index-build CronJob failed in **all lower envs** (aat/demo/perftest) with:

```
cat: /mnt/secrets/civil/cmc-db-host-v15: No such file or directory
psql: error: local user with ID 1001 does not exist
```

Root cause: `SecretProviderClass civil-service-java-civil` mounts each secret under its **`objectAlias`**, so the files at `/mnt/secrets/civil/` are named `CMC_DB_HOST` / `CMC_DB_USERNAME` / `CMC_DB_PASSWORD`, not the raw `cmc-db-*-v15` objectNames I read. Empty creds then triggered the `psql` OS-user fallback (`1001` isn't in `/etc/passwd`).

This changes the three `cat` paths to the alias filenames. Nothing else changes.

## Why prod was safe

This is exactly why we validated in lower envs first (via #45963's `*/15` schedule): the bug surfaced in aat/demo/perftest and **prod never ran it** (prod stays `0 2 * * *`). Once this merges and Flux reconciles, the next `*/15` run in the lower envs picks up the corrected script and should print `OK: index valid`.