### PR TITLE
feat(apim): add apim-marketplace Flux resources (AMP-944)

### DIFF
--- a/apps/apim/aat/base/kustomization.yaml
+++ b/apps/apim/aat/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: apim
 patches:
   - path: ../../serviceaccount/aat.yaml
+  - path: ../../apim-marketplace/aat.yaml

--- a/apps/apim/apim-marketplace/aat.yaml
+++ b/apps/apim/apim-marketplace/aat.yaml
@@ -1,0 +1,7 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace
+spec:
+  values:
+    java:

--- a/apps/apim/apim-marketplace/apim-marketplace.yaml
+++ b/apps/apim/apim-marketplace/apim-marketplace.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace
+spec:
+  releaseName: apim-marketplace
+  values:
+    java:
+      image: hmctspublic.azurecr.io/apim/marketplace:prod-9dcd796-20260311135129 #{"$imagepolicy": "flux-system:apim-marketplace"}
+  chart:
+    spec:
+      chart: ./stable/apim-marketplace
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/apim/apim-marketplace/demo.yaml
+++ b/apps/apim/apim-marketplace/demo.yaml
@@ -1,0 +1,7 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace
+spec:
+  values:
+    java:

--- a/apps/apim/apim-marketplace/image-policy.yaml
+++ b/apps/apim/apim-marketplace/image-policy.yaml
@@ -1,13 +1,7 @@
-apiVersion: image.toolkit.fluxcd.io/v1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: apim-marketplace
 spec:
   imageRepositoryRef:
     name: apim-marketplace
-  filterTags:
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
-  policy:
-    numerical:
-      order: asc

--- a/apps/apim/apim-marketplace/image-policy.yaml
+++ b/apps/apim/apim-marketplace/image-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: apim-marketplace
+spec:
+  imageRepositoryRef:
+    name: apim-marketplace
+  filterTags:
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc

--- a/apps/apim/apim-marketplace/image-repo.yaml
+++ b/apps/apim/apim-marketplace/image-repo.yaml
@@ -1,8 +1,6 @@
-apiVersion: image.toolkit.fluxcd.io/v1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: apim-marketplace
-  annotations:
-    hmcts.github.com/image-registry: hmctspublic
 spec:
   image: hmctspublic.azurecr.io/apim/marketplace

--- a/apps/apim/apim-marketplace/image-repo.yaml
+++ b/apps/apim/apim-marketplace/image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: apim-marketplace
+  annotations:
+    hmcts.github.com/image-registry: hmctspublic
+spec:
+  image: hmctspublic.azurecr.io/apim/marketplace

--- a/apps/apim/apim-marketplace/preview.yaml
+++ b/apps/apim/apim-marketplace/preview.yaml
@@ -1,0 +1,7 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace
+spec:
+  values:
+    java:

--- a/apps/apim/automation/kustomization.yaml
+++ b/apps/apim/automation/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../apim-marketplace/image-repo.yaml
+  - ../apim-marketplace/image-policy.yaml

--- a/apps/apim/base/kustomization.yaml
+++ b/apps/apim/base/kustomization.yaml
@@ -4,6 +4,4 @@ resources:
   - ../../base
   - ../../base/workload-identity
   - ../apim-marketplace/apim-marketplace.yaml
-  - ../apim-marketplace/image-policy.yaml
-  - ../apim-marketplace/image-repo.yaml
 namespace: apim

--- a/apps/apim/base/kustomization.yaml
+++ b/apps/apim/base/kustomization.yaml
@@ -3,4 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../base/workload-identity
+  - ../apim-marketplace/apim-marketplace.yaml
+  - ../apim-marketplace/image-policy.yaml
+  - ../apim-marketplace/image-repo.yaml
 namespace: apim

--- a/apps/apim/demo/base/kustomization.yaml
+++ b/apps/apim/demo/base/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
 namespace: apim
+patches:
+  - path: ../../serviceaccount/demo.yaml
+  - path: ../../apim-marketplace/demo.yaml

--- a/apps/apim/serviceaccount/demo.yaml
+++ b/apps/apim/serviceaccount/demo.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "e0c75a03-b349-4915-b176-22585226def3"

--- a/apps/flux-system/automation/kustomization.yaml
+++ b/apps/flux-system/automation/kustomization.yaml
@@ -62,6 +62,7 @@ resources:
   - ../../rota/automation
   - ../../labs/automation
   - ../../pt/automation
+  - ../../apim/automation
 patches:
   - path: hmctspublic-image-repo.yaml
     target:


### PR DESCRIPTION
## Summary

- Adds `apim-marketplace` HelmRelease, ImagePolicy, and ImageRepository to the `apim` namespace
- Wires up workload identity ServiceAccount patches for `aat` (`apim-aat-mi`) and `demo` (`apim-demo-mi`)
- Adds environment-specific HelmRelease patches for `aat`, `demo`, and `preview`

## Resources added

- `apps/apim/apim-marketplace/apim-marketplace.yaml` — HelmRelease
- `apps/apim/apim-marketplace/image-policy.yaml` — ImagePolicy (prod tag filter)
- `apps/apim/apim-marketplace/image-repo.yaml` — ImageRepository (`hmctspublic.azurecr.io/apim/marketplace`)
- `apps/apim/apim-marketplace/aat.yaml`, `demo.yaml`, `preview.yaml` — env patches
- `apps/apim/serviceaccount/demo.yaml` — workload identity for demo MI

## Test plan

- [ ] Merge after `hmcts/cnp-jenkins-config` PR #1298 is merged
- [ ] After first Jenkins master build, verify Flux reconciles the HelmRelease in AAT
- [ ] Check `kubectl get helmrelease apim-marketplace -n apim` shows `Ready`