### PR TITLE
Revert xui-webapp prod image back to master

### DIFF
--- a/apps/xui/xui-webapp/xui-webapp.yaml
+++ b/apps/xui/xui-webapp/xui-webapp.yaml
@@ -8,7 +8,7 @@ spec:
     nodejs:
       replicas: 2
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/xui/webapp:prod-c86b296-20260723160911
+      image: hmctsprod.azurecr.io/xui/webapp:prod-5038207-20260806091919 #{"$imagepolicy": "flux-system:xui-webapp"}
       environment:
         FEATURE_COMPRESSION_ENABLED: false
   chart:


### PR DESCRIPTION
Revert prod image to master

### Jira link

https://tools.hmcts.net/jira/browse/EXUI-2645

### Change description

Revert prod image back to master

### Testing done

N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ x ] No
