### PR TITLE
Use central AI vault for direct access

### DIFF
--- a/apps/cnp/plum-fastapi-backend/sbox.yaml
+++ b/apps/cnp/plum-fastapi-backend/sbox.yaml
@@ -14,13 +14,16 @@ spec:
         plumsi:
           secrets:
             - name: appinsights-connection-string
-            - name: ai-gateway-subscription-key
-            - name: ai-gateway-subscription-key-frontend
+        sps-ai-kv-sbox:
+          excludeEnvironmentSuffix: true
+          secrets:
+            - name: apim-subscription-cnp-plum-fastapi
+            - name: apim-subscription-cnp-plum-frontend
       environment:
         RECIPES_SERVICE_URL: http://plum-recipe-backend-java
         APPLICATIONINSIGHTS_CONNECTION_STRING_FILE: /mnt/secrets/plumsi/appinsights-connection-string
         AI_GATEWAY_URL: https://ai-gateway.sandbox.platform.hmcts.net/ai/platform/foundry/models/v1/chat/completions
         AI_GATEWAY_SCOPE: api://b3bfa0f5-faa5-4d10-bba0-e284144aea89/.default
         AI_GATEWAY_MODEL: gpt-5.5
-        AI_GATEWAY_SUBSCRIPTION_KEY_FILE: /mnt/secrets/plumsi/ai-gateway-subscription-key
-        AI_GATEWAY_SUBSCRIPTION_KEY_FRONTEND_FILE: /mnt/secrets/plumsi/ai-gateway-subscription-key-frontend
+        AI_GATEWAY_SUBSCRIPTION_KEY_FILE: /mnt/secrets/sps-ai-kv-sbox/apim-subscription-cnp-plum-fastapi
+        AI_GATEWAY_SUBSCRIPTION_KEY_FRONTEND_FILE: /mnt/secrets/sps-ai-kv-sbox/apim-subscription-cnp-plum-frontend


### PR DESCRIPTION
To test direct MI access to subscription keys for use with AI gateway