### PR TITLE
AMP-1031: add apim-marketplace-web

### DIFF
--- a/apps/apim/aat/base/kustomization.yaml
+++ b/apps/apim/aat/base/kustomization.yaml
@@ -7,3 +7,4 @@ namespace: apim
 patches:
   - path: ../../serviceaccount/aat.yaml
   - path: ../../apim-marketplace/aat.yaml
+  - path: ../../apim-marketplace-web/aat.yaml

--- a/apps/apim/apim-marketplace-web/aat.yaml
+++ b/apps/apim/apim-marketplace-web/aat.yaml
@@ -1,0 +1,8 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace-web
+spec:
+  values:
+    nodejs:
+      ingressHost: apim-marketplace-web.aat.platform.hmcts.net

--- a/apps/apim/apim-marketplace-web/apim-marketplace-web.yaml
+++ b/apps/apim/apim-marketplace-web/apim-marketplace-web.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace-web
+spec:
+  releaseName: apim-marketplace-web
+  values:
+    nodejs:
+      image: hmctsprod.azurecr.io/apim/marketplace-web:latest #{"$imagepolicy": "flux-system:apim-marketplace-web"}
+  chart:
+    spec:
+      chart: ./stable/apim-marketplace-web
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/apim/apim-marketplace-web/apim-marketplace-web.yaml
+++ b/apps/apim/apim-marketplace-web/apim-marketplace-web.yaml
@@ -6,7 +6,7 @@ spec:
   releaseName: apim-marketplace-web
   values:
     nodejs:
-      image: hmctsprod.azurecr.io/apim/marketplace-web:latest #{"$imagepolicy": "flux-system:apim-marketplace-web"}
+      image: hmctsprod.azurecr.io/apim/marketplace-web:prod-0000000-00000000000000 #{"$imagepolicy": "flux-system:apim-marketplace-web"}
   chart:
     spec:
       chart: ./stable/apim-marketplace-web

--- a/apps/apim/apim-marketplace-web/demo.yaml
+++ b/apps/apim/apim-marketplace-web/demo.yaml
@@ -1,0 +1,8 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: apim-marketplace-web
+spec:
+  values:
+    nodejs:
+      ingressHost: apim-marketplace-web.demo.platform.hmcts.net

--- a/apps/apim/apim-marketplace-web/image-policy.yaml
+++ b/apps/apim/apim-marketplace-web/image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: apim-marketplace-web
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    numerical:
+      order: asc
+  imageRepositoryRef:
+    name: apim-marketplace-web

--- a/apps/apim/apim-marketplace-web/image-repo.yaml
+++ b/apps/apim/apim-marketplace-web/image-repo.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: apim-marketplace-web
+  annotations:
+    hmcts.github.com/image-registry: hmctsprod
+spec:
+  image: hmctsprod.azurecr.io/apim/marketplace-web

--- a/apps/apim/automation/kustomization.yaml
+++ b/apps/apim/automation/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
   - ../apim-marketplace/image-repo.yaml
   - ../apim-marketplace/image-policy.yaml
+  - ../apim-marketplace-web/image-repo.yaml
+  - ../apim-marketplace-web/image-policy.yaml

--- a/apps/apim/base/kustomization.yaml
+++ b/apps/apim/base/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - ../../base
   - ../../base/workload-identity
   - ../apim-marketplace/apim-marketplace.yaml
+  - ../apim-marketplace-web/apim-marketplace-web.yaml
 namespace: apim

--- a/apps/apim/demo/base/kustomization.yaml
+++ b/apps/apim/demo/base/kustomization.yaml
@@ -7,3 +7,4 @@ namespace: apim
 patches:
   - path: ../../serviceaccount/demo.yaml
   - path: ../../apim-marketplace/demo.yaml
+  - path: ../../apim-marketplace-web/demo.yaml


### PR DESCRIPTION
Adds the API Marketplace web frontend to the existing `apim` namespace, alongside
`apim-marketplace`.

- `apps/apim/apim-marketplace-web/` — HelmRelease, ImageRepository, ImagePolicy,
  plus `aat.yaml` / `demo.yaml` ingress patches
- Wired into `apps/apim/base`, `apps/apim/automation`, and the `aat` / `demo` overlays

Mirrors `apim-marketplace` exactly, with a `nodejs:` values block instead of `java:`.
Registry is `hmctsprod` throughout. No preview overlay is needed — `apps/apim/preview/base`
references the global base rather than `apps/apim/base`, so preview comes from the
Jenkins helm install.

`apps/apim/automation` is already registered in `apps/flux-system/automation`, so no
change is needed there.

Validated locally with `kubectl kustomize --load-restrictor LoadRestrictionsNone` on
`apps/apim/base`, `apps/apim/aat/base`, `apps/apim/demo/base` and `apps/apim/automation`
— all build, and the AAT overlay renders:

```
image:       hmctsprod.azurecr.io/apim/marketplace-web:latest
ingressHost: apim-marketplace-web.aat.platform.hmcts.net
```

Note: the HelmRelease will not reconcile until the first successful master build of
hmcts/web-api-marketplace publishes the `apim-marketplace-web` chart to hmcts-charts.

Repo: https://github.com/hmcts/web-api-marketplace
Ticket: AMP-1031
