### PR TITLE
feat(AMP-1018): deploy apim-marketplace to CNP sbox via Flux

### DIFF
--- a/apps/cnp/apim-marketplace/apim-marketplace.yaml
+++ b/apps/cnp/apim-marketplace/apim-marketplace.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace
+spec:
+  releaseName: apim-marketplace
+  values:
+    java:
+      image: hmctsprod.azurecr.io/apim/marketplace:prod-86e9b66-20260819000000 # {"$imagepolicy": "flux-system:apim-marketplace"}
+  chart:
+    spec:
+      chart: ./stable/apim-marketplace
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/cnp/apim-marketplace/image-policy.yaml
+++ b/apps/cnp/apim-marketplace/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: apim-marketplace
+spec:
+  imageRepositoryRef:
+    name: apim-marketplace

--- a/apps/cnp/apim-marketplace/image-repo.yaml
+++ b/apps/cnp/apim-marketplace/image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: apim-marketplace
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
+spec:
+  image: hmctsprod.azurecr.io/apim/marketplace

--- a/apps/cnp/apim-marketplace/sbox.yaml
+++ b/apps/cnp/apim-marketplace/sbox.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace
+spec:
+  values:
+    java:
+      ingressHost: apim-marketplace-sandbox.service.core-compute-sandbox.internal
+      keyVaults: {}
+      environment:
+        APPLICATIONINSIGHTS_ENABLED: "false"
+        APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=00000000-0000-0000-0000-000000000000"
+        SPRING_AUTOCONFIGURE_EXCLUDE: >-
+          org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration,
+          org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration,
+          org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration

--- a/apps/cnp/base/kustomization.yaml
+++ b/apps/cnp/base/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ../plum-frontend/plum-frontend.yaml
   - ../plum-recipe-backend/plum-recipe-backend.yaml
   - ../plum-recipe-receiver/plum-recipe-receiver.yaml
+  - ../apim-marketplace/apim-marketplace.yaml
   - ../plum-fastapi-backend/plum-fastapi-backend.yaml
 namespace: cnp

--- a/apps/cnp/sbox/base/kustomization.yaml
+++ b/apps/cnp/sbox/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - descheduler-helmrepo.yaml
 namespace: cnp
 patches:
+  - path: ../../apim-marketplace/sbox.yaml
   - path: ../../plum-fastapi-backend/sbox.yaml
   - path: ../../banana-frontend/sbox.yaml
   - path: ../../banana-backend/sbox.yaml


### PR DESCRIPTION
## Summary
- Adds Flux `HelmRelease`, `ImageRepository` and `ImagePolicy` for `apim-marketplace` in the CNP sbox cluster
- Sbox deployment disables postgres and vault (`SPRING_AUTOCONFIGURE_EXCLUDE`) so the pod starts cleanly without sbox infrastructure
- Wires the service into `apps/cnp/base/kustomization.yaml` and `apps/cnp/sbox/base/kustomization.yaml`
- Goal: prove SPS APIM sbox → CNP sbox network routing works end-to-end

## Test plan
- [ ] Pod starts in CNP sbox (`kubectl get pods -n cnp | grep marketplace`)
- [ ] `GET https://apim-marketplace-sandbox.service.core-compute-sandbox.internal/` returns 200
- [ ] Register API in `sps-api-mgmt-sbox` with backend URL `https://apim-marketplace-sandbox.service.core-compute-sandbox.internal` and confirm no 500