### PR TITLE
fix(AMP-1018): move keyVaults to per-env overlays, remove ineffective apim null from sbox

### DIFF
--- a/apps/apim/apim-marketplace/aat.yaml
+++ b/apps/apim/apim-marketplace/aat.yaml
@@ -6,3 +6,16 @@ spec:
   values:
     java:
       ingressHost: apim-marketplace.aat.platform.hmcts.net
+      keyVaults:
+        apim:
+          secrets:
+            - name: marketplace-POSTGRES-USER
+              alias: POSTGRES_USER
+            - name: marketplace-POSTGRES-PASS
+              alias: POSTGRES_PASS
+            - name: marketplace-POSTGRES-HOST
+              alias: POSTGRES_HOST
+            - name: marketplace-POSTGRES-PORT
+              alias: POSTGRES_PORT
+            - name: marketplace-POSTGRES-DATABASE
+              alias: POSTGRES_DATABASE

--- a/apps/apim/apim-marketplace/demo.yaml
+++ b/apps/apim/apim-marketplace/demo.yaml
@@ -6,3 +6,16 @@ spec:
   values:
     java:
       ingressHost: apim-marketplace.demo.platform.hmcts.net
+      keyVaults:
+        apim:
+          secrets:
+            - name: marketplace-POSTGRES-USER
+              alias: POSTGRES_USER
+            - name: marketplace-POSTGRES-PASS
+              alias: POSTGRES_PASS
+            - name: marketplace-POSTGRES-HOST
+              alias: POSTGRES_HOST
+            - name: marketplace-POSTGRES-PORT
+              alias: POSTGRES_PORT
+            - name: marketplace-POSTGRES-DATABASE
+              alias: POSTGRES_DATABASE

--- a/apps/apim/apim-marketplace/preview.yaml
+++ b/apps/apim/apim-marketplace/preview.yaml
@@ -5,3 +5,16 @@ metadata:
 spec:
   values:
     java:
+      keyVaults:
+        apim:
+          secrets:
+            - name: marketplace-POSTGRES-USER
+              alias: POSTGRES_USER
+            - name: marketplace-POSTGRES-PASS
+              alias: POSTGRES_PASS
+            - name: marketplace-POSTGRES-HOST
+              alias: POSTGRES_HOST
+            - name: marketplace-POSTGRES-PORT
+              alias: POSTGRES_PORT
+            - name: marketplace-POSTGRES-DATABASE
+              alias: POSTGRES_DATABASE

--- a/apps/apim/apim-marketplace/sbox.yaml
+++ b/apps/apim/apim-marketplace/sbox.yaml
@@ -13,7 +13,6 @@ spec:
         APPLICATIONINSIGHTS_ENABLED: "false"
         APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=00000000-0000-0000-0000-000000000000"
       keyVaults:
-        apim: ~
         apim-sbox:
           excludeEnvironmentSuffix: true
           secrets:


### PR DESCRIPTION
## Summary
`apim: ~` (YAML null) in the sbox overlay does not remove the vault from pod volume mounts — Helm's template engine still includes null keys in the range loop, generating the `vault-apim` CSI volume which tries to mount `apim-sandbox.vault.azure.net` (owned by another team, 401).

Fix follows the plum-fastapi-backend pattern: base chart `values.yaml` has keyVaults commented out; each env defines its own vaults in the flux overlay.

Changes:
- `aat.yaml` — add `keyVaults.apim` (mounts `apim-aat`)
- `demo.yaml` — add `keyVaults.apim` (mounts `apim-demo`)
- `preview.yaml` — add `keyVaults.apim` (mounts `apim-preview`)
- `sbox.yaml` — remove `apim: ~` (no longer needed; base has no keyVaults)

## Companion PR
Requires `service-api-marketplace` PR #45 (comments out base keyVaults) to be merged first — otherwise AAT/demo/preview get duplicate vault mounts.

## Test plan
- [ ] After both PRs merge, sbox flux reconciles with only `vault-apim-sbox` mounted
- [ ] AAT pod continues to mount `vault-apim` (apim-aat) correctly