### PR TITLE
aac: DTSCCI-6085 add civil_service to ITHC NoC S2S allow-list

### DIFF
--- a/apps/aac/manage-case-assignment/ithc.yaml
+++ b/apps/aac/manage-case-assignment/ithc.yaml
@@ -6,7 +6,7 @@ spec:
   values:
     java:
       environment:
-        MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,fpl_case_service,prl_cos_api,et_cos,nfdiv_case_api,et_sya_api,pt_api,pcs_api
+        MANAGE_CASE_S2S_AUTHORISED_SERVICES: xui_webapp,ccd_data,finrem_case_orchestration,divorce_frontend,iac,nfdiv_cos,fpl_case_service,prl_cos_api,et_cos,civil_service,nfdiv_case_api,et_sya_api,pt_api,pcs_api
         MCA_DS_PROXY_URLS_ALLOWED_LIST: /searchCases.*,/internal/searchCases.*,/internal/cases.*
         CCD_DEFINITION_STORE_API_BASE_URL: http://ccd-definition-store-api-ithc.service.core-compute-ithc.internal
         MCA_DEF_STORE_PROXY_URLS_ALLOWED_LIST: /api/display/challenge-questions.*


### PR DESCRIPTION
## What
Adds `civil_service` to `MANAGE_CASE_S2S_AUTHORISED_SERVICES` in the **AAC** (manage-case-assignment) **ITHC** overlay (`apps/aac/manage-case-assignment/ithc.yaml`).

## Why
Notice of Change fails in ITHC with "Failed service validation: CIVIL". civil-service pod logs show a **403 Forbidden** from `aac-manage-case-assignment-ithc.../noc/check-noc-approval`. Root cause: AAC only accepts S2S calls from services in `MANAGE_CASE_S2S_AUTHORISED_SERVICES`, and `civil_service` was **missing from the ITHC overlay** (it is present in aat/demo/perftest/base, where NoC works). So AAC rejects civil-service's NoC callback.

Reproduced on ITHC cases `1786-4492-7177-5972` and `1786-4545-2976-1261`; the identical flow succeeds on AAT.

## Change
```
- ...,et_cos,nfdiv_case_api,...
+ ...,et_cos,civil_service,nfdiv_case_api,...
```
(placed next to `et_cos`, mirroring the AAT overlay)

## Impact
Unblocks Notice of Change in ITHC ahead of the pen test / software assurance review (starts 24 Aug 2026). Config-only, single environment (ITHC), no code.

Jira: DTSCCI-6085

🤖 Generated with [Claude Code](https://claude.com/claude-code)