### PR TITLE
Reduce ET CCD data migration window size to 50k

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -147,7 +147,7 @@ spec:
         CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings
-        CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "500000"
+        CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "50000"
         CCD_DATA_MIGRATION_MAX_BATCHES_PER_RUN: "1000000"
         CCD_DATA_MIGRATION_MAX_RUN_TIME: 2h # limit each invocation; subsequent scheduled runs resume
         CCD_DATA_MIGRATION_STATEMENT_TIMEOUT: 30m


### PR DESCRIPTION
Reduces the ET CCD data migration event ID window in prod from 500k to 50k. This should reduce the temp-space pressure from dense event ranges while allowing the preload to continue from the persisted HWM.