### PR TITLE
EL-18: add ITHC CCD Elasticsearch app suite

### DIFF
--- a/apps/ccd/ccd-elasticsearch-app-suite/data-store/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/data-store/kustomization.yaml
@@ -1,0 +1,51 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-data-store-api/ccd-data-store-api.yaml
+patches:
+  - path: ../../ccd-data-store-api/ithc.yaml
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-data-store-api
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-data-store-api
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-data-store-api
+      - op: add
+        path: /spec/values/java/ingressHost
+        value: ccd-elasticsearch-app-data-store-api-ithc.service.core-compute-ithc.internal
+      - op: add
+        path: /spec/values/java/environment/DEFINITION_STORE_HOST
+        value: http://ccd-elasticsearch-app-definition-store-api-ithc.service.core-compute-ithc.internal
+      - op: add
+        path: /spec/values/java/keyVaults
+        value:
+          ccd:
+            secrets:
+              - name: data-store-api-POSTGRES-USER-V15
+                alias: DATA_STORE_DB_USERNAME
+              - name: data-store-api-POSTGRES-PASS-V15
+                alias: DATA_STORE_DB_PASSWORD
+              - name: data-store-api-draft-key
+                alias: CCD_DRAFT_ENCRYPTION_KEY
+              - name: ccd-data-s2s-secret
+                alias: DATA_STORE_IDAM_KEY
+              - name: ccd-ELASTICSEARCH-APP-URL
+                alias: ELASTIC_SEARCH_HOSTS
+              - name: ccd-ELASTICSEARCH-APP-DATA-NODES-URL
+                alias: ELASTIC_SEARCH_DATA_NODES_HOSTS
+              - name: app-insights-connection-string
+                alias: app-insights-connection-string
+              - name: idam-data-store-client-secret
+                alias: IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET
+              - name: idam-data-store-system-user-username
+                alias: IDAM_DATA_STORE_SYSTEM_USER_USERNAME
+              - name: idam-data-store-system-user-password
+                alias: IDAM_DATA_STORE_SYSTEM_USER_PASSWORD
+              - name: data-store-api-TOKEN-SECRET
+                alias: DATA_STORE_TOKEN_SECRET

--- a/apps/ccd/ccd-elasticsearch-app-suite/definition-store/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/definition-store/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-definition-store-api/ccd-definition-store-api.yaml
+patches:
+  - path: ../../ccd-definition-store-api/ithc.yaml
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-definition-store-api
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-definition-store-api
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-definition-store-api
+      - op: add
+        path: /spec/values/java/ingressHost
+        value: ccd-elasticsearch-app-definition-store-api-ithc.service.core-compute-ithc.internal
+      - op: add
+        path: /spec/values/java/keyVaults
+        value:
+          ccd:
+            secrets:
+              - name: definition-store-api-POSTGRES-USER-V15
+                alias: DEFINITION_STORE_DB_USERNAME
+              - name: definition-store-api-POSTGRES-PASS-V15
+                alias: DEFINITION_STORE_DB_PASSWORD
+              - name: ccd-definition-s2s-secret
+                alias: DEFINITION_STORE_IDAM_KEY
+              - name: ccd-ELASTICSEARCH-APP-URL
+                alias: ELASTIC_SEARCH_HOST
+              - name: storage-account-primary-connection-string
+                alias: AZURE_STORAGE_CONNECTION_STRING
+              - name: app-insights-connection-string
+                alias: app-insights-connection-string

--- a/apps/ccd/ccd-elasticsearch-app-suite/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/kustomization.yaml
@@ -1,0 +1,57 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ccd
+resources:
+  - data-store
+  - definition-store
+  - logstash-config.yaml
+  - logstash-main
+  - logstash-civil
+  - logstash-fpl
+  - logstash-cmc
+  - logstash-divorce
+  - logstash-ethos
+  - logstash-probate
+  - logstash-probateman
+  - logstash-sscs
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-elasticsearch-app-logstash.*
+    patch: |-
+      - op: replace
+        path: /spec/values/envFrom
+        value:
+          - secretRef:
+              name: logstash-secret
+          - configMapRef:
+              name: ccd-elasticsearch-app-logstash-config
+      - op: add
+        path: /spec/values/persistence
+        value:
+          enabled: true
+      - op: add
+        path: /spec/values/volumeClaimTemplate
+        value:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-elasticsearch-app-logstash-probateman
+    patch: |-
+      - op: replace
+        path: /spec/values/envFrom
+        value:
+          - secretRef:
+              name: logstash-secret
+          - secretRef:
+              name: probatemandb
+          - configMapRef:
+              name: ccd-elasticsearch-app-logstash-config

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-civil/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-civil/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-civil
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-civil
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-civil
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-civil
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'CIVIL' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-cmc/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-cmc/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-cmc
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-cmc
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-cmc
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-cmc
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'CMC' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-config.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ccd-elasticsearch-app-logstash-config
+data:
+  ES_HOST0: http://ccd-es-app-ithc-0.service.core-compute-ithc.internal:9200
+  ES_HOST1: http://ccd-es-app-ithc-1.service.core-compute-ithc.internal:9200
+  ES_HOST2: http://ccd-es-app-ithc-2.service.core-compute-ithc.internal:9200
+  ES_HOST3: http://ccd-es-app-ithc-3.service.core-compute-ithc.internal:9200

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-divorce/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-divorce/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-divorce
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-divorce
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-divorce
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-divorce
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'DIVORCE' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-ethos/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-ethos/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-ethos
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-ethos
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-ethos
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-ethos
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'EMPLOYMENT' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-fpl/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-fpl/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-fpl
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-fpl
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-fpl
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-fpl
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 1000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'PUBLICLAW' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-main/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-main/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash/ccd-logstash.yaml
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction NOT IN ('DIVORCE', 'CIVIL', 'PUBLICLAW', 'CMC', 'PROBATE', 'SSCS', 'EMPLOYMENT') ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-probate/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-probate/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-probate
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-probate
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-probate
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-probate
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'PROBATE' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-probateman/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-probateman/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-probateman
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-probateman
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-probateman
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-probateman

