### PR TITLE
civil: DTSCCI-5764 escape shell vars in index CronJob (Flux postBuild)

### DIFF
--- a/apps/civil/civil-service/dashboard-notif-index-cronjob.yaml
+++ b/apps/civil/civil-service/dashboard-notif-index-cronjob.yaml
@@ -70,17 +70,19 @@ spec:
                   export PGPASSWORD="$(cat /mnt/secrets/civil/CMC_DB_PASSWORD)"
                   export PGDATABASE=cmc PGPORT=5432 PGSSLMODE=require PGCONNECT_TIMEOUT=15
                   export PGOPTIONS="-c lock_timeout=60000"   # NOT statement_timeout (would abort a concurrent build)
+                  # NB: shell vars are written $${VAR} so Flux postBuild.substitute
+                  # passes them through literally (it would otherwise blank ${VAR}).
                   IDX="dbs.idx_dashboard_notifications_notification_action_id"
                   echo "Checking for an INVALID leftover index..."
-                  INVALID=$(psql -tAqc "SELECT NOT indisvalid FROM pg_index WHERE indexrelid = to_regclass('${IDX}');" || true)
-                  if [ "${INVALID}" = "t" ]; then
+                  INVALID=$(psql -tAqc "SELECT NOT indisvalid FROM pg_index WHERE indexrelid = to_regclass('$${IDX}');" || true)
+                  if [ "$${INVALID}" = "t" ]; then
                     echo "Found INVALID index -> dropping"
-                    psql -v ON_ERROR_STOP=1 -c "DROP INDEX CONCURRENTLY IF EXISTS ${IDX};"
+                    psql -v ON_ERROR_STOP=1 -c "DROP INDEX CONCURRENTLY IF EXISTS $${IDX};"
                   fi
                   echo "Building index CONCURRENTLY (non-blocking)..."
                   psql -v ON_ERROR_STOP=1 -c "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_notifications_notification_action_id ON dbs.dashboard_notifications(notification_action_id);"
                   echo "Verifying index is valid..."
-                  psql -v ON_ERROR_STOP=1 -tAc "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass('${IDX}');" | grep -qx "t" \
+                  psql -v ON_ERROR_STOP=1 -tAc "SELECT indisvalid FROM pg_index WHERE indexrelid = to_regclass('$${IDX}');" | grep -qx "t" \
                     && echo "OK: index valid" || { echo "FAIL: index missing or invalid"; exit 1; }
               volumeMounts:
                 - name: vault-civil


### PR DESCRIPTION
## Fix

Follow-up to #45966. After the secret-filename fix, the lower-env runs connected fine but failed verification:

```
Checking for an INVALID leftover index...
ERROR:  invalid name syntax
Building index CONCURRENTLY (non-blocking)...
CREATE INDEX
Verifying index is valid...
ERROR:  invalid name syntax
FAIL: index missing or invalid
```

Root cause: **Flux `postBuild.substitute`** (configured on `apps/civil`) replaces `${VAR}` tokens in the resource. My shell variables `${IDX}` / `${INVALID}` aren't Flux substitution vars, so Flux blanked them - the rendered in-cluster script had `to_regclass('')`, which throws `invalid name syntax`. (The `CREATE INDEX` line uses the literal index name with no `${...}`, which is why it succeeded.)

Fix: write the shell vars as `$${IDX}` / `$${INVALID}` so Flux emits literal `${IDX}` / `${INVALID}` for the shell to expand. The `$(cat ...)` credential reads were already safe (not `${...}`).

## Note

The index was almost certainly **already built** in aat/demo/perftest by the literal-name `CREATE INDEX` - only the check/verify steps were broken. Once this reconciles, the next `*/15` run will confirm `OK: index valid` (idempotent, so it just re-verifies). Prod still on `0 2 * * *`, untouched.