### PR TITLE
Activate ET decentralised runtime in production

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -144,9 +144,9 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
-        ET_SERVICEBUS_SCHEDULER_ENABLED: false
+        ET_SERVICEBUS_SCHEDULER_ENABLED: true
         ELASTIC_SEARCH_HOSTS: "http://ccd-data-0.service.core-compute-prod.internal:9200,http://ccd-data-1.service.core-compute-prod.internal:9200,http://ccd-data-2.service.core-compute-prod.internal:9200,http://ccd-data-3.service.core-compute-prod.internal:9200"
-        MIGRATION_CCD_DATA_ENABLED: true
+        MIGRATION_CCD_DATA_ENABLED: false
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         CCD_DATA_MIGRATION_ENABLED: true
         CCD_DATA_MIGRATION_TASK_NAME: et-ccd-data-migration-v2


### PR DESCRIPTION
## Summary

Finalises the ET production runtime after the CCD data migration has completed:

- disables the scheduled migration runner
- enables ET's CCD case-event Service Bus publisher

The decentralised Elasticsearch indexer is already enabled in production and is unchanged here.

## Dependency

This PR is stacked on #47310 so its diff contains only the runtime changes. Merge #47310 first.

## Merge instructions

**Do not merge until all of the following are true:**

1. ET remains shuttered/read-only and direct writers remain stopped.
2. The `et-ccd-data-migration-v2` progress status is `COMPLETE`.
3. Migration validation passed and the final event high-water mark was reached.
4. The ET Elasticsearch and message-publisher queues have been checked and are in the expected state.

After merging:

1. Wait for Flux to reconcile ET in both production clusters.
2. Confirm all ET COS pods are ready and `/ccd-persistence/*` is healthy.
3. Confirm the migration scheduler no longer starts new runs.
4. Confirm the Service Bus publisher is healthy before enabling CCD routing.
5. Keep ET shuttered until the separate CCD routing PR has reconciled and smoke testing begins.

## Abort / rollback

If runtime activation is unhealthy before CCD routing is enabled:

1. Set `ET_SERVICEBUS_SCHEDULER_ENABLED` back to `false`.
2. Set `MIGRATION_CCD_DATA_ENABLED` back to `true` only when another migration invocation is intentionally required.
3. Keep ET shuttered while the migration state and queues are checked.

If CCD routing has already been enabled, remove the CCD routing first while ET remains shuttered, then disable this publisher. Do not route live traffic back to CCD after ET has accepted user writes without reconciling the post-cutover data delta.
