### PR TITLE
DTSPO-34949 - Add nightly agents for civil and xui aat

### DIFF
--- a/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl-intsvc/jenkins-azure-vm-agent.yaml
@@ -154,10 +154,42 @@ spec:
                           galleryImageDefinition: "jenkins-ubuntu-v2"
                           galleryImageVersion: "24.04.110"
                         <<: *vm_template_values_anchor
+                      - templateName: "cnp-jenkins-ubuntu-civil-nightly"
+                        templateDesc: "Jenkins nightly build agents for Civil builds"
+                        labels: "civil-nightly"
+                        maxVirtualMachinesLimit: 10
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
                       - templateName: "cnp-jenkins-ubuntu-xui"
                         templateDesc: "Jenkins build agents for xui builds"
                         labels: "xui"
                         maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                      - templateName: "cnp-jenkins-ubuntu-xui-nightly"
+                        templateDesc: "Jenkins nightly build agents for xui builds"
+                        labels: "xui-nightly"
+                        maxVirtualMachinesLimit: 10
                         retentionStrategy:
                           azureVMCloudRetentionStrategy:
                             idleTerminationMinutes: 5
@@ -501,6 +533,23 @@ spec:
                           galleryImageVersion: "24.04.110"
                         <<: *vm_template_values_anchor
                         uamiID: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/managed-identities-cftptl-intsvc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-cftptl-intsvc-mi
+                      - templateName: "cnp-jenkins-ubuntu-civil-aat-nightly"
+                        templateDesc: "Jenkins nightly build agents for Civil AAT builds"
+                        labels: "civil-aat-nightly"
+                        maxVirtualMachinesLimit: 25
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi
                       - templateName: "cnp-jenkins-ubuntu-xui-preview"
                         templateDesc: "Jenkins build agents for XUI builds"
                         labels: "xui-preview"
@@ -603,3 +652,20 @@ spec:
                           galleryImageVersion: "24.04.110"
                         <<: *vm_template_values_anchor
                         uamiID: /subscriptions/8999dec3-0104-4a27-94ee-6588559729d1/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-prod-mi
+                      - templateName: "cnp-jenkins-ubuntu-xui-aat-nightly"
+                        templateDesc: "Jenkins nightly build agents for XUI builds"
+                        labels: "xui-aat nightly"
+                        maxVirtualMachinesLimit: 10
+                        retentionStrategy:
+                          azureVMCloudRetentionStrategy:
+                            idleTerminationMinutes: 5
+                        usageMode: "EXCLUSIVE"
+                        virtualMachineSize: "Standard_D8ds_v5"
+                        imageReference:
+                          galleryName: "hmcts"
+                          galleryResourceGroup: "hmcts-image-gallery-rg"
+                          gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"
+                          galleryImageDefinition: "jenkins-ubuntu-v2"
+                          galleryImageVersion: "24.04.110"
+                        <<: *vm_template_values_anchor
+                        uamiID: /subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/managed-identities-aat-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-aat-mi


### PR DESCRIPTION
### Jira link

See [DTSPO-34949](https://tools.hmcts.net/jira/browse/DTSPO-34949)

### Change description

After releasing 2.7.0 of the jenkins library, new nightly agent pools were needed
Forgot to add pools for civil and xui

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
