### PR TITLE
fix(apim): replace hmctspublic ACR with hmctsprod in apim-marketplace (AMP-944)

### DIFF
--- a/apps/apim/apim-marketplace/apim-marketplace.yaml
+++ b/apps/apim/apim-marketplace/apim-marketplace.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: apim-marketplace
   values:
     java:
-      image: hmctspublic.azurecr.io/apim/marketplace:prod-9dcd796-20260311135129 #{"$imagepolicy": "flux-system:apim-marketplace"}
+      image: hmctsprod.azurecr.io/apim/marketplace:prod-9dcd796-20260311135129 #{"$imagepolicy": "flux-system:apim-marketplace"}
   chart:
     spec:
       chart: ./stable/apim-marketplace

--- a/apps/apim/apim-marketplace/image-repo.yaml
+++ b/apps/apim/apim-marketplace/image-repo.yaml
@@ -3,4 +3,4 @@ kind: ImageRepository
 metadata:
   name: apim-marketplace
 spec:
-  image: hmctspublic.azurecr.io/apim/marketplace
+  image: hmctsprod.azurecr.io/apim/marketplace


### PR DESCRIPTION
## Summary

- Updates `apps/apim/apim-marketplace/image-repo.yaml` image from `hmctspublic.azurecr.io` to `hmctsprod.azurecr.io`
- Updates `apps/apim/apim-marketplace/apim-marketplace.yaml` HelmRelease seed image tag to use `hmctsprod.azurecr.io`

## Reason

Platform has migrated from `hmctspublic` to `hmctsprod.azurecr.io` for service images. Aligns Flux image automation with the new registry.

## Test plan

- [ ] `kustomize build clusters/ptl-intsvc/base` still produces valid ImageRepository for `apim-marketplace`
- [ ] Flux image automation continues to reconcile correctly after merge