### PR TITLE
Revert "disable cicd ahead of versioned release"

### DIFF
--- a/apps/idam/idam-api/idam-api.yaml
+++ b/apps/idam/idam-api/idam-api.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-c66498a-20260731160827
+      image: hmctsprod.azurecr.io/idam/api:prod-c66498a-20260731160827 # {"$imagepolicy": "flux-system:idam-api"}
       replicas: 2
       cpuRequests: '160m'
       cpuLimits: '1500m'

--- a/apps/idam/idam-api/prod.yaml
+++ b/apps/idam/idam-api/prod.yaml
@@ -7,4 +7,4 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:prod-c66498a-20260731160827
+      image: hmctsprod.azurecr.io/idam/api:prod-c66498a-20260731160827 # {"$imagepolicy": "flux-system:idam-api"}


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#46636