### PR TITLE
SIDM-10508 update Sandbox IDAM API image

### DIFF
--- a/apps/idam/idam-api/sbox.yaml
+++ b/apps/idam/idam-api/sbox.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: idam-api
   values:
     java:
-      image: hmctsprod.azurecr.io/idam/api:preview-4331f55-20260819123430
+      image: hmctsprod.azurecr.io/idam/api:preview-d7f38b5-20260824163606
       ingressHost: idam-api.sandbox.platform.hmcts.net
       disableTraefikTls: true
       replicas: 1


### PR DESCRIPTION
## Summary
- Update only the Sandbox IDAM API image
- Replace the deleted preview-4331f55 image tag
- Use the verified ACR image preview-d7f38b5-20260824163606


## Reason
The previous Sandbox image tag no longer exists in ACR, causing idam-api to remain in ImagePullBackOff and idam-web-public to fail readiness.