### PR TITLE
Replace obsolete value for retentionStrategy in sbox jenkins

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins-azure-vm-agent.yaml
@@ -60,7 +60,7 @@ spec:
               osDiskStorageAccountType: "Standard_LRS"
               osType: "Linux"
               retentionStrategy:
-                AzureVMCloudPoolRetentionStrategy:
+                azureVMCloudPool:
                   dynamicBufferEnabled: true
                   dynamicBufferPercentage: 10
                   maximumBuffer: 5


### PR DESCRIPTION
### Change description

[Previous PR](https://github.com/hmcts/cnp-flux-config/pull/46406) change hasn't taken
Getting warnings about the value in the UI:

```
'AzureVMCloudPoolRetentionStrategy' is obsolete, please use 'azureVMCloudPool'
```

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
