### PR TITLE
Reduce ET production migration event window

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -151,7 +151,7 @@ spec:
         CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings
-        CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "50000"
+        CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "10000"
         CCD_DATA_MIGRATION_SIGNIFICANT_ITEM_ID_WINDOW_SIZE: "5000"
         CCD_DATA_MIGRATION_MAX_BATCHES_PER_RUN: "1000000"
         CCD_DATA_MIGRATION_MAX_RUN_TIME: 2h # limit each invocation; subsequent scheduled runs resume


### PR DESCRIPTION
Reduce the ET production CCD migration event ID window from 50,000 to 10,000 after the preload query exhausted PostgreSQL temporary tablespace.