### PR TITLE
HDPI-8173: repin demo pcs-frontend to live image (freeze pin deleted by ACR retention)

### DIFF
--- a/apps/pcs/pcs-frontend/demo.yaml
+++ b/apps/pcs/pcs-frontend/demo.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/pcs/frontend:prod-7b2bbc6-20260720134829 #{"$imagepolicy": "flux-system:demo-pcs-frontend"}
+      image: hmctsprod.azurecr.io/pcs/frontend:prod-668310f-20260806145504 #{"$imagepolicy": "flux-system:demo-pcs-frontend"}
       environment:
         DEMO_VAR: "2"

--- a/apps/pcs/pcs-frontend/demo.yaml
+++ b/apps/pcs/pcs-frontend/demo.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/pcs/frontend:prod-668310f-20260806145504 #{"$imagepolicy": "flux-system:demo-pcs-frontend"}
+      image: hmctsprod.azurecr.io/pcs/frontend:prod-eb32aa1-20260813074540 #{"$imagepolicy": "flux-system:demo-pcs-frontend"}
       environment:
         DEMO_VAR: "2"


### PR DESCRIPTION
Demo pcs-frontend has been in ImagePullBackOff since ~06:20 today. The 20 Jul freeze pinned `apps/pcs/pcs-frontend/demo.yaml` to `prod-7b2bbc6-20260720134829`, which ACR retention has now deleted (oldest surviving pcs/frontend prod tag is 30 Jul).

This repins to today's `prod-668310f-20260806145504` to restore the environment. Same failure mode as the pcs-api demo image in HDPI-8017 (same freeze event).

Heads-up for reviewers: frontend prod tags only survive about a week under current retention, so this pin needs a durable follow-up: either demo returns to tracking prod normally, or the chosen image gets imported to a retention-safe repository.