### PR TITLE
Enable ET production Elasticsearch indexer

### DIFF
--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -8,6 +8,9 @@ spec:
     java:
       image: hmctsprod.azurecr.io/et/cos:pr-3196-d04e2ad-20260902093738 #{"$imagepolicy": "flux-system:demo-et-cos"}
       environment:
+        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
+        ET_SERVICEBUS_SCHEDULER_ENABLED: false
+        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-demo.internal:9200
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-demo.service.core-compute-demo.internal
         RD_COMMONDATA_API_URL: http://rd-commondata-api-demo.service.core-compute-demo.internal
         AAC_URL: http://aac-manage-case-assignment-demo.service.core-compute-demo.internal

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -144,7 +144,7 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
-        ET_SERVICEBUS_SCHEDULER_ENABLED: true
+        ET_SERVICEBUS_SCHEDULER_ENABLED: false
         ELASTIC_SEARCH_HOSTS: "http://ccd-data-0.service.core-compute-prod.internal:9200,http://ccd-data-1.service.core-compute-prod.internal:9200,http://ccd-data-2.service.core-compute-prod.internal:9200,http://ccd-data-3.service.core-compute-prod.internal:9200"
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -143,8 +143,8 @@ spec:
         MULTIPLE_SHELL_CASE_CREATION_ERROR_EMAIL_TEMPLATE_ID: d2d427cd-efd5-4121-abc4-242c5beac158
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
-        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
-        ET_SERVICEBUS_SCHEDULER_ENABLED: false
+        CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
+        ET_SERVICEBUS_SCHEDULER_ENABLED: true
         ELASTIC_SEARCH_HOSTS: "http://ccd-data-0.service.core-compute-prod.internal:9200,http://ccd-data-1.service.core-compute-prod.internal:9200,http://ccd-data-2.service.core-compute-prod.internal:9200,http://ccd-data-3.service.core-compute-prod.internal:9200"
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -144,6 +144,8 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
+        ET_SERVICEBUS_SCHEDULER_ENABLED: false
+        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-prod.internal:9200
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true

--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -145,7 +145,7 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
         ET_SERVICEBUS_SCHEDULER_ENABLED: false
-        ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-prod.internal:9200
+        ELASTIC_SEARCH_HOSTS: "http://ccd-data-0.service.core-compute-prod.internal:9200,http://ccd-data-1.service.core-compute-prod.internal:9200,http://ccd-data-2.service.core-compute-prod.internal:9200,http://ccd-data-3.service.core-compute-prod.internal:9200"
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true


### PR DESCRIPTION
## Summary

- configure the Elasticsearch hosts for ET COS in demo and production
- use all four CCD Elasticsearch nodes in production
- enable the decentralised Elasticsearch indexer in production only
- keep the indexer disabled in demo
- keep CCD case-event Service Bus publishing disabled in both environments

The production Elasticsearch queues were checked before enablement and were empty.

## Validation

- parsed both updated manifests as YAML
- `git diff --check` passes