### PR TITLE
Add Flux image policy to idam-api on Iower environments

### DIFF
--- a/apps/idam/idam-api/aat.yaml
+++ b/apps/idam/idam-api/aat.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117
+      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117 # {"$imagepolicy": "flux-system:idam-api"}
       ingressHost: idam-api.aat.platform.hmcts.net
       environment:
         SERVER_MAX_HTTP_REQUEST_HEADER_SIZE: 20KB

--- a/apps/idam/idam-api/demo.yaml
+++ b/apps/idam/idam-api/demo.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117
+      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117 # {"$imagepolicy": "flux-system:idam-api"}
       replicas: 1
       ingressHost: idam-api.demo.platform.hmcts.net
       environment:

--- a/apps/idam/idam-api/ithc.yaml
+++ b/apps/idam/idam-api/ithc.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117
+      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117 # {"$imagepolicy": "flux-system:idam-api"}
       ingressHost: idam-api.ithc.platform.hmcts.net
       replicas: 1
       environment:

--- a/apps/idam/idam-api/perftest.yaml
+++ b/apps/idam/idam-api/perftest.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117
+      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117 # {"$imagepolicy": "flux-system:idam-api"}
       replicas: 2
       ingressHost: idam-api.perftest.platform.hmcts.net
       environment:

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117
+      image: hmctsprod.azurecr.io/idam/api:prod-22d2f22-20260706101117 # {"$imagepolicy": "flux-system:idam-api"}
       ingressHost: idam-api.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1


### PR DESCRIPTION
## Jira link
https://tools.hmcts.net/jira/browse/SIDM-10432

## Change description
- Add the Flux image policy marker to IDAM API image values in `aat`, `demo`, `ithc`, `perftest`, and `sbox`.

## Testing done
- `git diff --check`