### PR TITLE
Remove et-xui-e2e-tests from buildMonitor regex

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -340,7 +340,7 @@ spec:
                     title: FinRem Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(et-ccd-callbacks|et-shared-infrastructure|et-sya-frontend|et-syr-frontend|et-sya-api|et-xui-e2e-tests)\/master
+                      ^HMCTS.*\/(et-ccd-callbacks|et-shared-infrastructure|et-sya-frontend|et-syr-frontend|et-sya-api)\/master
                     name: ET
                     recurse: true
                     title: Employment Tribunals


### PR DESCRIPTION
et-xui-e2e-tests has been archived as it was merged into et-ccd-callbacks so removing it from the ET Dashboard