### PR TITLE
SIDM-10409 add sandbox IDAM API operation reporter

### DIFF
--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -24,6 +24,7 @@ spec:
         STRATEGIC_ADMIN_URL: https://idam-user-dashboard.sandbox.platform.hmcts.net
         STRATEGIC_FRONTEND_URL: https://idam-web-public.sandbox.platform.hmcts.net
         STRATEGIC_API_URL: http://idam-api
+        STRATEGIC_OPERATION_REPORTER: console-and-insight
         IDAM_SPI_FORGEROCK_AM_ROOT: https://forgerock-am.service.core-compute-idam-sandbox.internal:8443/openam
         IDAM_SPI_FORGEROCK_AM_TOPLEVELHOST: forgerock-am.service.core-compute-idam-sandbox.internal:8443
         IDAM_SPI_FORGEROCK_AM_JWKSURIFOROAUTH2CLIENTS: http://forgerock-am.service.core-compute-idam-sandbox.internal:8080/openam/oauth2/hmcts/connect/jwk_uri


### PR DESCRIPTION
Adds STRATEGIC_OPERATION_REPORTER: console-and-insight to the Sandbox idam-api Flux environment, matching James's requested Sandbox setting.
Scope: Sandbox only
idam-api only
 No image changes in this PR