### PR TITLE
Revert "Update pcs-api.yaml (#47385)"

### DIFF
--- a/apps/pcs/pcs-api/pcs-api.yaml
+++ b/apps/pcs/pcs-api/pcs-api.yaml
@@ -7,10 +7,6 @@ spec:
   values:
     java:
       replicas: 2
-      memoryLimits: "1024Mi"
-      memoryRequests: "512Mi"
-      cpuLimits: "1500m"
-      cpuRequests: "500m"
       image: hmctsprod.azurecr.io/pcs/api:prod-c2ca9c0-20260909094541 #{"$imagepolicy": "flux-system:pcs-api"}
       environment:
         RESTART: "true"

--- a/apps/pcs/pcs-frontend/pcs-frontend.yaml
+++ b/apps/pcs/pcs-frontend/pcs-frontend.yaml
@@ -7,10 +7,6 @@ spec:
   values:
     nodejs:
       replicas: 2
-      memoryLimits: "1024Mi"
-      memoryRequests: "512Mi"
-      cpuLimits: "1500m"
-      cpuRequests: "500m"
       image: hmctsprod.azurecr.io/pcs/frontend:prod-a25f612-20260908173204 #{"$imagepolicy": "flux-system:pcs-frontend"}
       environment:
         TRIGGER_VAR: 1


### PR DESCRIPTION
Reverts #47385.

That PR added CPU and memory requests and limits to the shared base files for
pcs-api and pcs-frontend. Those files are included by every environment's
kustomization, and no environment patch overrides these keys, so the values
applied to aat, demo, ithc, perftest and prod at once.

For pcs-api it's a large reduction. `charts/pcs-api/values.yaml` sets
`memoryRequests: 2Gi` and `memoryLimits: 2.5Gi`; the base override took those to
`512Mi` and `1024Mi` — a 75% cut to requests and 60% to limits, in prod
included. Memory limits are a hard kill rather than throttling, and the JVM sizes
its heap from the container limit, so this also shrinks max heap.

Reverting to get back to the previous known-good sizing. Happy to reapply with
per-environment values once we've agreed the numbers from actual usage.

@jmcadam for visibility.
