### PR TITLE
Run ET production migration in cutover mode

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -150,7 +150,7 @@ spec:
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true
         CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration-v2
-        CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
+        CCD_DATA_MIGRATION_MODE: CUTOVER
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         CCD_DATA_MIGRATION_CASE_TYPE_IDS: ET_EnglandWales,ET_Scotland,ET_Admin,Pre_Hearing_Deposit,ET_EnglandWales_Multiple,ET_Scotland_Multiple,ET_EnglandWales_Listings,ET_Scotland_Listings
         CCD_DATA_MIGRATION_EVENT_ID_WINDOW_SIZE: "10000"


### PR DESCRIPTION
## Summary

Switches the ET production CCD data migration from `PRELOAD_EVENTS` to `CUTOVER` so the final event delta, significant items and case data can be copied into the ET-owned database.

This PR does **not** route CCD traffic to ET and does **not** enable ET event publishing.

## Merge instructions

**Do not merge before the agreed cutover window.**

Before merging:

1. Shutter ET or otherwise make every migrating case type read-only.
2. Confirm direct writers are stopped and in-flight CCD transactions have drained.
3. Confirm the production preload is healthy and caught up.
4. Confirm ET COS, its PostgreSQL database and the CCD FDW connection are healthy.

After merging:

1. Wait for Flux to reconcile ET in both production clusters.
2. Monitor the `et-ccd-data-migration-v2` task. A time-limited run may resume on a later schedule; do not treat one invocation ending as completion.
3. Confirm the migration progress status is `COMPLETE`, the final source event high-water mark was reached, validation passed, and the migrated case types have no outstanding Elasticsearch queue rows.
4. Only then proceed to the ET runtime activation PR.

## Abort / rollback

If cutover is interrupted or fails before CCD routing is enabled, revert `CCD_DATA_MIGRATION_MODE` to `PRELOAD_EVENTS`. The migration task supports returning an incomplete cutover to preload mode and will capture a fresh high-water mark on the next cutover attempt.

Keep ET shuttered until the migration state and target database have been checked.

## Scope

The configured migration includes:

- `ET_EnglandWales`
- `ET_Scotland`
- `ET_Admin`
- `Pre_Hearing_Deposit`
- `ET_EnglandWales_Multiple`
- `ET_Scotland_Multiple`
- `ET_EnglandWales_Listings`
- `ET_Scotland_Listings`
