### PR TITLE
Add XUI media viewer AAT deployment

### DIFF
--- a/apps/xui/aat/base/kustomization.yaml
+++ b/apps/xui/aat/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../xui-media-viewer/xui-media-viewer.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../rbac/db-query-job-role.yaml
   - register-org-ingress.yaml

--- a/apps/xui/automation/kustomization.yaml
+++ b/apps/xui/automation/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../xui-media-viewer/image-repo.yaml
+  - ../xui-media-viewer/image-policy.yaml
   - ../xui-mo-webapp/image-repo.yaml
   - ../xui-mo-webapp/image-policy.yaml
   - ../xui-mo-webapp/demo-image-policy.yaml

--- a/apps/xui/xui-media-viewer/image-policy.yaml
+++ b/apps/xui/xui-media-viewer/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: xui-media-viewer
+spec:
+  imageRepositoryRef:
+    name: xui-media-viewer

--- a/apps/xui/xui-media-viewer/image-repo.yaml
+++ b/apps/xui/xui-media-viewer/image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: xui-media-viewer
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
+spec:
+  image: hmctsprod.azurecr.io/xui/media-viewer

--- a/apps/xui/xui-media-viewer/xui-media-viewer.yaml
+++ b/apps/xui/xui-media-viewer/xui-media-viewer.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: xui-media-viewer
+spec:
+  releaseName: xui-media-viewer
+  values:
+    nodejs:
+      replicas: 1
+      autoscaling:
+        enabled: true
+        maxReplicas: 1 # Staging pod for validating the media-viewer package before retiring em-media-viewer.
+      useInterpodAntiAffinity: true
+      image: hmctsprod.azurecr.io/xui/media-viewer:latest #{"$imagepolicy": "flux-system:xui-media-viewer"}
+      environment:
+        VAR_T3: trigger1
+  chart:
+    spec:
+      chart: ./stable/xui-media-viewer
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/xui/xui-media-viewer/xui-media-viewer.yaml
+++ b/apps/xui/xui-media-viewer/xui-media-viewer.yaml
@@ -11,7 +11,7 @@ spec:
         enabled: true
         maxReplicas: 1 # Staging pod for validating the media-viewer package before retiring em-media-viewer.
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/xui/media-viewer:latest #{"$imagepolicy": "flux-system:xui-media-viewer"}
+      image: hmctsprod.azurecr.io/xui/media-viewer:prod-fa0d8f2-20260706133108 #{"$imagepolicy": "flux-system:xui-media-viewer"}
       environment:
         VAR_T3: trigger1
   chart:

--- a/tests/dry-run-kustomize.sh
+++ b/tests/dry-run-kustomize.sh
@@ -30,6 +30,37 @@ split_files() {
     cd "$CURRENT_DIRECTORY"
 }
 
+run_kubeconform() {
+    local attempt=1
+    local max_attempts=4
+    local retry_delay=20
+    local status
+    local output_file
+    output_file=$(mktemp)
+
+    while true; do
+        set +e
+        kubeconform "${kubeconform_config[@]}" "$TMP_DIR" 2>&1 | tee "$output_file"
+        status=${PIPESTATUS[0]}
+        set -e
+
+        if [[ "$status" -eq 0 ]]; then
+            rm -f "$output_file"
+            return 0
+        fi
+
+        if grep -q "received HTTP status 429" "$output_file" && grep -q "Invalid: 0" "$output_file" && [[ "$attempt" -lt "$max_attempts" ]]; then
+            echo "Kubeconform schema download was rate limited. Retrying attempt $((attempt + 1))/$max_attempts after ${retry_delay}s..."
+            sleep "$retry_delay"
+            attempt=$((attempt + 1))
+            retry_delay=$((retry_delay * 2))
+            continue
+        fi
+
+        rm -f "$output_file"
+        return "$status"
+    done
+}
 
 if [[ -d "clusters/$ENVIRONMENT/$CLUSTER" ]]; then
     TMP_DIR="/tmp/$ENVIRONMENT/$CLUSTER/"
@@ -68,5 +99,5 @@ if [[ -d "clusters/$ENVIRONMENT/$CLUSTER" ]]; then
     rm -rf CustomResourceDefinition-*
     cd "$CURRENT_DIRECTORY"
 
-    kubeconform "${kubeconform_config[@]}" "$TMP_DIR"
+    run_kubeconform
 fi


### PR DESCRIPTION
### Jira link

See [EXUI-4915](https://tools.hmcts.net/jira/browse/EXUI-4915)

### Change description

Add the permanent AAT deployment wiring for `rpx-xui-media-viewer` in the `xui` namespace.

This is part of porting `em-media-viewer` to `rpx-xui-media-viewer`. The application behaviour stays equivalent, but the platform configuration moves to the XUI/RPX shape:
- namespace: `xui`
- image repository: `hmctsprod.azurecr.io/xui/media-viewer`
- chart: `stable/xui-media-viewer`
- Key Vault/config: RPX-backed chart values
- AAT endpoint: `http://xui-media-viewer-aat.service.core-compute-aat.internal`

This PR:
- adds the `xui-media-viewer` HelmRelease for AAT
- adds the Flux ImageRepository and ImagePolicy for `xui/media-viewer`
- includes `xui-media-viewer` in the XUI AAT base kustomization
- includes the new image automation resources in the XUI automation kustomization
- adds bounded retry handling for transient kubeconform HTTP 429 schema downloads where kubeconform reports `Invalid: 0`

The deployment follows the same staging-pod pattern as old `em-media-viewer`, but in the XUI namespace with the XUI chart and image repository.

Companion application PR: https://github.com/hmcts/rpx-xui-media-viewer/pull/11

### Testing done

Local checks:
- `git diff --check`
- `bash -n tests/dry-run-kustomize.sh`
- `./tests/image-policy-exists.sh`
- YAML parse for touched YAML files

Configuration checks:
- confirmed `hmcts/hmcts-charts` contains `stable/xui-media-viewer`
- confirmed chart values define `xui-media-viewer-aat.service.core-compute-aat.internal`
- confirmed chart values use `aadIdentityName: xui`
- confirmed chart values use the RPX Key Vault
- confirmed ACR repository `hmctsprod.azurecr.io/xui/media-viewer` exists
- confirmed the seed image tag exists in ACR

GitHub checks:
- `static_tests`: passed
- full schema matrix: passed
- `schema (demo, 01)`: passed after kubeconform 429 retry hardening
- `schema (aat, 00)` and `schema (aat, 01)`: passed

Full local `./tests/dry-run-kustomize.sh demo 01` was not runnable on my laptop because `flux`, `kustomize`, and `kubeconform` are not installed locally. The GitHub schema matrix has run this path successfully.

### Rollout / merge order

Merge this Flux PR before relying on the nightly changes in `rpx-xui-media-viewer`.

After merge, Flux needs to reconcile AAT and create:
- HelmRelease: `xui-media-viewer`
- internal endpoint: `http://xui-media-viewer-aat.service.core-compute-aat.internal`

Once AAT has reconciled, the `rpx-xui-media-viewer` nightly pipeline can run against the permanent AAT service.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

No application dependency or runtime CVE suppression is introduced by this PR. The kubeconform change only retries transient schema-download HTTP 429s and does not bypass invalid manifest failures.

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
