### PR TITLE
DTSCCI-6013 Restore CUI perftest master image

### DIFF
--- a/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
@@ -2,6 +2,8 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: perftest-civil-citizen-ui
+annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
     pattern: '^pr-7986-[a-f0-9]+-(?P<ts>[0-9]+)'

--- a/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
@@ -2,7 +2,7 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: perftest-civil-citizen-ui
-annotations:
+  annotations:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:

--- a/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
@@ -2,11 +2,9 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: perftest-civil-citizen-ui
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-7986-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
+++ b/apps/civil/civil-citizen-ui/perftest-image-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: perftest-civil-citizen-ui
 spec:
   filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-7986-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/civil/civil-citizen-ui/perftest.yaml
+++ b/apps/civil/civil-citizen-ui/perftest.yaml
@@ -19,7 +19,7 @@ spec:
       devcpuLimits: 2
       devmemoryLimits: 2G
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/civil/citizen-ui:prod-8af131f-20260729145326 #{"$imagepolicy": "flux-system:perftest-civil-citizen-ui"}
+      image: hmctsprod.azurecr.io/civil/citizen-ui:prod-8af131f-20260729145326 #{"$imagepolicy": "flux-system:civil-citizen-ui"}
       keyVaults:
         civil-cui:
           resourceGroup: civil-citizen-ui

--- a/apps/civil/civil-citizen-ui/perftest.yaml
+++ b/apps/civil/civil-citizen-ui/perftest.yaml
@@ -35,4 +35,4 @@ spec:
             - name: launch-darkly-sdk-key-non-prod
               alias: LAUNCH_DARKLY_SDK_KEY
       environment:
-        DUMMY_RESTART_VAR: 1
+        DUMMY_RESTART_VAR: 2

--- a/apps/civil/civil-citizen-ui/perftest.yaml
+++ b/apps/civil/civil-citizen-ui/perftest.yaml
@@ -19,7 +19,7 @@ spec:
       devcpuLimits: 2
       devmemoryLimits: 2G
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/civil/citizen-ui:pr-7986-71632f2-20260729152112 #{"$imagepolicy": "flux-system:perftest-civil-citizen-ui"}
+      image: hmctsprod.azurecr.io/civil/citizen-ui:prod-8af131f-20260729145326 #{"$imagepolicy": "flux-system:perftest-civil-citizen-ui"}
       keyVaults:
         civil-cui:
           resourceGroup: civil-citizen-ui


### PR DESCRIPTION
## Change

- replace the Civil Citizen UI perftest `pr-7986` image with the current `prod-*` image used by the base/master deployment
- restore the perftest Flux image policy to track `prod-*` tags
- remove the temporary annotation that disabled production image automation

This allows future successful master builds to update the perftest deployment automatically.

## Verification

- `git diff --check`
- both edited files parse as valid YAML
- `kubectl kustomize apps/civil/perftest/base --load-restrictor LoadRestrictionsNone` renders successfully
- rendered CUI image: `hmctsprod.azurecr.io/civil/citizen-ui:prod-8af131f-20260729145326`