### PR TITLE
DTSPO-34106 - Testing multiple jenkinsfiles in sandbox

### DIFF
--- a/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/sbox-intsvc/jenkins.yaml
@@ -385,3 +385,27 @@ spec:
                             emptyDir:
                           - name: volume-4
                             emptyDir:
+          jobs: |
+            jobs:
+              - url: https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/test-second-pipeline-sandbox/jobdsl/organisations-beta.groovy
+              - script: >
+                  pipelineJob('Seed Job') {
+                    triggers {
+                      cron('H 8,11,14,17 * * 1-5')
+                    }
+                    definition {
+                      cpsScm {
+                        scm {
+                          git {
+                            remote {
+                              github('hmcts/cnp-jenkins-config')
+                              credentials('hmcts-jenkins-cnp')
+                            }
+                            branch('test-second-pipeline-sandbox')
+                          }
+                        }
+                        scriptPath('jobdsl/Jenkinsfile_seed')
+                        lightweight(true)
+                      }
+                    }
+                  }


### PR DESCRIPTION
### Jira link

See [DTSPO-34016](https://tools.hmcts.net/jira/browse/DTSP-34016)

### Change description

This has originally came up as a potential thing we'd like to do for this docmosis work
It is also something the performance testing team are interested in for their repos
Testing the ability to have multiple jenkinsfiles within the same repo and how can could work (if at all)
See https://github.com/hmcts/cnp-jenkins-config/tree/test-second-pipeline-sandbox

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
