### PR TITLE
Add PCS decentralised webUrl to xui-webapp for aat, perftest, demo and ithc

### DIFF
--- a/apps/xui/xui-webapp/aat.yaml
+++ b/apps/xui/xui-webapp/aat.yaml
@@ -33,4 +33,4 @@ spec:
         FEATURE_LAU_SPECIFIC_CHALLENGED_ENABLED: true
         SERVICES_HEARINGS_COMPONENT_API_SSCS: http://sscs-tribunals-api-aat.service.core-compute-aat.internal
         DECENTRALISED_CASE_TYPE_CONFIG: >-
-          {"PCS": {"nocBaseUrl": "http://pcs-api-aat.service.core-compute-aat.internal"}}
+          {"PCS": {"webUrl": "https://pcs.aat.platform.hmcts.net", "nocBaseUrl": "http://pcs-api-aat.service.core-compute-aat.internal"}}

--- a/apps/xui/xui-webapp/demo.yaml
+++ b/apps/xui/xui-webapp/demo.yaml
@@ -8,6 +8,8 @@ spec:
       ingressHost: manage-case.demo.platform.hmcts.net
       environment:
         DUMMY_VAR_FOR_RESTART: 1
+        DECENTRALISED_CASE_TYPE_CONFIG: >-
+          {"PCS": {"webUrl": "https://pcs.demo.platform.hmcts.net", "nocBaseUrl": "http://pcs-api-demo.service.core-compute-demo.internal"}}
         FEATURE_SECURE_COOKIE_ENABLED: false
         SERVICES_MARKUP_API: http://em-npa-demo.service.core-compute-demo.internal
         JURISDICTIONS: DIVORCE,PROBATE,FR,PUBLICLAW,IA,SSCS,ADOPTION,EMPLOYMENT,CIVIL,AUTOTEST1,CMC,HRS,BEFTA_JURISDICTION_1,PRIVATELAW,BEFTA_JURISDICTION_2,BEFTA_JURISDICTION_3,ST_CIC,ST_PHL,ST_CS,ST_SEND,ST_MH,BEFTA_MASTER,PCS,PT

--- a/apps/xui/xui-webapp/ithc.yaml
+++ b/apps/xui/xui-webapp/ithc.yaml
@@ -8,6 +8,8 @@ spec:
       ingressHost: manage-case.ithc.platform.hmcts.net
       environment:
         DUMMY_VAR_FOR_RESTART: 1
+        DECENTRALISED_CASE_TYPE_CONFIG: >-
+          {"PCS": {"webUrl": "https://pcs.ithc.platform.hmcts.net", "nocBaseUrl": "http://pcs-api-ithc.service.core-compute-ithc.internal"}}
         SERVICES_IDAM_LOGIN_URL: https://idam-web-public.ithc.platform.hmcts.net
         SERVICES_IDAM_API_URL: https://idam-api.ithc.platform.hmcts.net
         SERVICES_MARKUP_API: http://em-npa-ithc.service.core-compute-ithc.internal

--- a/apps/xui/xui-webapp/perftest-00.yaml
+++ b/apps/xui/xui-webapp/perftest-00.yaml
@@ -61,5 +61,5 @@ spec:
         ROLE_ASSIGNMENT_PAGE_SIZE: 500
         NODE_OPTIONS: ""
         DECENTRALISED_CASE_TYPE_CONFIG: >-
-          {"PCS": {"nocBaseUrl": "http://pcs-api-perftest.service.core-compute-perftest.internal"}}
+          {"PCS": {"webUrl": "https://pcs.perftest.platform.hmcts.net", "nocBaseUrl": "http://pcs-api-perftest.service.core-compute-perftest.internal"}}
       image: hmctsprod.azurecr.io/xui/webapp:pr-5298-6e33129-20260814085644 #{"$imagepolicy": "flux-system:perftest-xui-webapp"}

--- a/apps/xui/xui-webapp/perftest-01.yaml
+++ b/apps/xui/xui-webapp/perftest-01.yaml
@@ -61,5 +61,5 @@ spec:
         ROLE_ASSIGNMENT_PAGE_SIZE: 500
         NODE_OPTIONS: ""
         DECENTRALISED_CASE_TYPE_CONFIG: >-
-          {"PCS": {"nocBaseUrl": "http://pcs-api-perftest.service.core-compute-perftest.internal"}}
+          {"PCS": {"webUrl": "https://pcs.perftest.platform.hmcts.net", "nocBaseUrl": "http://pcs-api-perftest.service.core-compute-perftest.internal"}}
       image: hmctsprod.azurecr.io/xui/webapp:pr-5298-6e33129-20260814085644 #{"$imagepolicy": "flux-system:perftest-xui-webapp"}


### PR DESCRIPTION
### Jira link

See [HDPI-8688](https://tools.hmcts.net/jira/browse/HDPI-8688)

### Change description

XUI needs a `webUrl` in `DECENTRALISED_CASE_TYPE_CONFIG` to redirect `ext:` case events to the owning service's frontend. PCS only had `nocBaseUrl`, so the legal rep "Respond to claim" option does nothing when selected.

- aat / perftest: add `webUrl` next to the existing `nocBaseUrl`
- demo / ithc: add the PCS entry

Prod will follow with the PCS R1.2/1.3 go-live.

### Testing done

All four frontend hosts return 200 on `/health`, and the redirect path (`/cases/<ref>/event/ext:respondPossessionClaim`) resolves on each (302 to login). Will retest the full journey on AAT after sync.
