### PR TITLE
Update Helm chart version to 1.0.7

### DIFF
--- a/apps/et/et-cron-wa-task-for-expired-bfactions/et-cron-wa-task-for-expired-bfactions.yaml
+++ b/apps/et/et-cron-wa-task-for-expired-bfactions/et-cron-wa-task-for-expired-bfactions.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: et-cron
-      version: 1.0.5
+      version: 1.0.7
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci


### PR DESCRIPTION
This pull request updates the Helm chart version for the `et-cron-wa-task-for-expired-bfactions` deployment. The only change is a version bump to ensure the deployment uses the latest chart.

* Increased the `et-cron` Helm chart version from `1.0.5` to `1.0.7` in `et-cron-wa-task-for-expired-bfactions.yaml` to pull in the latest chart updates.