### PR TITLE
Enable ET production migration preload

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -142,11 +142,11 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
-        MIGRATION_CCD_DATA_ENABLED: false
+        MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true
         CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration-v2
-        CCD_DATA_MIGRATION_MODE: CUTOVER
+        CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings
         CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "50000"


### PR DESCRIPTION
Enables the ET production CCD data migration schedule and restores the migration mode to `PRELOAD_EVENTS`. 