### PR TITLE
Allow AAC NoC callbacks

### DIFF
--- a/apps/aac/manage-case-assignment/aat.yaml
+++ b/apps/aac/manage-case-assignment/aat.yaml
@@ -6,5 +6,5 @@ spec:
   values:
     java:
       environment:
-        MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,fpl_case_service,nfdiv_case_api,probate_backend,prl_cos_api,et_cos,civil_service,et_sya_api,pt_api,pcs_api
+        MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,fpl_case_service,nfdiv_case_api,probate_backend,prl_cos_api,et_cos,civil_service,et_sya_api,pt_api,pcs_api,aac_manage_case_assignment
         DUMMY: true

--- a/apps/aac/manage-case-assignment/manage-case-assignment.yaml
+++ b/apps/aac/manage-case-assignment/manage-case-assignment.yaml
@@ -16,7 +16,7 @@ spec:
       image: hmctsprod.azurecr.io/aac/manage-case-assignment:prod-8768dc8-20260713193529 #{"$imagepolicy": "flux-system:manage-case-assignment"}
       environment:
         SPRING_CACHE_CAFFEINE_SPEC: expireAfterWrite=1800s
-        MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,nfdiv_case_api,fpl_case_service,probate_backend,prl_cos_api,et_cos,civil_service,et_sya_api,pcs_api
+        MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,nfdiv_case_api,fpl_case_service,probate_backend,prl_cos_api,et_cos,civil_service,et_sya_api,pcs_api,aac_manage_case_assignment
   chart:
     spec:
       chart: ./stable/aac-manage-case-assignment


### PR DESCRIPTION
Adds the AAC service itself to the authorised S2S services in AAT and production.

With ET decentralised, the SDK callback bridge forwards the S2S token from the nocRequest submission. That token identifies AAC, so the check-noc-approval callback is currently rejected with 403 and the request remains pending.