### PR TITLE
Enable ET service bus scheduler in production

### DIFF
--- a/apps/et/et-cos/prod.yaml
+++ b/apps/et/et-cos/prod.yaml
@@ -144,7 +144,7 @@ spec:
         SPRING_SERVLET_MULTIPART_MAX_FILE_SIZE: 300MB
         SPRING_SERVLET_MULTIPART_MAX_REQUEST_SIZE: 300MB
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: true
-        ET_SERVICEBUS_SCHEDULER_ENABLED: false
+        ET_SERVICEBUS_SCHEDULER_ENABLED: true
         ELASTIC_SEARCH_HOSTS: "http://ccd-data-0.service.core-compute-prod.internal:9200,http://ccd-data-1.service.core-compute-prod.internal:9200,http://ccd-data-2.service.core-compute-prod.internal:9200,http://ccd-data-3.service.core-compute-prod.internal:9200"
         MIGRATION_CCD_DATA_ENABLED: true
         MIGRATION_CCD_DATA_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)


### PR DESCRIPTION
This will be a Noop at the moment, I have verified that no messages are in the queue which is populated by decentralised events.