### PR TITLE
SIDM-10409 Update sandbox IDAM reset flow images

### DIFF
--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:preview-29545c9-20260715160742
+      image: hmctsprod.azurecr.io/idam/api:preview-edfeb7f-20260724094301
       ingressHost: idam-api.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1

--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -23,6 +23,7 @@ spec:
         TESTING_SUPPORT_ENABLED: true
         STRATEGIC_ADMIN_URL: https://idam-user-dashboard.sandbox.platform.hmcts.net
         STRATEGIC_FRONTEND_URL: https://idam-web-public.sandbox.platform.hmcts.net
+        STRATEGIC_FRONTEND_FORGOTPASSWORDRESETPATH: /change-password
         STRATEGIC_API_URL: http://idam-api
         IDAM_SPI_FORGEROCK_AM_ROOT: https://forgerock-am.service.core-compute-idam-sandbox.internal:8443/openam
         IDAM_SPI_FORGEROCK_AM_TOPLEVELHOST: forgerock-am.service.core-compute-idam-sandbox.internal:8443

--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -7,12 +7,13 @@ spec:
   releaseName: idam-hmcts-access
   values:
     nodejs:
+      image: hmctsprod.azurecr.io/idam/hmcts-access:pr-1667-1154ae5-20260723104359
       pdb:
         enabled: false
       replicas: 1
       ingressHost: hmcts-access.sandbox.platform.hmcts.net
       disableTraefikTls: true
       environment:
-        NODE_CONFIG: '{"services":{"idam":{"api":{"endpoints":{"forgot-password":"/forgotPasswordDetails"}}}}}'
+        PASSWORD_RESET_V2_ENABLED: true
         STRATEGIC_SERVICE_URL: 'https://idam-api.sandbox.platform.hmcts.net'
         STRATEGIC_TESTING_URL: 'https://idam-testing-support-api.sandbox.platform.hmcts.net'

--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -13,5 +13,6 @@ spec:
       ingressHost: hmcts-access.sandbox.platform.hmcts.net
       disableTraefikTls: true
       environment:
+        NODE_CONFIG: '{"services":{"idam":{"api":{"endpoints":{"forgot-password":"/forgotPasswordDetails"}}}}}'
         STRATEGIC_SERVICE_URL: 'https://idam-api.sandbox.platform.hmcts.net'
         STRATEGIC_TESTING_URL: 'https://idam-testing-support-api.sandbox.platform.hmcts.net'


### PR DESCRIPTION
## Summary
- Updates Sandbox `idam-api` to `hmctsprod.azurecr.io/idam/api:preview-edfeb7f-20260724094301`, the preview image built from `hmcts/idam-api#2597`.
- Keeps the Sandbox `idam-api` reset-link override as `/change-password`.
- Keeps the Sandbox HMCTS Access v2 reset experiment image and `PASSWORD_RESET_V2_ENABLED: true` already on this branch.

## Scope
- Sandbox only.
- Changed files are `apps/idam/idam-api/sbox.yaml` and `apps/idam/idam-hmcts-access/sbox.yaml`.

## Validation
- `git diff --check` passed.
- YAML parse passed for the two changed Sandbox HelmRelease files.
- Prior live Sandbox check deployed `preview-edfeb7f-20260724094301` manually and `/info` reported commit `edfeb7f`.
- Prior HMCTS Access performance smoke on Sandbox did not fully pass: setup `OK=14 KO=0`, performance `OK=180 KO=2`, cleanup `OK=5 KO=0`. The reset password failures still showed HMCTS Access calling legacy `/forgotPassword`, so this PR codifies the image/config update but is not proof that SIDM-10409 is fully fixed.