### PR TITLE
POFCC-394 Enable `ga_prm_1_0` RAS flag in PerfTest

### DIFF
--- a/apps/am/am-role-assignment-service/perftest.yaml
+++ b/apps/am/am-role-assignment-service/perftest.yaml
@@ -10,7 +10,7 @@ spec:
         APPLICATION_LOGGING_LEVEL: INFO
         BYPASS_ORG_DROOL_RULE: true
         MAX_POOL_SIZE: 20
-        DB_FEATURE_FLAG_ENABLE: sscs_wa_1_0
+        DB_FEATURE_FLAG_ENABLE: ga_prm_1_0
         ROLE_ASSIGNMENT_S2S_AUTHORISED_SERVICES: ccd_gw,am_role_assignment_service,am_org_role_mapping_service,am_role_assignment_refresh_batch,wa_task_management_api,wa_task_configuration_api,xui_webapp,aac_manage_case_assignment,ccd_data,wa_workflow_api,wa_task_monitor,wa_case_event_handler,iac,hmc_cft_hearing_service,ccd_case_disposer,sscs,fis_hmc_api,fpl_case_service,disposer-idam-user,civil_service,prl_cos_api,pcs_api,wa_reporting_frontend,pt_api
         RUN_DB_MIGRATION_ON_STARTUP: true
         DUMMY_VAR: false


### PR DESCRIPTION
### Jira link

[POFCC-394](https://tools.hmcts.net/jira/browse/POFCC-394) _"Enable group access in perftest - am"_

### Change description

Enabling group access in AM (Part 2: RAS DB Flag)

> Part 1: see #47019

### Testing done

This has been enabled and tested in aat

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
