### PR TITLE
Set perftest ET3 legacy redirect URL

### DIFF
--- a/apps/et/et-syr/perftest.yaml
+++ b/apps/et/et-syr/perftest.yaml
@@ -9,3 +9,5 @@ spec:
     nodejs:
       image: hmctsprod.azurecr.io/et/syr:prod-b712e2d-20260703090749 #{"$imagepolicy": "flux-system:perftest-et-syr"}
       ingressHost: et-syr.perftest.platform.hmcts.net
+      environment:
+        ET3_LEGACY_URL: https://et-pet-et3.perftest.platform.hmcts.net/users/sign_up


### PR DESCRIPTION
Sets ET3_LEGACY_URL for the perftest et-syr deployment so fallback ET3 sign-up redirects stay within perftest. This pairs with the et-syr-frontend configurable redirect change.