### PR TITLE
Enable perftest CDAM image updates

### DIFF
--- a/apps/ccd/automation/kustomization.yaml
+++ b/apps/ccd/automation/kustomization.yaml
@@ -44,6 +44,7 @@ resources:
 #  - ../ccd-logstash/image-repo.yaml
   - ../ccd-case-document-am-api/image-repo.yaml
   - ../ccd-case-document-am-api/image-policy.yaml
+  - ../ccd-case-document-am-api/perftest-image-policy.yaml
   - ../ccd-int-data-store-api/image-repo.yaml
   - ../ccd-int-data-store-api/demo-image-policy.yaml
   - ../ccd-int-data-store-api/image-policy.yaml

--- a/apps/ccd/ccd-case-document-am-api/perftest.yaml
+++ b/apps/ccd/ccd-case-document-am-api/perftest.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctspublic.azurecr.io/ccd/case-document-am-api:prod-d742391-20260204142728 #{"$imagepolicy": "flux-system:perftest-ccd-case-document-am-api"}
+      image: hmctsprod.azurecr.io/ccd/case-document-am-api:prod-6f35dbe-20260713091832 #{"$imagepolicy": "flux-system:perftest-ccd-case-document-am-api"}
       replicas: 7
       memoryRequests: "3Gi"
       cpuRequests: "1"


### PR DESCRIPTION
Summary
- Update perftest CDAM to the current master image tag: prod-6f35dbe-20260713091832.
- Add the existing perftest CDAM ImagePolicy to CCD image automation so Flux can keep this image current.

Context
- The perftest override was still pinned to the February CDAM image and the old registry.
- The perftest ImagePolicy already existed, but it was not included in apps/ccd/automation/kustomization.yaml, so automation had no policy to reconcile for this override.

Validation
- Ran git diff --check.