### PR TITLE
Load archive job DSL from shared Jenkins config

### DIFF
--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -327,7 +327,7 @@ spec:
                           url: "https://${pipeline-metrics-account-name}.documents.azure.com:443/"
           jobs: |
             jobs:
-              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations-beta.groovy
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/feature/archive-completed-builds-job/jobdsl/organisations-beta.groovy
               - script: >
                   pipelineJob('Seed Job') {
                     triggers {

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -24,6 +24,30 @@ spec:
           memory: "22Gi"
       JCasC:
         configScripts:
+          jobs: |
+            jobs:
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/feature/archive-completed-builds-job/jobdsl/organisations-beta.groovy
+              - script: >
+                  pipelineJob('Seed Job') {
+                    triggers {
+                      cron('H 8,11,14,17 * * 1-5')
+                    }
+                    definition {
+                      cpsScm {
+                        scm {
+                          git {
+                            remote {
+                              github('hmcts/cnp-jenkins-config')
+                              credentials('hmcts-jenkins-cnp')
+                            }
+                            branch('master')
+                          }
+                        }
+                        scriptPath('jobdsl/Jenkinsfile_seed')
+                        lightweight(true)
+                      }
+                    }
+                  }
           welcome-message: |
             jenkins:
               systemMessage: >-

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -24,30 +24,6 @@ spec:
           memory: "22Gi"
       JCasC:
         configScripts:
-          jobs: |
-            jobs:
-              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/feature/archive-completed-builds-job/jobdsl/organisations-beta.groovy
-              - script: >
-                  pipelineJob('Seed Job') {
-                    triggers {
-                      cron('H 8,11,14,17 * * 1-5')
-                    }
-                    definition {
-                      cpsScm {
-                        scm {
-                          git {
-                            remote {
-                              github('hmcts/cnp-jenkins-config')
-                              credentials('hmcts-jenkins-cnp')
-                            }
-                            branch('master')
-                          }
-                        }
-                        scriptPath('jobdsl/Jenkinsfile_seed')
-                        lightweight(true)
-                      }
-                    }
-                  }
           welcome-message: |
             jenkins:
               systemMessage: >-

--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -37,30 +37,6 @@ spec:
           value: https://cftsbox-intsvc.vault.azure.net
       JCasC:
         configScripts:
-          jobs: |
-            jobs:
-              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/feature/archive-completed-builds-job/jobdsl/organisations-beta.groovy
-              - script: >
-                  pipelineJob('Seed Job') {
-                    triggers {
-                      cron('H 8,11,14,17 * * 1-5')
-                    }
-                    definition {
-                      cpsScm {
-                        scm {
-                          git {
-                            remote {
-                              github('hmcts/cnp-jenkins-config')
-                              credentials('hmcts-jenkins-cnp')
-                            }
-                            branch('master')
-                          }
-                        }
-                        scriptPath('jobdsl/Jenkinsfile_seed')
-                        lightweight(true)
-                      }
-                    }
-                  }
           welcome-message: |
             jenkins:
               systemMessage: >-


### PR DESCRIPTION
## What changed

Updates the shared Jenkins Configuration as Code jobs block so both sandbox and PTL load `organisations-beta.groovy` from the `feature/archive-completed-builds-job` branch of `cnp-jenkins-config`.

It also removes the now-redundant sandbox-specific jobs override. The existing Seed Job definition remains unchanged and continues to use `master`.

## Why

This temporarily creates the `Archive Completed Builds` job consistently on both Jenkins controllers, allowing the draft ET pull request to exercise `Infrastructure@archive-complete-build-results` end to end before the Jenkins library and config changes are merged.

## Impact

Both Jenkins controllers will load the proposed archive job definition at startup. Existing job definitions in the same file are unchanged. The shared URL should return to `master` after the Jenkins config change is merged.

## Validation

- `git diff --check`
- Parsed the shared, sandbox and PTL Jenkins YAML successfully with Ruby YAML
- Confirmed the final diff changes only the shared Job DSL URL and removes the sandbox-specific override
