### PR TITLE
Deploy rota worker and optimiser to AAT and demo

### DIFF
--- a/apps/rota/aat/base/kustomization.yaml
+++ b/apps/rota/aat/base/kustomization.yaml
@@ -3,7 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../rota-optimiser/rota-optimiser.yaml
+  - ../../rota-worker/rota-worker.yaml
 namespace: rota
 patches:
   - path: ../../rota-resource/aat.yaml
+  - path: ../../rota-worker/aat.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/rota/demo/base/kustomization.yaml
+++ b/apps/rota/demo/base/kustomization.yaml
@@ -3,7 +3,10 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../rota-optimiser/rota-optimiser.yaml
+  - ../../rota-worker/rota-worker.yaml
 namespace: rota
 patches:
   - path: ../../rota-resource/demo.yaml
+  - path: ../../rota-worker/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/rota/rota-optimiser/rota-optimiser.yaml
+++ b/apps/rota/rota-optimiser/rota-optimiser.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rota-optimiser
+spec:
+  releaseName: rota-optimiser
+  values:
+    java:
+      image: hmctsprod.azurecr.io/rota/optimiser:prod-233c8e7-20260717090106 # {"$imagepolicy": "flux-system:rota-optimiser"}
+  chart:
+    spec:
+      chart: ./stable/rota-optimiser
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/rota/rota-worker/aat.yaml
+++ b/apps/rota/rota-worker/aat.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rota-worker
+spec:
+  values:
+    java:
+      environment:
+        WORKER_ENABLED: true

--- a/apps/rota/rota-worker/demo.yaml
+++ b/apps/rota/rota-worker/demo.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rota-worker
+spec:
+  values:
+    java:
+      environment:
+        WORKER_ENABLED: true

--- a/apps/rota/rota-worker/rota-worker.yaml
+++ b/apps/rota/rota-worker/rota-worker.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rota-worker
+spec:
+  releaseName: rota-worker
+  dependsOn:
+    - name: rota-optimiser
+  values:
+    java:
+      image: hmctsprod.azurecr.io/rota/worker:prod-85ff17d-20260723103309 # {"$imagepolicy": "flux-system:rota-worker"}
+  chart:
+    spec:
+      chart: ./stable/rota-worker
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m


### PR DESCRIPTION
## Summary

- deploy `rota-optimiser` and `rota-worker` Helm releases to AAT and demo
- pin the current immutable production images:
  - optimiser: `prod-233c8e7-20260717090106`
  - worker: `prod-85ff17d-20260723103309`
- retain Flux image automation markers for both services
- make the worker depend on the optimiser Helm release
- enable worker processing in AAT and demo only

The published `rota-worker` chart is version `0.1.3` and uses the in-cluster endpoint `http://rota-optimiser-java`.

## Infrastructure verification

Verified in `DCD-CNP-DEV` for both AAT and demo:

- `rota-shared-infra-<env>` resource group
- PostgreSQL 16 flexible server and `rota` database
- `rota-shared-<env>` Key Vault
- Application Insights
- `application-insights-connection-string`, `postgresql-fqdn`, `postgresql-admin-username`, and `postgresql-admin-password` secrets

## Validation

- AAT and demo Kustomize overlays render successfully
- rendered worker releases depend on `rota-optimiser`
- rendered worker releases have `WORKER_ENABLED: true`
- immutable image tags and Flux policy markers verified
- repository image automation checks pass
- repository YAML lint passes