### PR TITLE
DTSPO-34621 - Add new nightly agent pools to jenkins

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -296,7 +296,7 @@ spec:
                       - templateName: "cnp-jenkins-ubuntu-aat-nightly"
                         templateDesc: "Jenkins nightly build agents for CFT AAT environment"
                         labels: "ubuntu-aat nightly"
-                        maxVirtualMachinesLimit: 120
+                        maxVirtualMachinesLimit: 20
                         retentionStrategy:
                           azureVMCloudRetentionStrategy:
                             idleTerminationMinutes: 5
@@ -364,7 +364,7 @@ spec:
                       - templateName: "cnp-jenkins-ubuntu-ptl-nightly"
                         templateDesc: "Jenkins nightly build agents for CFT ptl environment"
                         labels: "ubuntu-ptl nightly"
-                        maxVirtualMachinesLimit: 10
+                        maxVirtualMachinesLimit: 20
                         retentionStrategy:
                           azureVMCloudPool:
                             retentionInHours: 1

--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -122,6 +122,22 @@ spec:
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.110"
                         <<: *vm_template_values_anchor
+                      - templateName: "cnp-jenkins-ubuntu-nightly"
+                        templateDesc: "Jenkins build agents for HMCTS nightly builds"
+                        labels: "nightly"
+                        maxVirtualMachinesLimit: 40
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D4ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-civil"
                         templateDesc: "Jenkins build agents for Civil builds"
                         labels: "civil"
@@ -259,6 +275,95 @@ spec:
                       - templateName: "cnp-jenkins-ubuntu-ptl"
                         templateDesc: "Jenkins build agents for CFT ptl environment"
                         labels: "ubuntu-ptl"
+                        maxVirtualMachinesLimit: 10
+                        retentionStrategy:
+                          azureVMCloudPool:
+                            retentionInHours: 1
+                            dynamicBufferEnabled: true
+                            bufferPercentage: 10
+                            maximumBuffer: 5
+                            poolSize: 2
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D4ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/managed-identities-cftptl-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftptl-intsvc-mi
+                      - templateName: "cnp-jenkins-ubuntu-aat-nightly"
+                        templateDesc: "Jenkins nightly build agents for CFT AAT environment"
+                        labels: "ubuntu-aat nightly"
+                        maxVirtualMachinesLimit: 120
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D4ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
+                      - templateName: "cnp-jenkins-ubuntu-ithc-nightly"
+                        templateDesc: "Jenkins nightly build agents for CFT ITHC environment"
+                        labels: "ubuntu-ithc nightly"
+                        maxVirtualMachinesLimit: 10
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D4ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ithc-mi
+                      - templateName: "cnp-jenkins-ubuntu-perftest-nightly"
+                        templateDesc: "Jenkins nightly build agents for CFT perftest environment"
+                        labels: "ubuntu-perftest nightly"
+                        maxVirtualMachinesLimit: 10
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D4ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c/resourceGroups/managed-identities-perftest-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-perftest-mi
+                      - templateName: "cnp-jenkins-ubuntu-demo-nightly"
+                        templateDesc: "Jenkins nightly build agents for CFT demo environment"
+                        labels: "ubuntu-demo nightly"
+                        maxVirtualMachinesLimit: 10
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D4ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-demo-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-demo-mi
+                      - templateName: "cnp-jenkins-ubuntu-ptl-nightly"
+                        templateDesc: "Jenkins nightly build agents for CFT ptl environment"
+                        labels: "ubuntu-ptl nightly"
                         maxVirtualMachinesLimit: 10
                         retentionStrategy:
                           azureVMCloudPool:


### PR DESCRIPTION
### Jira link

See [DTSPO-34601](https://tools.hmcts.net/jira/browse/DTSPO-34601)

### Change description

Add new agent pools that will be environment specific but only used for nightly builds
Testing out DTSPO-30107-jenkins-agents-2 branch of jenkins library to enable environment aware nightly pipelines

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
