### PR TITLE
Enable ET decentralised routing in perftest

### DIFF
--- a/apps/ccd/ccd-data-store-api/perftest.yaml
+++ b/apps/ccd/ccd-data-store-api/perftest.yaml
@@ -45,3 +45,19 @@ spec:
         FEIGN_CLIENT_READ_TIMEOUT: 29000
         HTTP_CLIENT_CONNECTION_DEFINITION_STORE_TIMEOUT: 8000
         UPLOAD_TIMESTAMP_FEATURED_CASE_TYPES: xuiTestCaseType_dev,AAT_AUTH_15,BEFTA_CASETYPE_2_1,BEFTA_CASETYPE_2_2,abc,BEFTA_CASETYPE_3_2,FT_MasterCaseType,FT_CaseFileView_1,FT_CaseFileView_2,FT_CRUD_2,FinancialRemedyContested,CARE_SUPERVISION_EPO,CIVIL,GENERALAPPLICATION,PRLAPPS,GrantOfRepresentation
+        SPRING_APPLICATION_JSON: |
+          {
+            "ccd": {
+              "decentralised": {
+                "case-type-service-urls": {
+                  "ET_EnglandWales": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Scotland": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_EnglandWales_Listings": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Scotland_Listings": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_EnglandWales_Multiple": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Scotland_Multiple": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Admin": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+                }
+              }
+            }
+          }


### PR DESCRIPTION
## Summary
- route ET case types in perftest CCD data-store to et-cos via decentralised case-type service URLs
- mirror the AAT ET decentralised routing pattern for ET_EnglandWales, ET_Scotland, listings, multiple, and admin case types

## Notes
- compared AAT and perftest CCD data-store env vars; the ET-specific missing setting was the SPRING_APPLICATION_JSON routing block
- perftest et-cos already has decentralised runtime/indexer-related settings enabled
- did not copy AAT-only debug/test-support or PCS/PT settings because they are not needed for ET decentralised routing

## Validation
- ruby -ryaml -e 'YAML.load_file("apps/ccd/ccd-data-store-api/perftest.yaml"); puts "yaml ok"'
- ruby -ryaml -rjson -e 'env=YAML.load_file("apps/ccd/ccd-data-store-api/perftest.yaml").dig("spec","values","java","environment"); JSON.parse(env.fetch("SPRING_APPLICATION_JSON")); puts "json ok"'
- tests/lint-yaml.sh could not run locally because yamllint is not installed
- dry-run kustomize checks could not run locally because yq, flux, kustomize, and kubeconform are not installed