### PR TITLE
Revert ET production migration to preload mode

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -146,7 +146,7 @@ spec:
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true
         CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration-v2
-        CCD_DATA_MIGRATION_MODE: CUTOVER
+        CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings
         CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "50000"


### PR DESCRIPTION
Returns the ET production CCD data migration task to `PRELOAD_EVENTS` after the cutover run.
