### PR TITLE
Enable Query Store on ET preview Postgres

### DIFF
--- a/apps/et/preview/aso/et-postgres-config.yaml
+++ b/apps/et/preview/aso/et-postgres-config.yaml
@@ -11,3 +11,48 @@ spec:
   azureName: azure.extensions
   source: user-override
   value: "btree_gin,postgres_fdw"
+
+---
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+kind: FlexibleServersConfiguration
+metadata:
+  name: query-capture-mode
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  owner:
+    name: ${NAMESPACE}-${ENVIRONMENT}
+  azureName: pg_qs.query_capture_mode
+  source: user-override
+  value: "top"
+
+---
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+kind: FlexibleServersConfiguration
+metadata:
+  name: store-query-plans
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  owner:
+    name: ${NAMESPACE}-${ENVIRONMENT}
+  azureName: pg_qs.store_query_plans
+  source: user-override
+  value: "on"
+
+---
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
+kind: FlexibleServersConfiguration
+metadata:
+  name: wait-sampling-query-capture-mode
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  owner:
+    name: ${NAMESPACE}-${ENVIRONMENT}
+  azureName: pgms_wait_sampling.query_capture_mode
+  source: user-override
+  value: "all"


### PR DESCRIPTION
Enable PostgreSQL Query Store and wait sampling on the ET preview PostgreSQL server.

The shared `et-preview` server reached 1,098 active connections and 88% memory during the failed ET callback PR build, with PostgreSQL out-of-memory errors in both case upsert and audit history queries. Capturing query text, plans and wait samples will allow the source of the pressure to be identified from Azure Monitor.

This applies only to the ET preview FlexibleServer configuration and does not change AAT or production databases.
