### PR TITLE
Remove a test auto shutdown github runner as a DR test/simulation for github runner recovery

### DIFF
--- a/apps/github-arc/base/kustomization.yaml
+++ b/apps/github-arc/base/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - ../runner-controller/helmrepo.yaml
   - ../runner-controller/controller.yaml
   - ../sups/sups-caps.yaml
-  - ../runners/auto-shutdown-dev.yaml
+  # - ../runners/auto-shutdown-dev.yaml
 namespace: github-arc


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33737

### Change description

Removing Enda's auto shutdown test runner to perform a DR test/simulation as described in the task.
Will revert this once confirmed the runner is gone.

### Testing done

This is a test.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
