### PR TITLE
fix(apim): complete Flux HelmRelease config for apim-marketplace

### DIFF
--- a/apps/apim/apim-marketplace/aat.yaml
+++ b/apps/apim/apim-marketplace/aat.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   values:
     java:
+      ingressHost: apim-marketplace.aat.platform.hmcts.net

--- a/apps/apim/apim-marketplace/demo.yaml
+++ b/apps/apim/apim-marketplace/demo.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   values:
     java:
+      ingressHost: apim-marketplace.demo.platform.hmcts.net

--- a/apps/apim/apim-marketplace/image-policy.yaml
+++ b/apps/apim/apim-marketplace/image-policy.yaml
@@ -1,7 +1,15 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: apim-marketplace
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc
   imageRepositoryRef:
     name: apim-marketplace

--- a/apps/apim/apim-marketplace/image-repo.yaml
+++ b/apps/apim/apim-marketplace/image-repo.yaml
@@ -1,6 +1,8 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: apim-marketplace
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
 spec:
   image: hmctsprod.azurecr.io/apim/marketplace


### PR DESCRIPTION
## Summary
- Fix `image-policy.yaml` and `image-repo.yaml` apiVersion (`v1beta2` → `v1`)
- Add `filterTags` prod pattern and `numerical` policy so Flux tracks the correct image tags
- Add `hmcts.github.com/image-registry: hmctsprod` annotation to image repo
- Set `ingressHost` for AAT (`apim-marketplace.aat.platform.hmcts.net`) and demo (`apim-marketplace.demo.platform.hmcts.net`)

## Test plan
- [ ] Flux reconciles `apim-marketplace` HelmRelease in AAT after merge
- [ ] `kubectl get helmrelease apim-marketplace -n apim` shows `Ready`
- [ ] `https://apim-marketplace.aat.platform.hmcts.net/health` returns 200

Part of AMP-944