### PR TITLE
PTLSBOX: enable UseHelm3Defaults feature gate, revert temp fixes

### DIFF
--- a/apps/azure-devops/azure-devops-agent/sbox-intsvc.yaml
+++ b/apps/azure-devops/azure-devops-agent/sbox-intsvc.yaml
@@ -27,7 +27,7 @@ spec:
   chart:
     spec:
       chart: function
-      version: 2.6.4-beta
+      version: 2.6.3
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml
+++ b/apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
+        - --watch-all-namespaces=true
+        - --log-level=info
+        - --log-encoding=json
+        - --enable-leader-election
+        - --feature-gates=UseHelm3Defaults=true

--- a/apps/flux-system/sbox-intsvc/base/kustomization.yaml
+++ b/apps/flux-system/sbox-intsvc/base/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
   - path: ../../serviceaccount/sbox-intsvc-source-controller.yaml
   - path: ../../base/patches/workload-identity-deployment-patch.yaml
   - path: ../../base/patches/workload-identity-source-controller-patch.yaml
+  - path: ../../base/patches/helm-controller-helm3-defaults-patch.yaml

--- a/apps/jenkins/jenkins-webhook-relay/sbox-intsvc/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/sbox-intsvc/jenkins-webhook-relay.yaml
@@ -12,7 +12,7 @@ spec:
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: GitRepository
-        name: jenkins-webhook-relay-fix
+        name: jenkins-webhook-relay
         namespace: flux-system
       version: '*'
   interval: 5m


### PR DESCRIPTION
## Summary
- Adds `apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml` setting `--feature-gates=UseHelm3Defaults=true` on the helm-controller `manager` container, wired in only via `apps/flux-system/sbox-intsvc/base/kustomization.yaml` — scoped to CFT PTLSBOX (`sbox-intsvc`) only, no other cluster is affected.
- Reverts `azure-devops-agent` chart-function version from the temporary `2.6.4-beta` back to the pre-fix `2.6.3` (`apps/azure-devops/azure-devops-agent/sbox-intsvc.yaml`).
- Reverts `jenkins-webhook-relay` HelmRelease source from `jenkins-webhook-relay-fix` (branch `fix-use-newer-chart-function`) back to `jenkins-webhook-relay` (branch `master`) (`apps/jenkins/jenkins-webhook-relay/sbox-intsvc/jenkins-webhook-relay.yaml`).

Goal: prove that `UseHelm3Defaults` (client-side apply, matching pre-Flux-upgrade behaviour) fixes the HelmRelease install failures seen when `azure-devops-agent` / `jenkins-webhook-relay` were deleted/recreated during a CFT PTLSBOX rebuild — without relying on the temporary chart-level workarounds. If proven, the gate will be rolled out to all cluster helm-controllers (checking AAT/STG first).

## Test plan
- [x] `kubectl kustomize apps/flux-system/sbox-intsvc/base --load-restrictor LoadRestrictionsNone` renders the helm-controller Deployment with all 6 args intact (`--events-addr`, `--watch-all-namespaces`, `--log-level`, `--log-encoding`, `--enable-leader-election`, `--feature-gates=UseHelm3Defaults=true`).
- [x] Confirmed via `kubectl kustomize` that no other cluster (`aat`, `sbox`, `prod`, `ithc`, `perftest`, `preview`, `demo`, `ptl-intsvc`) picks up the feature gate.
- [ ] After merge + Flux reconcile: confirm ADO agent pool has no running jobs, then delete the `azure-devops-agent` and `jenkins-webhook-relay` HelmReleases on `cft-ptlsbox-00-aks` and observe clean reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)