### PR TITLE
SIDM-10409: enable PASSWORD_RESET_V2 in sandbox hmcts-access

### DIFF
--- a/apps/idam/idam-hmcts-access/sbox.yaml
+++ b/apps/idam/idam-hmcts-access/sbox.yaml
@@ -15,3 +15,4 @@ spec:
       environment:
         STRATEGIC_SERVICE_URL: 'https://idam-api.sandbox.platform.hmcts.net'
         STRATEGIC_TESTING_URL: 'https://idam-testing-support-api.sandbox.platform.hmcts.net'
+        PASSWORD_RESET_V2_ENABLED: true


### PR DESCRIPTION
Enable `PASSWORD_RESET_V2_ENABLED: true` in `apps/idam/idam-hmcts-access/sbox.yaml