### PR TITLE
Use v2 ET CCD data migration task name

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -143,7 +143,7 @@ spec:
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true
-        CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration
+        CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration-v2
         CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings


### PR DESCRIPTION
Updates the ET CCD data migration task name to use a fresh v2 progress key.

This lets the SDK create a new ccd_data_migration_progress row for the current migration configuration instead of failing against the existing et-ccd-data-migration row that was created with a different config hash.
