### PR TITLE
fix(AMP-1018): null out base apim vault in sbox to prevent mount of apim-sandbox

### DIFF
--- a/apps/apim/apim-marketplace/sbox.yaml
+++ b/apps/apim/apim-marketplace/sbox.yaml
@@ -13,6 +13,7 @@ spec:
         APPLICATIONINSIGHTS_ENABLED: "false"
         APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=00000000-0000-0000-0000-000000000000"
       keyVaults:
+        apim: ~
         apim-sbox:
           excludeEnvironmentSuffix: true
           secrets:


### PR DESCRIPTION
## Summary
Pod was failing to start with `MountVolume.SetUp failed for volume "vault-apim"` — it was trying to mount both `apim-sandbox` (from the base chart `keyVaults.apim`) and `apim-sbox` (from the sbox overlay).

Helm merges maps rather than replacing them, so the sbox overlay adding `apim-sbox` left the base `apim` entry intact, causing the chart to attempt mounting `apim-sandbox.vault.azure.net` — a vault owned by another team in a different tenant.

Setting `apim: ~` (YAML null) in the sbox overlay tells Helm's values merger to remove that key, leaving only `apim-sbox` mounted.

## Error
```
GET https://apim-sandbox.vault.azure.net/secrets/marketplace-POSTGRES-USER/
RESPONSE 401: Unauthorized - Invalid issuer
```

## Test plan
- [ ] After merge, flux reconciles and pod starts without vault-apim mount error
- [ ] Only `vault-apim-sbox` volume present in pod describe
- [ ] Postgres secrets readable at `/mnt/secrets/apim-sbox/`