### PR TITLE
Point pcs-frontend at Azure Managed Redis in aat

### DIFF
--- a/apps/pcs/aat/base/kustomization.yaml
+++ b/apps/pcs/aat/base/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
 namespace: pcs
 patches:
   - path: ../../pcs-api/aat.yaml
+  - path: ../../pcs-frontend/aat.yaml
   - path: ../../serviceaccount/aat.yaml

--- a/apps/pcs/pcs-frontend/aat.yaml
+++ b/apps/pcs/pcs-frontend/aat.yaml
@@ -1,0 +1,24 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pcs-frontend
+spec:
+  values:
+    nodejs:
+      # Point sessions at the new Azure Managed Redis instance. The instance is
+      # provisioned alongside the old Azure Cache for Redis one, so rolling back
+      # is a matter of reverting this patch.
+      #
+      # The whole secrets list has to be restated: helm replaces lists rather
+      # than merging them, so anything left out here would stop being mounted.
+      keyVaults:
+        pcs:
+          secrets:
+            - name: azure-managed-redis-connection-string
+              alias: redis-connection-string # mounts at /mnt/secrets/pcs/redis-connection-string
+            - pcs-session-secret
+            - app-insights-connection-string
+            - pcs-frontend-s2s-secret
+            - pcs-frontend-idam-secret
+            - pcs-os-client-lookup-key
+            - pcs-pcq-token-key


### PR DESCRIPTION
Cuts pcs-frontend sessions over to Azure Managed Redis in aat.

Companion to hmcts/pcs-shared-infrastructure#35, which provisions an Azure Managed Redis instance alongside the existing Azure Cache for Redis one and publishes its connection string to a separate key vault secret, `azure-managed-redis-connection-string`. **That PR needs to merge and apply first** — the secret has to exist before this mounts it.

## Changes

- **`apps/pcs/pcs-frontend/aat.yaml`** (new) — mounts `azure-managed-redis-connection-string` under the `redis-connection-string` alias, so it lands at `/mnt/secrets/pcs/redis-connection-string` and the app picks it up with no code change.
- **`apps/pcs/aat/base/kustomization.yaml`** — registers the patch.

`pcs-frontend.yaml` is shared across environments, so this follows the existing `pcs-api/aat.yaml` pattern of an aat-only patch rather than touching the shared release.

## Why the patch restates all seven secrets

Helm replaces lists rather than merging them, so listing only the redis secret would silently unmount the other six. The full set is restated deliberately; it needs to stay in step with `charts/pcs-frontend/values.yaml` in the pcs-frontend repo.

## Verified

`kubectl kustomize --load-restrictor=LoadRestrictionsNone apps/pcs/aat/base` renders the frontend release with:

- the redis secret aliased to `redis-connection-string`, and the other six secrets intact
- `image`, `replicas` and `environment` still inherited from the shared base

Also confirmed demo, ithc and perftest render with no `keyVaults` override, so they keep using the chart default and stay on the old cache.

## Rollback

Revert this patch. The old Azure Cache for Redis instance and its `redis-connection-string` secret are untouched by the terraform change, so nothing needs re-applying.

No data migration: the only thing in Redis is ephemeral session state, so a cold cutover just means users re-login. Worth landing outside peak hours for that reason.

Note that `apps/**/kustomization.yaml` is owned by @hmcts/platform-operations, so this needs a platops review alongside the PCS one.