### PR TITLE
HDPI-8342: demo inherits base images for pcs-api and pcs-frontend

### DIFF
--- a/apps/pcs/pcs-api/demo.yaml
+++ b/apps/pcs/pcs-api/demo.yaml
@@ -4,7 +4,6 @@ metadata:
   name: pcs-api
 spec:
   values:
-    image: hmctsprod.azurecr.io/pcs/api:pr-2313 #{"$imagepolicy": "flux-system:demo-pcs-api"}
     java:
       environment:
         HASH_PINS_ENABLED: "false"

--- a/apps/pcs/pcs-frontend/demo.yaml
+++ b/apps/pcs/pcs-frontend/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/pcs/frontend:prod-eb32aa1-20260813074540 #{"$imagepolicy": "flux-system:demo-pcs-frontend"}
       environment:
         DEMO_VAR: "2"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/HDPI-8342

### Change description

Removes both demo image overrides so demo tracks the base image for pcs-api and pcs-frontend.

The pcs-api demo pin (pr-2313) sat at `values.image`, a key the java chart never reads (the chart consumes `values.java.image`, inherited from base where the image automation marker is live). Demo api has therefore been tracking base all along and the line was dead config with an inert marker.

The pcs-frontend demo pin (prod-eb32aa1-20260813074540, 13 Aug) was live but frozen. pcs/frontend prod tags are retained for roughly seven days, so the pinned tag had about two days left before deletion, which would repeat the HDPI-8173 ErrImagePull outage on the next pod restart.

After this change both demo apps inherit the base tag (currently prod-d5a9e47 for api, prod-1c8a156 for frontend, both auto-updated). The now-unused demo-pcs-api and demo-pcs-frontend ImagePolicy objects can be cleaned up in a follow-up.

### Testing done

Verified against both demo clusters: api already runs the base tag (proving the pin was inert), frontend currently runs the pinned 13 Aug tag and will roll forward to the base tag on reconcile. DEMO_VAR and testing-support values are untouched.
