### PR TITLE
SIDM-10409 Update sandbox HMCTS Access image

### DIFF
--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: idam-hmcts-access
   values:
     nodejs:
+      image: hmctsprod.azurecr.io/idam/hmcts-access:staging-f6063c4-20260724153157
       pdb:
         enabled: false
       replicas: 1

--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -14,5 +14,6 @@ spec:
       ingressHost: hmcts-access.sandbox.platform.hmcts.net
       disableTraefikTls: true
       environment:
+        PASSWORD_RESET_V2_ENABLED: 'true'
         STRATEGIC_SERVICE_URL: 'https://idam-api.sandbox.platform.hmcts.net'
         STRATEGIC_TESTING_URL: 'https://idam-testing-support-api.sandbox.platform.hmcts.net'


### PR DESCRIPTION
## Jira Ticket
https://tools.hmcts.net/jira/browse/SIDM-10409

## Summary
- Updates Sandbox `idam-hmcts-access` to James’s merged HMCTS Access image `hmctsprod.azurecr.io/idam/hmcts-access:staging-f6063c4-20260724153157`.
- Enables `PASSWORD_RESET_V2_ENABLED: true` in Sandbox so the merged HMCTS Access code selects the V2 reset services.
- This image was built from the merged `hmcts/idam-hmcts-access#1667` master change.
