### PR TITLE
Patch for aat to use helm3 defaults instead of helm4

### DIFF
--- a/clusters/aat/00/kustomization.yaml
+++ b/clusters/aat/00/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 
 patches:
 - path: ../../../apps/flux-system/aat/00/kustomize.yaml
+- path: ../../../apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33272

### Change description

Patch flux fixes to use helm3 as default for aat.

### Testing done

This is already tested on sbox.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
