### PR TITLE
Revert "Remove a test auto shutdown github runner as a DR test/simulation for github runner recovery"

### DIFF
--- a/apps/github-arc/base/kustomization.yaml
+++ b/apps/github-arc/base/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - ../runner-controller/helmrepo.yaml
   - ../runner-controller/controller.yaml
   - ../sups/sups-caps.yaml
-  # - ../runners/auto-shutdown-dev.yaml
+  - ../runners/auto-shutdown-dev.yaml
 namespace: github-arc


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#47188
Bring back the runner as part of dr test