### PR TITLE
Disable ET production migration cron

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -142,7 +142,7 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
-        MIGRATION_CCD_DATA_ENABLED: true
+        MIGRATION_CCD_DATA_ENABLED: false
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true
         CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration-v2


### PR DESCRIPTION
Disables the ET production CCD data migration scheduler after the cutover run.

This PR is stacked on the cutover-mode change so it should be merged only after that run has completed.