--- a/apps/ccd/ccd-elasticsearch-app-suite/logstash-sscs/kustomization.yaml
+++ b/apps/ccd/ccd-elasticsearch-app-suite/logstash-sscs/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../ccd-logstash-sscs
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: ccd-logstash-sscs
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ccd-elasticsearch-app-logstash-sscs
+      - op: replace
+        path: /spec/releaseName
+        value: ccd-elasticsearch-app-logstash-sscs
+      - op: replace
+        path: /spec/values/logstashPipeline/01_input.conf
+        value: |
+          input {
+            jdbc {
+              jdbc_connection_string => "${DATA_STORE_URL}"
+              jdbc_user => "${DATA_STORE_USER}"
+              jdbc_password => "${DATA_STORE_PASS}"
+              jdbc_validate_connection => true
+              jdbc_validation_timeout => "1"
+              jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
+              jdbc_driver_class => "org.postgresql.Driver"
+              jdbc_default_timezone => "UTC"
+              jdbc_paging_enabled => true
+              jdbc_page_size => 5000
+              use_column_value => true
+              tracking_column => "last_modified"
+              tracking_column_type => "timestamp"
+              last_run_metadata_path => "/usr/share/logstash/data/ccd-elasticsearch-app-last-run"
+              statement => "SELECT id, created_date, last_modified, jurisdiction, case_type_id, state, last_state_modified_date, data::TEXT AS json_data, data_classification::TEXT AS json_data_classification, reference, security_classification, supplementary_data::TEXT AS json_supplementary_data FROM case_data WHERE last_modified >= :sql_last_value AND jurisdiction = 'SSCS' ORDER BY last_modified, id"
+              clean_run => false
+              schedule => "* * * * * *"
+            }
+          }

--- a/apps/ccd/ithc/00/kustomization.yaml
+++ b/apps/ccd/ithc/00/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: ccd
 resources:
   - ../base
+  - ../../ccd-elasticsearch-app-suite
 patches:
   - path: ../../message-publisher/ithc-00.yaml

--- a/apps/ccd/ithc/01/kustomization.yaml
+++ b/apps/ccd/ithc/01/kustomization.yaml
@@ -3,5 +3,6 @@ kind: Kustomization
 namespace: ccd
 resources:
 - ../base
+- ../../ccd-elasticsearch-app-suite
 patches:
 - path: ../../message-publisher/ithc-01.yaml

--- a/apps/ccd/ithc/01/kustomization.yaml
+++ b/apps/ccd/ithc/01/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ccd
 resources:
-- ../base
-- ../../ccd-elasticsearch-app-suite
+- ../elasticsearch-app
 patches:
 - path: ../../message-publisher/ithc-01.yaml

--- a/apps/ccd/ithc/elasticsearch-app/kustomization.yaml
+++ b/apps/ccd/ithc/elasticsearch-app/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ccd
 resources:
-  - ../elasticsearch-app
-patches:
-  - path: ../../message-publisher/ithc-00.yaml
+  - ../base
+  - ../../ccd-elasticsearch-app-suite


### PR DESCRIPTION
## Summary

- add a side-by-side CCD Data Store release for `ccd-elasticsearch-app` in ITHC
- add a side-by-side CCD Definition Store release for `ccd-elasticsearch-app` in ITHC
- add dedicated APP Logstash releases for the main, Civil, CMC, Divorce, Employment, FPL, Probate, Probate Manager and SSCS feeds
- deploy the suite to both ITHC clusters without changing or replacing the legacy CCD releases

## Isolation

- Data Store and Definition Store use the APP-specific Key Vault secrets:
  - `ccd-ELASTICSEARCH-APP-URL`
  - `ccd-ELASTICSEARCH-APP-DATA-NODES-URL`
- Logstash outputs use only the four `ccd-es-app-ithc-*` nodes
- case-data Logstash workers use a read-only `last_modified` cursor instead of updating `marked_by_logstash`, so the APP and legacy fleets do not compete for rows
- each APP Logstash release has its own 10 GiB persistent volume for cursor, queue and dead-letter state
- no consumer traffic is cut over by this change

## Validation

- rendered `apps/ccd/ithc/00` successfully with Kustomize
- rendered `apps/ccd/ithc/01` successfully with Kustomize
- confirmed 11 unique APP Helm releases in each ITHC cluster
- confirmed the rendered APP suite contains no legacy `marked_by_logstash` query or legacy Elasticsearch node endpoint
- YAML lint passed for all changed files

The full Flux/kubeconform workflow will run in PR CI.

## Rollout plan

- [EL-18](https://tools.hmcts.net/jira/browse/EL-18)
- [Elasticsearch 2.0 Rollout Plan](https://tools.hmcts.net/confluence/spaces/EL/pages/1990253658/Elasticsearch+2.0+Rollout+Plan)
