### PR TITLE
Disable ES indexer in ET cron jobs

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -141,7 +141,9 @@ spec:
         MULTIPLE_SHELL_CASE_CREATION_ERROR_EMAIL_TEMPLATE_ID: d2d427cd-efd5-4121-abc4-242c5beac158
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
-        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
+        CCD_SDK_DECENTRALISED: true
+        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
+        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-prod.internal:9200
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -141,9 +141,7 @@ spec:
         MULTIPLE_SHELL_CASE_CREATION_ERROR_EMAIL_TEMPLATE_ID: d2d427cd-efd5-4121-abc4-242c5beac158
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
-        CCD_SDK_DECENTRALISED: true
-        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
-        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-prod.internal:9200
+        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true

--- a/apps/et/et-cron-wa-task-for-expired-bfactions/et-cron-wa-task-for-expired-bfactions.yaml
+++ b/apps/et/et-cron-wa-task-for-expired-bfactions/et-cron-wa-task-for-expired-bfactions.yaml
@@ -12,6 +12,7 @@ spec:
       cpuLimits: "1500m"
       cpuRequests: "200m"
       environment:
+        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
         TASK_NAME: WaTaskCreationCronForExpiredBfActions
         TRIGGER_RESTART: 1
       schedule: 0/30 * * * *

--- a/apps/et/et-reconfiguration-cron/et-reconfiguration-cron.yaml
+++ b/apps/et/et-reconfiguration-cron/et-reconfiguration-cron.yaml
@@ -12,6 +12,7 @@ spec:
       cpuLimits: "1500m"
       cpuRequests: "200m"
       environment:
+        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
         TASK_NAME: BatchReconfigurationTask
       schedule: 0 1 * * *
       disableActiveClusterCheck: true


### PR DESCRIPTION
Explicitly disables the decentralised Elasticsearch indexer in the shared ET CronJob definitions so batch workloads cannot start an indexer when the setting is otherwise absent.