### PR TITLE
Enable ET AAT service bus scheduler

### DIFF
--- a/apps/et/et-cos/aat.yaml
+++ b/apps/et/et-cos/aat.yaml
@@ -13,6 +13,7 @@ spec:
         ET_CCD_DATA_MIGRATION_ENABLED: false
         CCD_SDK_DECENTRALISED: true
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
+        ET_SERVICEBUS_SCHEDULER_ENABLED: true
         ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-aat.internal:9200
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 9-17 * * *" # every 10mins between 9am and 5pm (db lock prevents paralell running)
         ET_CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration


### PR DESCRIPTION
## Summary

Enable the ET COS Service Bus scheduler in AAT so decentralised CCD case event messages are published from `ccd.message_queue_candidates`.

## Root cause

AAT had decentralisation and the decentralised ES indexer enabled, but the Service Bus scheduler was still left at the application default of disabled. The ES indexer drains `ccd.es_queue`; it does not publish WA case event messages.

## Impact

After deployment, ET COS should publish pending CCD case event messages to `ccd-case-events-aat`, allowing WA case event handling to drain the backlog.

## Validation

- Checked the staged diff contains only the AAT ET COS environment flag.
- Ran `git diff --check`.
