### PR TITLE
Revert cnp-jenkins-config to master

### DIFF
--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -327,7 +327,7 @@ spec:
                           url: "https://${pipeline-metrics-account-name}.documents.azure.com:443/"
           jobs: |
             jobs:
-              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/feature/archive-completed-builds-job/jobdsl/organisations-beta.groovy
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations-beta.groovy
               - script: >
                   pipelineJob('Seed Job') {
                     triggers {


### PR DESCRIPTION
### Change description

https://github.com/hmcts/cnp-jenkins-config/pull/1291 has been merged so this needs reverted

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
