### PR TITLE
Allow AAC NoC callbacks

### DIFF
--- a/apps/et/et-cos/aat.yaml
+++ b/apps/et/et-cos/aat.yaml
@@ -13,6 +13,7 @@ spec:
         ET_CCD_DATA_MIGRATION_ENABLED: false
         CCD_SDK_DECENTRALISED: true
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
+        AAC_URL: http://aac-manage-case-assignment-aat.service.core-compute-aat.internal
         ET_SERVICEBUS_SCHEDULER_ENABLED: true
         ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-aat.internal:9200
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 9-17 * * *" # every 10mins between 9am and 5pm (db lock prevents paralell running)

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -11,6 +11,7 @@ spec:
         IDAM_API_URL: https://idam-api.platform.hmcts.net
         IDAM_API_JWK_URL: https://idam-api.platform.hmcts.net/jwks
         CCD_GATEWAY_BASE_URL: https://manage-case.platform.hmcts.net
+        AAC_URL: http://aac-manage-case-assignment-prod.service.core-compute-prod.internal
         ACAS_BASE_URL: https://api.acas.org.uk/ECCLProd
         SECURE_DOC_STORE_FEATURE: false
         RESTART_MANUALLY: 6


### PR DESCRIPTION
Adds the AAC service itself to the authorised S2S services in AAT and production.

With ET decentralised, the SDK callback bridge forwards the S2S token from the nocRequest submission. That token identifies AAC, so the check-noc-approval callback is currently rejected with 403 and the request remains pending.