### PR TITLE
fix: align XUI ICP Flux artifacts

### DIFF
--- a/apps/xui/xui-icp/aat.yaml
+++ b/apps/xui/xui-icp/aat.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}

--- a/apps/xui/xui-icp/demo-image-policy.yaml
+++ b/apps/xui/xui-icp/demo-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-[0-9]+-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     numerical:

--- a/apps/xui/xui-icp/demo.yaml
+++ b/apps/xui/xui-icp/demo.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp-api:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:demo-xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:demo-xui-icp"}

--- a/apps/xui/xui-icp/demo.yaml
+++ b/apps/xui/xui-icp/demo.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:demo-xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:demo-xui-icp"}

--- a/apps/xui/xui-icp/image-repo.yaml
+++ b/apps/xui/xui-icp/image-repo.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     hmcts.github.com/image-registry: hmctsprod
 spec:
-  image: hmctsprod.azurecr.io/xui/icp
+  image: hmctsprod.azurecr.io/xui/icp-api

--- a/apps/xui/xui-icp/ithc.yaml
+++ b/apps/xui/xui-icp/ithc.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}

--- a/apps/xui/xui-icp/perftest-image-policy.yaml
+++ b/apps/xui/xui-icp/perftest-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-[0-9]+-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     numerical:

--- a/apps/xui/xui-icp/perftest.yaml
+++ b/apps/xui/xui-icp/perftest.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp-api:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:perftest-xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:perftest-xui-icp"}

--- a/apps/xui/xui-icp/perftest.yaml
+++ b/apps/xui/xui-icp/perftest.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:perftest-xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:perftest-xui-icp"}

--- a/apps/xui/xui-icp/xui-icp.yaml
+++ b/apps/xui/xui-icp/xui-icp.yaml
@@ -8,10 +8,10 @@ spec:
     nodejs:
       replicas: 0
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/xui/icp:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
   chart:
     spec:
-      chart: ./stable/xui-icp
+      chart: ./stable/xui-icp-api
       sourceRef:
         kind: GitRepository
         name: hmcts-charts


### PR DESCRIPTION
## What changed

Align the dormant XUI ICP Flux image and chart payloads with the API producer contract:

- image repository: `hmctsprod.azurecr.io/xui/icp-api`
- chart: `stable/xui-icp-api`

Flux object names and image-policy annotations remain `xui-icp`. All environment replicas remain `0`; this does not switch traffic, consumers, or EM ICP.
Every environment selects only promoted `prod-*` images; demo and perftest no longer reference a historical PR artifact.

## Validation

- `git diff --check`
- Kustomize render: base, AAT, demo, ITHC, perftest, and automation

## Release gate

Draft until `xui/icp-api` has a promoted `prod-*` image and the API master Terraform Redis-state ownership is resolved. This change alone cannot make the API master build green.

## AI assistance

AI-assisted change; human review required before merge.
