### PR TITLE
civil: DTSCCI-6007 enable DOCSTORE_DOC_REMOVAL_ENABLED in prod

### DIFF
--- a/apps/civil/civil-service/prod.yaml
+++ b/apps/civil/civil-service/prod.yaml
@@ -20,6 +20,7 @@ spec:
         DOCMOSIS_TORNADO_URL: https://docmosis.platform.hmcts.net
         TESTING_SUPPORT_ENABLED: false
         DOCUMENT_MANAGEMENT_SECURED: true
+        DOCSTORE_DOC_REMOVAL_ENABLED: true
         CUI_URL: https://www.moneyclaims.service.gov.uk
         CUI_URL_RESPOND_TO_CLAIM: https://www.moneyclaims.service.gov.uk/first-contact/start
         OCMC_CLIENT_URL: https://www1.moneyclaims.service.gov.uk


### PR DESCRIPTION
## What
Sets `DOCSTORE_DOC_REMOVAL_ENABLED: true` in the **civil-service** production overlay (`apps/civil/civil-service/prod.yaml`).

## Why
On the `REMOVE_DOCUMENT` event, civil-service only hard-deletes the document binary from the doc store (CDAM/dm-store) when this flag is enabled. It is currently **unset in prod**, so it defaults to `false` and removal only unlinks the document from case data — the binary persists in the store. This was confirmed during a confidential-document incident (Jira DTSCCI-6007): the removed file remained retrievable.

This flag is already set to `true` and exercised in **AAT** (`apps/civil/civil-service/aat.yaml`); this PR promotes the same setting to prod.

## Impact / risk
- This makes `REMOVE_DOCUMENT` **destructive** for **all** removals in prod (the binary is permanently deleted from the doc store, not just unlinked). Please review with that in mind.
- Behaviour is validated in AAT; verification steps (direct CDAM `GET` returns 404 after removal, plus an App Insights `dependencies` DELETE check) are documented on DTSCCI-6007.

## Notes
- Does **not** remediate documents already orphaned before this change (e.g. the incident document) — that is handled separately via a one-off migration task (DTSCCI-6009).

Jira: DTSCCI-6007

🤖 Generated with [Claude Code](https://claude.com/claude-code)