### PR TITLE
HDPI-8818: run pcs-api bulk-print sweep every 30 minutes on AAT

### DIFF
--- a/apps/pcs/pcs-api/aat.yaml
+++ b/apps/pcs/pcs-api/aat.yaml
@@ -9,3 +9,5 @@ spec:
         HASH_PINS_ENABLED: "false"
         ENABLE_TESTING_SUPPORT: "true"
         PCS_FRONTEND_URL: "https://pcs.aat.platform.hmcts.net"
+        BULK_PRINT_SCHEDULE: "FIXED_DELAY|1800s"
+        BULK_PRINT_LOOKBACK_HOURS: "1"


### PR DESCRIPTION
### Jira link

See [HDPI-8818](https://tools.hmcts.net/jira/browse/HDPI-8818)

### Change description

Run the pcs-api bulk-print dispatch sweep on AAT every 30 minutes instead of the default once a day at 02:00 UTC, so packs generated during the day are dispatched the same day. `BULK_PRINT_LOOKBACK_HOURS: "1"` is set alongside it so the frequent sweep only picks up recent documents rather than the historical backlog.

### Testing done

AAT-only: the patched file is referenced solely by the AAT kustomization; all other environments use their own patch files. All schema checks pass for every cluster.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed) — N/A
- [ ] tests have been updated / new tests has been added (if needed) — N/A, config only
- [ ] Does this PR introduce a breaking change
