### PR TITLE
Reduce ET significant item migration window

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -150,6 +150,7 @@ spec:
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings
         CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "50000"
+        CCD_DATA_MIGRATION_SIGNIFICANT_ITEM_ID_WINDOW_SIZE: "5000"
         CCD_DATA_MIGRATION_MAX_BATCHES_PER_RUN: "1000000"
         CCD_DATA_MIGRATION_MAX_RUN_TIME: 2h # limit each invocation; subsequent scheduled runs resume
         CCD_DATA_MIGRATION_STATEMENT_TIMEOUT: 30m


### PR DESCRIPTION
Reduce the significant-item ID window used by the ET production CCD data migration from the SDK default of 100,000 to 5,000.

