### PR TITLE
ADOP enable mailinator addresses for accessibility testing

### DIFF
--- a/apps/adoption/adoption-web/aat.yaml
+++ b/apps/adoption/adoption-web/aat.yaml
@@ -10,6 +10,9 @@ spec:
         cpu:
           averageUtilization: 300 #AAT only: To prevent pods scaling when pipelines run
       environment:
+        SOCIAL_WORKER_SUPPORTED_DOMAINS:
+          - gov.uk
+          - mailinator.com
         PCQ_ENABLED: "true"
         #Pilot local-court email-Ids
         CHELMSFORD_FAMILY_COURT_EMAIL: 'chelmsfordadoptionapplication.aat@mailinator.com'


### PR DESCRIPTION
### Jira link
N/A

### Change description
Adoption is undergoing Accessibility Testing in AAT next week.  As part of this it's necessary to enable the Noitify whitelisted mailinator emails domains in AAT. (mailinator, gov.uk).

### Testing done
Already applied to Demo.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [ ] Does this PR introduce a breaking change
