### PR TITLE
Configuring AT pods in perftest for debug

### DIFF
--- a/apps/xui/rpx-case-activity-api/perftest-00.yaml
+++ b/apps/xui/rpx-case-activity-api/perftest-00.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: xui-case-activity-api
   values:
     nodejs:
-      replicas: 2
+      replicas: 1
       image: hmctsprod.azurecr.io/xui/case-activity-api:pr-1-8453690-20260714110122 #{"$imagepolicy": "flux-system:perftest-rpx-case-activity-api"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1

--- a/apps/xui/rpx-case-activity-api/perftest-01.yaml
+++ b/apps/xui/rpx-case-activity-api/perftest-01.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: xui-case-activity-api
   values:
     nodejs:
-      replicas: 2
+      replicas: 0
       image: hmctsprod.azurecr.io/xui/case-activity-api:pr-1-8453690-20260714110122 #{"$imagepolicy": "flux-system:perftest-rpx-case-activity-api"}
       environment:
         DUMMY_VAR_TO_REDEPLOY: 1


### PR DESCRIPTION
debugging socket disconnects, to running with 1 pod only in perftest