### PR TITLE
Fix Sandbox WebPublic SSO configuration

### DIFF
--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -18,7 +18,6 @@ spec:
         STRATEGIC_ENDPOINT_FORGOTPASSWORD: forgotPasswordDetails
         spring.security.oauth2.client.provider.moj.issuer-uri: https://sts.windows.net/34c125c9-c7f3-486f-a78c-cf762c718831/
         SSOEMAILDOMAINS_EJUDICIARY_NET: ejudiciary-aad
-        LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_IDAM_WEB: DEBUG
         strategic_content_security_policy_form_action: "https: http:"
         TRIGGER: false
   chart:

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -18,6 +18,7 @@ spec:
         STRATEGIC_ENDPOINT_FORGOTPASSWORD: forgotPasswordDetails
         spring.security.oauth2.client.provider.moj.issuer-uri: https://sts.windows.net/34c125c9-c7f3-486f-a78c-cf762c718831/
         SSOEMAILDOMAINS_EJUDICIARY_NET: ejudiciary-aad
+        LOGGING_LEVEL_UK_GOV_HMCTS_REFORM_IDAM_WEB: DEBUG
         strategic_content_security_policy_form_action: "https: http:"
         TRIGGER: false
   chart:

--- a/apps/idam/idam-web-public/sbox.yaml
+++ b/apps/idam/idam-web-public/sbox.yaml
@@ -16,6 +16,8 @@ spec:
       environment:
         STRATEGIC_SERVICE_URL: http://idam-api
         STRATEGIC_ENDPOINT_FORGOTPASSWORD: forgotPasswordDetails
+        spring.security.oauth2.client.provider.moj.issuer-uri: https://sts.windows.net/34c125c9-c7f3-486f-a78c-cf762c718831/
+        SSOEMAILDOMAINS_EJUDICIARY_NET: ejudiciary-aad
         strategic_content_security_policy_form_action: "https: http:"
         TRIGGER: false
   chart:


### PR DESCRIPTION
## Summary

- Configure Sandbox WebPublic to use the Sandbox MOJ issuer tenant.
- Map `ejudiciary.net` usernames to the `ejudiciary-aad` provider.

## Validation

- The focused eJudiciary Sandbox test passes after the Sandbox callback was registered and both Sandbox AKS clusters were aligned.
- The Flux checks are passing.