### PR TITLE
Route ET production case types to ET COS

### DIFF
--- a/apps/ccd/ccd-data-store-api/prod.yaml
+++ b/apps/ccd/ccd-data-store-api/prod.yaml
@@ -43,3 +43,19 @@ spec:
         HTTP_CLIENT_CONNECTION_DEFINITION_STORE_TIMEOUT: 8000
         UPLOAD_TIMESTAMP_FEATURED_CASE_TYPES: xuiTestCaseType_dev,AAT_AUTH_15,BEFTA_CASETYPE_2_1,BEFTA_CASETYPE_2_2,abc,BEFTA_CASETYPE_3_2,FT_MasterCaseType,FT_CaseFileView_1,FT_CaseFileView_2,FT_CRUD_2,FinancialRemedyContested,CARE_SUPERVISION_EPO,CIVIL,GENERALAPPLICATION,PRLAPPS,GrantOfRepresentation
         CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_CriminalInjuriesCompensation: http://sptribs-case-api-prod.service.core-compute-prod.internal
+        SPRING_APPLICATION_JSON: |
+          {
+            "ccd": {
+              "decentralised": {
+                "case-type-service-urls": {
+                  "ET_EnglandWales": "http://et-cos-prod.service.core-compute-prod.internal",
+                  "ET_Scotland": "http://et-cos-prod.service.core-compute-prod.internal",
+                  "ET_EnglandWales_Listings": "http://et-cos-prod.service.core-compute-prod.internal",
+                  "ET_Scotland_Listings": "http://et-cos-prod.service.core-compute-prod.internal",
+                  "ET_EnglandWales_Multiple": "http://et-cos-prod.service.core-compute-prod.internal",
+                  "ET_Scotland_Multiple": "http://et-cos-prod.service.core-compute-prod.internal",
+                  "ET_Admin": "http://et-cos-prod.service.core-compute-prod.internal"
+                }
+              }
+            }
+          }


### PR DESCRIPTION
## Summary

Configures CCD Data Store in production to delegate persistence for the seven established ET decentralised case types to ET COS at:

`http://et-cos-prod.service.core-compute-prod.internal`

CCD remains the API gateway and access-control plane. This routing configuration is the actual production persistence cutover.

## Dependencies

Do not merge until:

1. #47310 has been merged and the final ET migration reports `COMPLETE`.
2. #47311 has been merged and ET COS, its event publisher and `/ccd-persistence/*` endpoints are healthy in both production clusters.
3. ET remains shuttered/read-only and all direct writers remain stopped.

## Case types routed

- `ET_EnglandWales`
- `ET_Scotland`
- `ET_EnglandWales_Listings`
- `ET_Scotland_Listings`
- `ET_EnglandWales_Multiple`
- `ET_Scotland_Multiple`
- `ET_Admin`

This matches the existing AAT routing map.

### Required decision before marking ready

The production migration configuration also copies `Pre_Hearing_Deposit`, but the proven AAT decentralised routing map does not route that case type. This PR deliberately follows AAT and leaves it centralised. Confirm that this is intended before marking the PR ready for review; if it must be decentralised, prove the additional route in a lower environment first.

## Merge and verification instructions

**Merge only during the agreed cutover window.**

After merging:

1. Wait for Flux and the CCD Data Store rollout to reconcile in all production clusters.
2. Confirm CCD Data Store is healthy and can reach ET COS.
3. Smoke-test viewing and updating migrated single, multiple, listing and admin cases.
4. Create a test case and confirm it is persisted in ET's `ccd` schema while CCD contains the expected pointer.
5. Confirm updated and newly created cases are searchable.
6. Confirm expected Work Allocation/Service Bus messages are published.
7. Make the explicit go/no-go decision before unshuttering ET.

## Rollback

For a no-go while ET is still shuttered, revert this routing change so CCD resumes central persistence, wait for the CCD rollout to complete, and verify central reads before unshuttering.

The source migration is non-destructive, so the original CCD rows remain available. However, any smoke-test writes accepted by ET are not automatically copied back to CCD. Clean up or reconcile those test artifacts before unshuttering.

After ET has been unshuttered and accepted live writes, reverting this PR alone is **not a safe rollback**. Shutter ET again and reconcile or reverse-migrate the post-cutover delta before making CCD authoritative.
