### PR TITLE
DTSAM-1104 Enable `disposer_1_1` RAS flag in PerfTest

### DIFF
--- a/apps/am/am-role-assignment-service/perftest.yaml
+++ b/apps/am/am-role-assignment-service/perftest.yaml
@@ -10,7 +10,7 @@ spec:
         APPLICATION_LOGGING_LEVEL: INFO
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 20
-        DB_FEATURE_FLAG_ENABLE: sscs_wa_1_0
+        DB_FEATURE_FLAG_ENABLE: disposer_1_1
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api,wa_reporting_frontend,pt_api
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false


### PR DESCRIPTION
### Jira link

[DTSAM-1104](https://tools.hmcts.net/jira/browse/DTSAM-1104) _"Enable 'disposer_1_1' RAS flag in a lower environment ready for R&D team to test"_

### Change description

Enable `disposer_1_1` RAS flag in **PerfTest**.

This is to allow PerfTest team to tidy up test data in this environment.

> NB: This enables the following change in *PerfTest*:
> * hmcts/am-role-assignment-service#2614