### PR TITLE
Test completed build archive job in sandbox

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -37,6 +37,30 @@ spec:
           value: https://cftsbox-intsvc.vault.azure.net
       JCasC:
         configScripts:
+          jobs: |
+            jobs:
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations-beta.groovy
+              - script: >
+                  pipelineJob('Seed Job') {
+                    triggers {
+                      cron('H 8,11,14,17 * * 1-5')
+                    }
+                    definition {
+                      cpsScm {
+                        scm {
+                          git {
+                            remote {
+                              github('hmcts/cnp-jenkins-config')
+                              credentials('hmcts-jenkins-cnp')
+                            }
+                            branch('feature/archive-completed-builds-job')
+                          }
+                        }
+                        scriptPath('jobdsl/Jenkinsfile_seed')
+                        lightweight(true)
+                      }
+                    }
+                  }
           welcome-message: |
             jenkins:
               systemMessage: >-


### PR DESCRIPTION
## What changed

Override the sandbox Jenkins JCasC `jobs` block so the Seed Job checks out `feature/archive-completed-builds-job` from `cnp-jenkins-config`.

PTL continues to use `master`.

## Why

This temporarily deploys the completed-build archive job from hmcts/cnp-jenkins-config#1291 to sandbox only. It allows the job definition and end-to-end archive flow to be tested before the Jenkins config change is rolled out to both environments.

## Impact

- sandbox Seed Job uses the feature branch
- PTL is unchanged
- no credentials or shared Jenkins configuration are added

After the sandbox test succeeds, this override should be removed so both environments return to the shared `master` configuration.

## Validation

- `git diff --check`
- `kubectl kustomize apps/jenkins/sbox-intsvc/base --load-restrictor=LoadRestrictionsNone`
- confirmed rendered sandbox Seed Job uses `feature/archive-completed-builds-job`
- confirmed rendered PTL Seed Job still uses `master`
