### PR TITLE
HDPI-8017: pin pcs-api java image on demo to the frozen tag

### DIFF
--- a/apps/pcs/pcs-api/demo.yaml
+++ b/apps/pcs/pcs-api/demo.yaml
@@ -6,6 +6,13 @@ spec:
   values:
     image: hmctsprod.azurecr.io/pcs/api:prod-111cefc-20260720134353 #{"$imagepolicy": "flux-system:demo-pcs-api"}
     java:
+      # Freeze: java image pinned alongside the base image pin above while
+      # Liberata phase 2 testing runs against demo. The shared automation
+      # marker in pcs-api.yaml otherwise rolls java onto every prod build;
+      # post-squash images (V001 baseline, HDPI-7834) cannot start against
+      # demo's pre-squash database. Remove both pins together after the
+      # database is reset to the new baseline.
+      image: hmctsprod.azurecr.io/pcs/api:prod-111cefc-20260720134353
       environment:
         HASH_PINS_ENABLED: "false"
         ENABLE_TESTING_SUPPORT: "true"


### PR DESCRIPTION
### What
Adds `values.java.image` to the pcs-api demo override, pinned to `prod-111cefc-20260720134353` - the same tag as the existing base image pin.

### Why
Demo is frozen for Liberata phase 2 testing. The 20 Jul freeze pinned `values.image` (with a pinned demo image policy) but missed `values.java.image`, which carries the shared `flux-system:pcs-api` automation marker in `pcs-api.yaml`. Image automation therefore rolled demo's java container onto every prod build.

The prod images published on 30 Jul contain the squashed `V001__r1a_baseline_schema.sql` (HDPI-7834). Against demo's pre-squash database Flyway validation fails (`checksum mismatch for migration version 001`) and the pod crashes before startup. `pcs-api-java` on cft-demo-00/01 has been in CrashLoopBackOff since 30 Jul 11:25 (98+ restarts).

### Scope
- Demo only. ITHC has the same fault but should have its database reset to the new baseline rather than a pin (it needs to track current code for ITHC).
- Remove this pin together with the base pin once the demo database is reset post-Liberata.

Refs: HDPI-7990 (environment parity), incident thread 31 Jul.