### PR TITLE
configure-et-pet-demo

### DIFF
--- a/apps/et-pet/et-pet-admin/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-admin/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-admin
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-admin
+  filterTags:
+    pattern: '^pr-762-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/et-pet/et-pet-api/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-api/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-api
+  filterTags:
+    pattern: '^pr-753-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/et-pet/et-pet-api/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-api/demo-image-policy.yaml
@@ -8,7 +8,7 @@ spec:
   imageRepositoryRef:
     name: et-pet-api
   filterTags:
-    pattern: '^pr-753-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-762-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/et-pet/et-pet-ccd-export/demo-image-policy.yaml
+++ b/apps/et-pet/et-pet-ccd-export/demo-image-policy.yaml
@@ -2,6 +2,14 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: demo-et-pet-ccd-export
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: et-pet-ccd-export
+  filterTags:
+    pattern: '^pr-413-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc


### PR DESCRIPTION


### Change description

A temporat change to point demo to the new database backed solid_queue in both the API and the ccd exporter

