### PR TITLE
fix(AMP-1018): null out apim vault in sbox to prevent failed mount

### DIFF
--- a/apps/cnp/apim-marketplace/sbox.yaml
+++ b/apps/cnp/apim-marketplace/sbox.yaml
@@ -6,7 +6,8 @@ spec:
   values:
     java:
       ingressHost: apim-marketplace-sandbox.service.core-compute-sandbox.internal
-      keyVaults: {}
+      keyVaults:
+        apim: ~
       environment:
         APPLICATIONINSIGHTS_ENABLED: "false"
         APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Summary
- Fixes `Init:0/1` failure for `apim-marketplace` in CNP sbox
- `keyVaults: {}` was not overriding the chart's default vault config — explicitly nulling the `apim` vault key prevents the CSI driver from attempting to mount `apim-aat` secrets

## Test plan
- [ ] Pod starts in CNP sbox (`kubectl get pods -n cnp | grep marketplace`)