### PR TITLE
fix(cath): recover cath AAT HelmReleases from MissingRollbackTarget s…

### DIFF
--- a/apps/cath/cath-api/cath-api.yaml
+++ b/apps/cath/cath-api/cath-api.yaml
@@ -8,10 +8,10 @@ spec:
   install:
     remediation:
       retries: 3
-    upgrade:
-      remediation:
-        strategy: uninstall
-        retries: 3
+  upgrade:
+    remediation:
+      strategy: uninstall
+      retries: 3
   values:
     nodejs:
       releaseNameOverride: cath-api

--- a/apps/cath/cath-api/cath-api.yaml
+++ b/apps/cath/cath-api/cath-api.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   releaseName: cath-api
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+    upgrade:
+      remediation:
+        strategy: uninstall
+        retries: 3
   values:
     nodejs:
       releaseNameOverride: cath-api
@@ -12,7 +19,7 @@ spec:
   chart:
     spec:
       chart: cath-api
-      version: ">=0.0.1-0"
+      version: ">=0.1.0-0"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/cath/cath-crons/cath-crons.yaml
+++ b/apps/cath/cath-crons/cath-crons.yaml
@@ -8,10 +8,10 @@ spec:
   install:
     remediation:
       retries: 3
-    upgrade:
-      remediation:
-        strategy: uninstall
-        retries: 3
+  upgrade:
+    remediation:
+      strategy: uninstall
+      retries: 3
   values:
     job:
       releaseNameOverride: cath-crons

--- a/apps/cath/cath-crons/cath-crons.yaml
+++ b/apps/cath/cath-crons/cath-crons.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   releaseName: cath-crons
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+    upgrade:
+      remediation:
+        strategy: uninstall
+        retries: 3
   values:
     job:
       releaseNameOverride: cath-crons
@@ -13,7 +20,7 @@ spec:
   chart:
     spec:
       chart: cath-crons
-      version: ">=0.0.1-0"
+      version: ">=0.1.0-0"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/cath/cath-postgres/cath-postgres.yaml
+++ b/apps/cath/cath-postgres/cath-postgres.yaml
@@ -8,10 +8,10 @@ spec:
   install:
     remediation:
       retries: 3
-    upgrade:
-      remediation:
-        strategy: uninstall
-        retries: 3
+  upgrade:
+    remediation:
+      strategy: uninstall
+      retries: 3
   values:
     nodejs:
       releaseNameOverride: cath-postgres

--- a/apps/cath/cath-postgres/cath-postgres.yaml
+++ b/apps/cath/cath-postgres/cath-postgres.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   releaseName: cath-postgres
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+    upgrade:
+      remediation:
+        strategy: uninstall
+        retries: 3
   values:
     nodejs:
       releaseNameOverride: cath-postgres
@@ -12,7 +19,7 @@ spec:
   chart:
     spec:
       chart: cath-postgres
-      version: ">=0.0.1-0"
+      version: ">=0.1.0-0"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/cath/cath-web/cath-web.yaml
+++ b/apps/cath/cath-web/cath-web.yaml
@@ -8,10 +8,10 @@ spec:
   install:
     remediation:
       retries: 3
-    upgrade:
-      remediation:
-        strategy: uninstall
-        retries: 3
+  upgrade:
+    remediation:
+      strategy: uninstall
+      retries: 3
   values:
     nodejs:
       releaseNameOverride: cath-web

--- a/apps/cath/cath-web/cath-web.yaml
+++ b/apps/cath/cath-web/cath-web.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   releaseName: cath-web
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+    upgrade:
+      remediation:
+        strategy: uninstall
+        retries: 3
   values:
     nodejs:
       releaseNameOverride: cath-web
@@ -12,7 +19,7 @@ spec:
   chart:
     spec:
       chart: cath-web
-      version: ">=0.0.1-0"
+      version: ">=0.1.0-0"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci


### PR DESCRIPTION
## Problem

  All four cath HelmReleases on `cft-aat-00` are stuck on a pre-migration chart, and `cath-web` has stalled terminally:

  ```
  $ kubectl describe helmrelease cath-web -n cath
  Type:                     Stalled
  Status:                   True
  Reason:                   MissingRollbackTarget
  Message:                  Failed to perform remediation: missing target release for
                            rollback: cannot remediate failed release
  Last Attempted Revision:  0.0.3-fa9b633
  Upgrade Failures:         1
  ```

  ```
  $ kubectl get helmchart -n flux-system | grep cath
  cath-cath-web        >=0.0.1-0   pulled 'cath-web' chart with version '0.0.3-fa9b633'
  cath-cath-api        >=0.0.1-0   pulled 'cath-api' chart with version '0.0.2-fa9b633'
  cath-cath-postgres   >=0.0.1-0   pulled 'cath-postgres' chart with version '0.0.1-fa9b633'
  cath-cath-crons      >=0.0.1-0   pulled 'cath-crons' chart with version '0.0.1-fa9b633'
  ```

  `fa9b633` is from 29 June, before cath migrated from SDS to CNP. It still references the retired `cath-ss-kv-aat` key vault, so pods never start:

  ```
  MountVolume.SetUp failed for volume "vault-cath-ss-kv":
  403 Forbidden ... does not have secrets get permission on key vault 'cath-ss-kv-aat'
  ```

  `https://cath.aat.platform.hmcts.net` returns 502 as a result.

  ## Two causes

  **1. `version: ">=0.0.1-0"` resolves by semver over a git-SHA prerelease field.** Chart versions are `0.0.3-<sha>`, so ordering is effectively alphabetical on the
  SHA. Digits sort before letters, so `0.0.3-fa9b633` outranked every chart published since — including post-migration ones. Charts were being published correctly; they
  just never won the comparison.

  **2. Default upgrade remediation is `rollback`.** The upgrade failed (5 min timeout waiting on pods that can't mount), Flux tried to roll back, found no
  previously-successful release on CNP, and stalled permanently with `MissingRollbackTarget`. It has not retried since.
