### PR TITLE
SIDM-10409 align sandbox IDAM API and HMCTS Access

### DIFF
--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:preview-edfeb7f-20260724094301
+      image: hmctsprod.azurecr.io/idam/api:preview-f91a831-20260727085118
       ingressHost: idam-api.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1

--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -7,13 +7,11 @@ spec:
   releaseName: idam-hmcts-access
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/idam/hmcts-access:prod-f6063c4-20260724153157
       pdb:
         enabled: false
       replicas: 1
       ingressHost: hmcts-access.sandbox.platform.hmcts.net
       disableTraefikTls: true
       environment:
-        PASSWORD_RESET_V2_ENABLED: 'true'
         STRATEGIC_SERVICE_URL: 'https://idam-api.sandbox.platform.hmcts.net'
         STRATEGIC_TESTING_URL: 'https://idam-testing-support-api.sandbox.platform.hmcts.net'

--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-hmcts-access
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/idam/hmcts-access:staging-f6063c4-20260724153157
+      image: hmctsprod.azurecr.io/idam/hmcts-access:prod-f6063c4-20260724153157
       pdb:
         enabled: false
       replicas: 1


### PR DESCRIPTION
Aligns Sandbox with the current expected IDAM application images/configuration after the SIDM-10430 work.
Changes:
Updates Sandbox idam-api from preview-edfeb7f-20260724094301 to the current preview image preview-f91a831-20260727085118.
Removes the Sandbox-specific HMCTS Access image override so Sandbox inherits the default prod f6063c4 image

 Removes the Sandbox-specific PASSWORD_RESET_V2_ENABLED override from HMCTS Access.\n\nThis keeps the change scoped to Sandbox Flux config and avoids pinning HMCTS Access Sandbox to one-off overrides.