### PR TITLE
HDPI-8460: unpin demo frontend from non-existent PR image, restore base inherit

### DIFF
--- a/apps/pcs/pcs-frontend/demo.yaml
+++ b/apps/pcs/pcs-frontend/demo.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/pcs/frontend:pr-1917-c61122d-20260818101324 #{"$imagepolicy": "flux-system:demo-pcs-frontend"}
       environment:
         DEMO_VAR: "2"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/HDPI-8460

### Change description

Removes the demo `nodejs.image` override (and its image automation marker) so demo frontend inherits the base image again, exactly the HDPI-8342 state.

Demo has served 502 since about 21:00 on 19 Aug: PR 46957 pinned the demo frontend to `pr-1917-c61122d-20260818101324`, a PR build of a now-closed pcs-frontend PR. That tag exists in neither hmctsprod nor hmctspublic, so both demo clusters have had zero ready frontend pods (ImagePullBackOff) ever since. The pin never worked for anyone.

After this change demo rolls to the current base tag, which exists and is auto-updated. If a demo freeze is genuinely needed for pr-1917's successor, the safe recipe is az acr import to a retention-safe repo plus a ticketed pin, per HDPI-8342.

### Testing done

Verified the failing state on both demo clusters (ImagePullBackOff on the pinned tag, api healthy) and confirmed the tag is absent from both registries. After merge, expect pcs-frontend pods to roll to the base tag and https://pcs.demo.platform.hmcts.net/ to return its healthy 302-to-login.