### PR TITLE
Add civil-ptl pool as workaround

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -375,6 +375,23 @@ spec:
                           galleryImageVersion: "24.04.93"
                         <<: *vm_template_values_anchor
                         uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi
+                      - templateName: "cnp-jenkins-ubuntu-civil-ptl"
+                        templateDesc: "Jenkins build agents for Civil builds"
+                        labels: "civil-ptl"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ads_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.93"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/managed-identities-cftptl-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftptl-intsvc-mi
                       - templateName: "cnp-jenkins-ubuntu-xui-preview"
                         templateDesc: "Jenkins build agents for XUI builds"
                         labels: "xui-preview"


### PR DESCRIPTION
### Jira link

See [DTSP-33257](https://tools.hmcts.net/jira/browse/DTSPO-33257)

### Change description

Adding civil-ptl as workaround till we can figure out why it's not using the prod agents for prod promotion

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
