### PR TITLE
DTSPO-33837 - Increase jenkins ptl memory limits

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -18,10 +18,10 @@ spec:
       resources:
         requests:
           cpu: "4"
-          memory: "22Gi"
+          memory: "28Gi"
         limits:
           cpu: "6"
-          memory: "22Gi"
+          memory: "28Gi"
       JCasC:
         configScripts:
           welcome-message: |


### PR DESCRIPTION
### Jira link

See [DTSPO-33837](https://tools.hmcts.net/jira/browse/DTSP-33837)

### Change description

Bumping memory requests and limits for jenkins ptl
Trying to ease UI slowness and build delays
Working on a library based fix to reduce the number of files being stashed as well

<img width="1465" height="200" alt="Screenshot 2026-08-03 at 10 33 45" src="https://github.com/user-attachments/assets/c13d7aa2-b10b-4b5f-973f-5e445bbca86d" />


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
