### PR TITLE
DTSRD-6658 Enable ORM TestingSupport APIs in PerfTest

### DIFF
--- a/apps/am/am-org-role-mapping-service/perftest.yaml
+++ b/apps/am/am-org-role-mapping-service/perftest.yaml
@@ -9,6 +9,7 @@ spec:
       environment:
         AM_INFO: false
         APPLICATION_LOGGING_LEVEL: INFO
+        TESTING_SUPPORT_ENABLED: true
         DB_FEATURE_FLAG_ENABLE: possessions_wa_1_0
         # PRD Config
         PROFESSIONAL_REFRESH_API_ENABLED: true


### PR DESCRIPTION
### Jira link

[DTSRD-6658](https://tools.hmcts.net/jira/browse/DTSRD-6658) _"Extract stats from PROD PRD to support GA PerfTest"_

### Change description

Enable the ORM TestingSupport APIs in PerfTest to aid their testing of GA.


