### PR TITLE
fix: align XUI ICP API Flux artifacts

### DIFF
--- a/apps/xui/prod/base/kustomization.yaml
+++ b/apps/xui/prod/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../../base/automated-db-queries/prod
 namespace: xui
 patches:
+  - path: ../../xui-icp/prod.yaml
   - path: ../../identity/prod.yaml
   - path: ../../xui-webapp/prod.yaml
   - path: ../../xui-ao-webapp/prod.yaml

--- a/apps/xui/xui-icp/aat.yaml
+++ b/apps/xui/xui-icp/aat.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}

--- a/apps/xui/xui-icp/aat.yaml
+++ b/apps/xui/xui-icp/aat.yaml
@@ -6,5 +6,5 @@ spec:
   releaseName: xui-icp
   values:
     nodejs:
-      replicas: 0
+      replicas: 2
       image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}

--- a/apps/xui/xui-icp/demo.yaml
+++ b/apps/xui/xui-icp/demo.yaml
@@ -6,5 +6,5 @@ spec:
   releaseName: xui-icp
   values:
     nodejs:
-      replicas: 0
+      replicas: 2
       image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:demo-xui-icp"}

--- a/apps/xui/xui-icp/demo.yaml
+++ b/apps/xui/xui-icp/demo.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:demo-xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:demo-xui-icp"}

--- a/apps/xui/xui-icp/image-policy.yaml
+++ b/apps/xui/xui-icp/image-policy.yaml
@@ -2,8 +2,6 @@ apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: xui-icp
-  annotations:
-    hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
     pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'

--- a/apps/xui/xui-icp/image-repo.yaml
+++ b/apps/xui/xui-icp/image-repo.yaml
@@ -5,4 +5,4 @@ metadata:
   annotations:
     hmcts.github.com/image-registry: hmctsprod
 spec:
-  image: hmctsprod.azurecr.io/xui/icp
+  image: hmctsprod.azurecr.io/xui/icp-api

--- a/apps/xui/xui-icp/ithc.yaml
+++ b/apps/xui/xui-icp/ithc.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}

--- a/apps/xui/xui-icp/ithc.yaml
+++ b/apps/xui/xui-icp/ithc.yaml
@@ -6,5 +6,5 @@ spec:
   releaseName: xui-icp
   values:
     nodejs:
-      replicas: 0
+      replicas: 2
       image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}

--- a/apps/xui/xui-icp/perftest.yaml
+++ b/apps/xui/xui-icp/perftest.yaml
@@ -7,4 +7,4 @@ spec:
   values:
     nodejs:
       replicas: 0
-      image: hmctsprod.azurecr.io/xui/icp:pr-43-e04e2fc-20260902155605 # {"$imagepolicy": "flux-system:perftest-xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:perftest-xui-icp"}

--- a/apps/xui/xui-icp/perftest.yaml
+++ b/apps/xui/xui-icp/perftest.yaml
@@ -6,5 +6,5 @@ spec:
   releaseName: xui-icp
   values:
     nodejs:
-      replicas: 0
+      replicas: 2
       image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:perftest-xui-icp"}

--- a/apps/xui/xui-icp/prod.yaml
+++ b/apps/xui/xui-icp/prod.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: xui-icp
+spec:
+  values:
+    nodejs:
+      ingressHost: xui-icp.platform.hmcts.net
+      environment:
+        IDAM_API_BASE_URL: https://idam-api.platform.hmcts.net
+        IDAM_S2S_URL: http://rpe-service-auth-provider-prod.service.core-compute-prod.internal
+        ICP_WS_URL: wss://xui-icp-webpubsub.platform.hmcts.net/client/hubs/Hub
+      spotInstances:
+        enabled: false

--- a/apps/xui/xui-icp/xui-icp.yaml
+++ b/apps/xui/xui-icp/xui-icp.yaml
@@ -8,10 +8,10 @@ spec:
     nodejs:
       replicas: 0
       useInterpodAntiAffinity: true
-      image: hmctsprod.azurecr.io/xui/icp:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
   chart:
     spec:
-      chart: ./stable/xui-icp
+      chart: ./stable/xui-icp-api
       sourceRef:
         kind: GitRepository
         name: hmcts-charts

--- a/apps/xui/xui-icp/xui-icp.yaml
+++ b/apps/xui/xui-icp/xui-icp.yaml
@@ -6,9 +6,18 @@ spec:
   releaseName: xui-icp
   values:
     nodejs:
-      replicas: 0
+      replicas: 2
+      DUMMY_VAR: 1
       useInterpodAntiAffinity: true
       image: hmctsprod.azurecr.io/xui/icp-api:prod-0000000-19700101000000 # {"$imagepolicy": "flux-system:xui-icp"}
+      startupDelay: 15
+      startupPeriod: 15
+      startupTimeout: 5
+      livenessPeriod: 20
+      readinessPeriod: 20
+      environment:
+        SLACK_CHANNEL: "xui-pipeline"
+        SLACK_NOTIFY_SUCCESS: "true"
   chart:
     spec:
       chart: ./stable/xui-icp-api

--- a/tests/flux-v2-image-automation.sh
+++ b/tests/flux-v2-image-automation.sh
@@ -167,7 +167,7 @@ for FILE_LOCATION in $(echo ${FILE_LOCATIONS}); do
             MATCH=$(yq e 'select(.metadata.name == env(POLICY_NAME))' "$FILE")
             if [ -n "$MATCH" ]; then
                 PATTERN=$(echo "$MATCH" | yq e '.spec.filterTags.pattern' -)
-                if [[ ! $PATTERN =~ ^prod-[a-f0-9]+-(?P<ts>[0-9]+)$ ]]; then
+                if [[ "$PATTERN" != '^prod-[a-f0-9]+-(?P<ts>[0-9]+)' ]]; then
                     echo "Non whitelisted pattern found in ImagePolicy: $POLICY_NAME located in: $FILE -- it should be ^prod-[a-f0-9]+-(?P<ts>[0-9]+) -- found $PATTERN"
                     exit 1
                 fi


### PR DESCRIPTION
## Summary

Align the XUI ICP API Flux configuration with the existing EM ICP deployment pattern.

## Changes

- Deploy the XUI ICP API image: `hmctsprod.azurecr.io/xui/icp-api`
- Use the `stable/xui-icp-api` Helm chart
- Set two replicas and enable inter-pod anti-affinity
- Add equivalent startup, liveness, and readiness settings
- Add the XUI production ingress, IDAM, and Web PubSub configuration
- Keep existing EM manifests and consumer routing unchanged
- Fix the image-policy validation so the approved production tag pattern is compared literally

## Validation

- Flux schema checks pass for AAT, demo, ITHC, perftest, preview, and production
- `git diff --check` passes
- The image-policy and HelmRelease automation checks are covered by CI

## Follow-up

- Obtain the required XUI and Platform Operations code-owner approvals
- Resolve the remaining required Flux sanity check
- After merge, reconcile XUI ICP API and verify pod readiness, Redis, Web PubSub, health checks, and alerts
- Switch consumers from EM ICP to XUI ICP only after runtime validation is complete