### PR TITLE
Add pcs_api to rd-user-profile-api and rd-caseworker-ref-api S2S allowlists (perftest, aat, demo, ithc)

### DIFF
--- a/apps/rd/rd-caseworker-ref-api/aat.yaml
+++ b/apps/rd/rd-caseworker-ref-api/aat.yaml
@@ -30,7 +30,7 @@ spec:
               alias: app-insights-connection-string
       environment:
         DELETE_CWR: true
-        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,et_cos,rd_profile_sync,fpl_case_service,idam-user-profile-bridge,probate_backend,finrem_case_orchestration,finrem_citizen_ui
+        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,et_cos,rd_profile_sync,fpl_case_service,idam-user-profile-bridge,probate_backend,finrem_case_orchestration,finrem_citizen_ui,pcs_api
         STAFF_DATA_FILE_VERSION: v1.15
         EMAIL_DOMAIN_LIST: justice.gov.uk,dwp.gov.uk,hmrc.gov.uk,hmcts.net,dfcni.gov.uk,gov.wales,cica.gov.uk,ibca.org.uk,cabinetoffice.gov.uk
         #file upload config

--- a/apps/rd/rd-caseworker-ref-api/demo.yaml
+++ b/apps/rd/rd-caseworker-ref-api/demo.yaml
@@ -33,7 +33,7 @@ spec:
         DUMMY_VAR: false
         HIKARI_MAX_POOL_SIZE: 60
         DELETE_CWR: true
-        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync,probate_backend,finrem_case_orchestration,finrem_citizen_ui
+        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync,probate_backend,finrem_case_orchestration,finrem_citizen_ui,pcs_api
         STAFF_DATA_FILE_VERSION: v1.15
         EMAIL_DOMAIN_LIST: justice.gov.uk,dwp.gov.uk,hmrc.gov.uk,hmcts.net,dfcni.gov.uk,gov.wales,cica.gov.uk,ibca.org.uk,cabinetoffice.gov.uk # refresh demo pods- delete after test
         #file upload config

--- a/apps/rd/rd-caseworker-ref-api/ithc.yaml
+++ b/apps/rd/rd-caseworker-ref-api/ithc.yaml
@@ -31,7 +31,7 @@ spec:
       environment:
         DUMMY_VAR: false
         DELETE_CWR: true
-        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync,probate_backend,finrem_case_orchestration,finrem_citizen_ui
+        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync,probate_backend,finrem_case_orchestration,finrem_citizen_ui,pcs_api
         STAFF_DATA_FILE_VERSION: v1.15
         EMAIL_DOMAIN_LIST: justice.gov.uk,dwp.gov.uk,hmrc.gov.uk,hmcts.net,dfcni.gov.uk,gov.wales,cica.gov.uk,ibca.org.uk,cabinetoffice.gov.uk
         #file upload config

--- a/apps/rd/rd-caseworker-ref-api/perftest.yaml
+++ b/apps/rd/rd-caseworker-ref-api/perftest.yaml
@@ -31,7 +31,7 @@ spec:
       environment:
         DUMMY_VAR: false
         DELETE_CWR: true
-        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync,probate_backend,finrem_case_orchestration,finrem_citizen_ui
+        CRD_S2S_AUTHORISED_SERVICES: rd_caseworker_ref_api,am_org_role_mapping_service,iac,xui_webapp,ccd_data,sscs,sscs_bulkscan,prl_cos_api,fpl_case_service,idam-user-profile-bridge,et_cos,rd_profile_sync,probate_backend,finrem_case_orchestration,finrem_citizen_ui,pcs_api
         STAFF_DATA_FILE_VERSION: v1.15
         EMAIL_DOMAIN_LIST: justice.gov.uk,dwp.gov.uk,hmrc.gov.uk,hmcts.net,dfcni.gov.uk,gov.wales,cica.gov.uk,ibca.org.uk,cabinetoffice.gov.uk
         #file upload config

--- a/apps/rd/rd-user-profile-api/aat.yaml
+++ b/apps/rd/rd-user-profile-api/aat.yaml
@@ -9,7 +9,7 @@ spec:
         DUMMY_VAR: true
         SPRING_JPA_OPEN-IN-VIEW: false
         DELETE_ORG: true
-        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,iac,et_cos,idam-user-profile-bridge,finrem_case_orchestration,finrem_citizen_ui
+        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,iac,et_cos,idam-user-profile-bridge,finrem_case_orchestration,finrem_citizen_ui,pcs_api
         APPLICATION_LOGGING_LEVEL: DEBUG
         FEIGN_CLIENT_CONFIG_DEFAULT_CONNECTTIMEOUT: 30000
         FEIGN_CLIENT_CONFIG_DEFAULT_READTIMEOUT: 30000

