### PR TITLE
fix(AMP-1018): disable key vaults globally in sbox

### DIFF
--- a/apps/apim/apim-marketplace/sbox.yaml
+++ b/apps/apim/apim-marketplace/sbox.yaml
@@ -4,10 +4,10 @@ metadata:
   name: apim-marketplace
 spec:
   values:
+    global:
+      enableKeyVaults: false
     java:
       ingressHost: apim-marketplace-sandbox.service.core-compute-sandbox.internal
-      keyVaults:
-        apim: ~
       environment:
         APPLICATIONINSIGHTS_ENABLED: "false"
         APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
## Summary
- Sets `global.enableKeyVaults: false` in `apps/apim/apim-marketplace/sbox.yaml`
- Replaces the previous `keyVaults: apim: ~` approach which was not fully suppressing the CSI secrets-store vault mount on sbox
- The sbox cluster does not have the secrets-store CSI driver, so vault mounts must be fully disabled

## Test plan
- [ ] Pod in `apim` namespace on `cft-sbox-00-aks` starts cleanly without vault mount errors