### PR TITLE
Set PCS_FRONTEND_URL for pcs-api in aat, demo, perftest and ithc

### DIFF
--- a/apps/pcs/ithc/base/kustomization.yaml
+++ b/apps/pcs/ithc/base/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ../../pcs-frontend/pcs-frontend.yaml
 namespace: pcs
 patches:
+  - path: ../../pcs-api/ithc.yaml
   - path: ../../serviceaccount/ithc.yaml

--- a/apps/pcs/pcs-api/aat.yaml
+++ b/apps/pcs/pcs-api/aat.yaml
@@ -8,3 +8,4 @@ spec:
       environment:
         HASH_PINS_ENABLED: "false"
         ENABLE_TESTING_SUPPORT: "true"
+        PCS_FRONTEND_URL: "https://pcs.aat.platform.hmcts.net"

--- a/apps/pcs/pcs-api/demo.yaml
+++ b/apps/pcs/pcs-api/demo.yaml
@@ -9,3 +9,4 @@ spec:
         HASH_PINS_ENABLED: "false"
         ENABLE_TESTING_SUPPORT: "true"
         DEMO_VAR: "2"
+        PCS_FRONTEND_URL: "https://pcs.demo.platform.hmcts.net"

--- a/apps/pcs/pcs-api/ithc.yaml
+++ b/apps/pcs/pcs-api/ithc.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pcs-api
+spec:
+  values:
+    java:
+      environment:
+        PCS_FRONTEND_URL: "https://pcs.ithc.platform.hmcts.net"

--- a/apps/pcs/pcs-api/perftest.yaml
+++ b/apps/pcs/pcs-api/perftest.yaml
@@ -9,3 +9,4 @@ spec:
       environment:
         HASH_PINS_ENABLED: "false"
         ENABLE_TESTING_SUPPORT: "true"
+        PCS_FRONTEND_URL: "https://pcs.perftest.platform.hmcts.net"


### PR DESCRIPTION
### Jira link

See [HDPI-8725](https://tools.hmcts.net/jira/browse/HDPI-8725)

### Change description

Follow-up to #47189, which fixed the 'Respond to claim' dropdown option. The 'Respond to claim' hyperlink on the case summary page is still broken — pcs-api builds it from `PCS_FRONTEND_URL`, and the chart default has the wrong host: `pcs-<env>.platform.hmcts.net` (hyphen) instead of `pcs.<env>.platform.hmcts.net` (dot). The hyphen host doesn't resolve.

- aat / demo / perftest: set `PCS_FRONTEND_URL` in the existing env patch files
- ithc: pcs-api had no env patch at all, so add `pcs-api/ithc.yaml` and wire it into the kustomization

Prod will follow with the PCS go-live, same as #47189. The chart default is fixed in hmcts/pcs-api#2543 but only lands with the next chart release — this gets the fix out now.

### Testing done

All four frontend hosts return 200 on `/health` (the `pcs-<env>` variants don't resolve). Rendered the four overlays with kustomize against master and this branch — the only diff per env is the added env var on the pcs-api HelmRelease. Will retest the full journey on AAT after sync.