### PR TITLE
Merge Family Integration into Private Law

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml
@@ -332,7 +332,7 @@ spec:
                     title: Performance Test Orchestrator Dashboard
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/(prl-cos-api|prl-ccd-definitions|prl-citizen-frontend|prl-shared-infrastructure|prl-wa-task-configuration|prl-ccd-case-migration|prl-cron|prl-e2e-tests)\/master
+                      ^HMCTS.*\/(prl-cos-api|prl-ccd-definitions|prl-citizen-frontend|prl-shared-infrastructure|prl-wa-task-configuration|prl-ccd-case-migration|prl-cron|prl-e2e-tests|fis-hmc-api|family-api-gateway)\/master
                     name: PRL
                     recurse: true
                     title: Private Law
@@ -348,12 +348,6 @@ spec:
                     name: ET
                     recurse: true
                     title: Employment Tribunals
-                - buildMonitor:
-                    includeRegex: >-
-                      ^HMCTS.*\/(fis-hmc-api|family-api-gateway)\/master
-                    name: FIS
-                    recurse: true
-                    title: Family Integration
                 - buildMonitor:
                     includeRegex: >-
                       ^HMCTS.*\/(tax-tribunals-shared-infrastructure|tax-tribunals-datacapture)\/master


### PR DESCRIPTION
### Change description

Merge Family Law build dashboard with Private Law as the Private Law team is responsible for both.
