### PR TITLE
Load archive job DSL in sandbox

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -39,7 +39,7 @@ spec:
         configScripts:
           jobs: |
             jobs:
-              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations-beta.groovy
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/feature/archive-completed-builds-job/jobdsl/organisations-beta.groovy
               - script: >
                   pipelineJob('Seed Job') {
                     triggers {
@@ -53,7 +53,7 @@ spec:
                               github('hmcts/cnp-jenkins-config')
                               credentials('hmcts-jenkins-cnp')
                             }
-                            branch('feature/archive-completed-builds-job')
+                            branch('master')
                           }
                         }
                         scriptPath('jobdsl/Jenkinsfile_seed')


### PR DESCRIPTION
## What changed

Correct the temporary sandbox-only archive-job test configuration:

- load `organisations-beta.groovy` from `feature/archive-completed-builds-job`
- keep the scheduled Seed Job itself on `master`

PTL remains unchanged and continues to load both from `master`.

## Why

The first sandbox override pointed the Seed Job SCM at the feature branch. The seed pipeline then checked out `master` internally, so the new archive job was not created. Changing the Job DSL URL directly is the sandbox patch point used for the generated Jenkins jobs and avoids requiring a Jenkins script-security approval.

## Validation

- `git diff --check`
- rendered the sandbox overlay and confirmed the Job DSL URL uses the feature branch while the Seed Job uses `master`
- rendered the PTL overlay and confirmed both remain on `master`

## Follow-up

After the sandbox archive test succeeds, remove the sandbox-only `jobs` override so both environments use the shared configuration again.
