### PR TITLE
Set ET AAT indexing hosts

### DIFF
--- a/apps/et/et-cos/aat.yaml
+++ b/apps/et/et-cos/aat.yaml
@@ -13,7 +13,7 @@ spec:
         ET_CCD_DATA_MIGRATION_ENABLED: false
         CCD_SDK_DECENTRALISED: true
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
-        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-aat.internal:9200,http://ccd-data-1.service.core-compute-aat.internal:9200,http://ccd-data-2.service.core-compute-aat.internal:9200,http://ccd-data-3.service.core-compute-aat.internal:9200
+        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-aat.internal:9200
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 9-17 * * *" # every 10mins between 9am and 5pm (db lock prevents paralell running)
         ET_CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration
         ET_CCD_DATA_MIGRATION_MODE: CUTOVER

--- a/apps/et/et-cos/aat.yaml
+++ b/apps/et/et-cos/aat.yaml
@@ -11,7 +11,9 @@ spec:
         CREATE_UPDATES_POLL_INTERVAL: 60000
         UPDATE_CASE_POLL_INTERVAL: 60000
         ET_CCD_DATA_MIGRATION_ENABLED: false
+        CCD_SDK_DECENTRALISED: true
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
+        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-aat.internal:9200,http://ccd-data-1.service.core-compute-aat.internal:9200,http://ccd-data-2.service.core-compute-aat.internal:9200,http://ccd-data-3.service.core-compute-aat.internal:9200
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 9-17 * * *" # every 10mins between 9am and 5pm (db lock prevents paralell running)
         ET_CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration
         ET_CCD_DATA_MIGRATION_MODE: CUTOVER


### PR DESCRIPTION
## What changed
- Set ET AAT runtime to decentralised mode.
- Point the ET AAT embedded ES indexer at the first CCD AAT Elasticsearch node.

## Why
The AAT cutover enables the embedded ES indexer, but without ELASTIC_SEARCH_HOSTS it would use the runtime default of localhost:9200 and fail to drain ccd.es_queue.

## Validation
- Parsed apps/et/et-cos/aat.yaml with PyYAML.
- Ran git diff --check.