--- a/apps/rd/rd-user-profile-api/demo.yaml
+++ b/apps/rd/rd-user-profile-api/demo.yaml
@@ -8,4 +8,4 @@ spec:
       environment:
         DUMMY_VAR: false
         DELETE_ORG: true
-        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,idam-user-profile-bridge,et_cos,finrem_case_orchestration,finrem_citizen_ui
+        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,idam-user-profile-bridge,et_cos,finrem_case_orchestration,finrem_citizen_ui,pcs_api

--- a/apps/rd/rd-user-profile-api/ithc.yaml
+++ b/apps/rd/rd-user-profile-api/ithc.yaml
@@ -8,4 +8,4 @@ spec:
       environment:
         DUMMY_VAR: false
         DELETE_ORG: false
-        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,idam-user-profile-bridge,et_cos,finrem_case_orchestration,finrem_citizen_ui
+        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,idam-user-profile-bridge,et_cos,finrem_case_orchestration,finrem_citizen_ui,pcs_api

--- a/apps/rd/rd-user-profile-api/perftest.yaml
+++ b/apps/rd/rd-user-profile-api/perftest.yaml
@@ -18,5 +18,5 @@ spec:
         DUMMY_VAR: false
         DELETE_ORG: true
         IDAM_URL1: https://idam-api.perftest.platform.hmcts.net
-        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,iac,idam-user-profile-bridge,et_cos,finrem_case_orchestration,finrem_citizen_ui
+        PRD_S2S_AUTHORISED_SERVICES: rd_professional_api,rd_user_profile_api,rd_profile_sync,rd_caseworker_ref_api,iac,idam-user-profile-bridge,et_cos,finrem_case_orchestration,finrem_citizen_ui,pcs_api
         DUMMY_VAR_TO_RESTART: 0


### PR DESCRIPTION
### Jira link

<!--
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
No ticket — found and fixed during investigation into why `pcs_api` couldn't approve organisations
or add users via `rd-professional-api` on perftest.

### Change description

`pcs_api` was allowlisted on `rd-professional-api` in every non-prod environment (create/list/users/
delete all work), but missing from two other RD services it also needs to call:

- **`rd-user-profile-api`** (`PRD_S2S_AUTHORISED_SERVICES`) — governs anything that creates a user
  profile: approving an organisation, adding a user to one. Without this, `approve`/`add-user` fail
  with a 403 that reads like an expired-token error rather than a missing-allowlist entry.
- **`rd-caseworker-ref-api`** (`CRD_S2S_AUTHORISED_SERVICES`) — governs creating/managing caseworker
  reference-data profiles. PCS's caseworker/staff/judicial automation users (`caseworker-pcs`,
  `cwd-user` roles) need this; it's what the workspace's own `cft-user` creation path
  (`PUT /test/cft/users`) writes through.

Both are one-line additions to the existing comma-separated allowlist, applied identically across
`perftest.yaml`, `aat.yaml`, `demo.yaml`, `ithc.yaml` for each service — 8 files, 8 one-line diffs.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
-->
Pre-change: confirmed the gap with `scripts/prd-test-org check -m pcs_api -e perftest`:
```
pcs_api IS on rd-professional-api (perftest) — can create / list / users / delete
pcs_api is NOT on rd-user-profile-api (perftest) — cannot approve / add-user
```
and by reading `PRD_S2S_AUTHORISED_SERVICES` / `CRD_S2S_AUTHORISED_SERVICES` directly off
`origin/master` for all four environments — `pcs_api` was absent from both lists everywhere.

This is a config-only allowlist addition (no code path changed), so there's nothing to execute
locally before merge. Post-merge/deploy verification plan:
- [ ] `scripts/prd-test-org check -m pcs_api -e <env>` passes both lines, for each of perftest/aat/demo/ithc
- [ ] `scripts/prd-test-org add-user -m pcs_api -e <env> --org-id <id> --admin-token "$TOK" --user-email <email> -r pui-case-manager` succeeds
- [ ] A `PUT /test/cft/users` call as `pcs_api` creates a caseworker profile visible at `GET /test/rd/caseworker-profiles/{userId}`

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed) — n/a, allowlist entries are self-describing
- [ ] tests have been updated / new tests has been added (if needed) — n/a, this repo has no test suite; see manual verification plan above
- [ ] Does this PR introduce a breaking change — no, purely additive (grants access, revokes none)