### PR TITLE
Deploy civil-citizen-ui PR #7986 (session-sharing fix) to perftest

### DIFF
--- a/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-7833-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-7986-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/civil/civil-citizen-ui/perftest.yaml
+++ b/apps/civil/civil-citizen-ui/perftest.yaml
@@ -19,7 +19,7 @@ spec:
       devcpuLimits: 2
       devmemoryLimits: 2G
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/civil/citizen-ui:pr-7833-9e2da42-20260724085915 #{"$imagepolicy": "flux-system:perftest-civil-citizen-ui"}
+      image: hmctsprod.azurecr.io/civil/citizen-ui:pr-7986-fc8d7e3-20260728142133 #{"$imagepolicy": "flux-system:perftest-civil-citizen-ui"}
       keyVaults:
         civil-cui:
           resourceGroup: civil-citizen-ui


### PR DESCRIPTION
Deploys **civil-citizen-ui PR #7986** to **perftest** for performance testing.

PR #7986 (DTSCCI-6013) reverts the `express.static` middleware ordering so static assets are served before `express-session`, fixing the session-id sharing that caused concurrent perftest vusers to trip over each other on the draft store ("Case not found"). This pins perftest to that PR image so the fix can be verified under load.

Changes:
- `perftest-image-policy.yaml`: repoint filter pattern `^pr-7833-…` → `^pr-7986-…`
- `perftest.yaml`: set image to `pr-7986-fc8d7e3-20260728142133` (marker already targets `perftest-civil-citizen-ui`)

Note: this replaces the previous `#7833` perftest pin. `prod-automated: disabled` is already set, so image automation won't fight this. Revert to `^prod-` once testing is complete.