### PR TITLE
fix: add XUI ICP AAT internal ingress route

### DIFF
--- a/apps/xui/aat/base/kustomization.yaml
+++ b/apps/xui/aat/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../../rbac/db-query-job-role.yaml
   - register-org-ingress.yaml
+  - xui-icp-internal-ingress.yaml
   - ../../../base/slack-provider/aat
   - ../../../base/docker-registry/aat
 namespace: xui

--- a/apps/xui/aat/base/xui-icp-internal-ingress.yaml
+++ b/apps/xui/aat/base/xui-icp-internal-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: xui-icp-internal
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: xui-icp-aat.service.core-compute-aat.internal
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: xui-icp-nodejs
+                port:
+                  number: 80


### PR DESCRIPTION
### Jira link

See [EXUI-5084](https://tools.hmcts.net/jira/browse/EXUI-5084)

### Change description ###

Add the missing AAT private Traefik route for the migrated XUI ICP API.

The Azure Application Gateway route is already provisioned, but its internal-host health probe currently reaches Traefik and receives `404`, producing `502` to the nightly test runner. This adds the matching host rule to the existing `xui-icp-nodejs` service while leaving the public route, EM configuration, replicas, and consumers unchanged.

### Testing done

Automated:

- [x] `yq` YAML parsing and field assertions passed.
- [x] `python3` YAML parsing passed.
- [x] `git diff --check` passed.
- [x] `tests/code-owner-check.sh` passed.
- [x] `tests/image-policy-exists.sh` passed.
- [ ] Full Kustomize render: not completed locally because the checkout's existing `apps/xui/base` path-security error prevents rendering the AAT base; CI must provide the full Flux/Kustomize/schema result.

Manual:

- [x] Root cause reproduced against AAT: public XUI `/health` returns 200; the private XUI route returns 502 because the Azure backend probe receives Traefik 404 for the internal Host header.
- [ ] Post-merge Flux reconciliation, Azure backend health, and XUI nightly rerun.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

* [ ] Yes
* [x] No

### Checklist

- [x] Commit message is meaningful and follows repository conventions.
- [x] No documentation update is required for this manifest-only route.
- [ ] Tests have been updated / new tests have been added (not applicable to declarative routing).
- [ ] This PR introduces a breaking change (No).
