### PR TITLE
Revert "Increase artifactory Web UI artefact upload limit to allow caps artefact to be uploaded (210mb)"

### DIFF
--- a/apps/artifactory/artifactory/artifactory-configmap.yaml
+++ b/apps/artifactory/artifactory/artifactory-configmap.yaml
@@ -13,7 +13,7 @@ spec:
             <config xmlns="http://artifactory.jfrog.org/xsd/2.1.6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jfrog.org/xsd/artifactory-v2_1_6.xsd">
                 <offlineMode>false</offlineMode>
                 <helpLinksEnabled>true</helpLinksEnabled>
-                <fileUploadMaxSizeMb>300</fileUploadMaxSizeMb>
+                <fileUploadMaxSizeMb>100</fileUploadMaxSizeMb>
                 <revision>8</revision>
                 <dateFormat>dd-MM-yy HH:mm:ss z</dateFormat>
                 <addons>


### PR DESCRIPTION
Reverts hmcts/cnp-flux-config#47308

Revert this, larger file uploads will never be successful anyway due to traefik ingress timeout so better to make it fail with a more obvious reason.