### PR TITLE
Enable selected WA ITHC cronjobs

### DIFF
--- a/apps/wa/wa-task-batch-initiation/ithc.yaml
+++ b/apps/wa/wa-task-batch-initiation/ithc.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     job:
+      suspend: false
       schedule: "*/2 * * * *"
       environment:
         JOB_NAME: INITIATION

--- a/apps/wa/wa-task-batch-reconfiguration/ithc.yaml
+++ b/apps/wa/wa-task-batch-reconfiguration/ithc.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     job:
+      suspend: false
       schedule: "*/2 * * * *"
       environment:
         JOB_NAME: RECONFIGURATION

--- a/apps/wa/wa-task-batch-termination/ithc.yaml
+++ b/apps/wa/wa-task-batch-termination/ithc.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   values:
     job:
+      suspend: false
       schedule: "*/2 * * * *"
       environment:
         JOB_NAME: TERMINATION


### PR DESCRIPTION
## Summary
- set job.suspend to false for WA task-batch initiation, reconfiguration and termination cronjobs in ITHC

## Verification
- checked the PR diff only changes the initiation, reconfiguration and termination ITHC cronjob patches
- checked no apps/wa ithc.yaml files contain enabled: true