### PR TITLE
test: route AAT WebApp consumer to XUI ICP

### DIFF
--- a/apps/xui/xui-webapp/aat.yaml
+++ b/apps/xui/xui-webapp/aat.yaml
@@ -29,7 +29,7 @@ spec:
         FEATURE_ACCESS_MANAGEMENT_ENABLED: true
         GLOBAL_SEARCH_SERVICES: IA,CIVIL,PRIVATELAW,PUBLICLAW,SSCS,ST_CIC,EMPLOYMENT,PCS
         SERVICE_REF_DATA_MAPPING: '[{"service":"IA", "serviceCodes":["BFA1"]}, {"service":"CIVIL", "serviceCodes":["AAA6", "AAA7"]}, {"service":"PRIVATELAW", "serviceCodes":["ABA5"]}, {"service":"PUBLICLAW", "serviceCodes":["ABA3"]}, {"service":"SSCS", "serviceCodes":["BBA3"]}, {"service":"ST_CIC", "serviceCodes":["BBA2"]}, {"service":"EMPLOYMENT", "serviceCodes":["BHA1"]}, {"service":"DIVORCE", "serviceCodes":["ABA1"]}, {"service":"FR", "serviceCodes":["ABA2"]}, {"service":"PROBATE", "serviceCodes":["ABA6"]}, {"service":"PCS", "serviceCodes":["AAA3"]}]'
-        SERVICES_ICP_API: https://em-icp.aat.platform.hmcts.net
+        SERVICES_ICP_API: https://xui-icp.aat.platform.hmcts.net
         FEATURE_LAU_SPECIFIC_CHALLENGED_ENABLED: true
         SERVICES_HEARINGS_COMPONENT_API_SSCS: http://sscs-tribunals-api-aat.service.core-compute-aat.internal
         DECENTRALISED_CASE_TYPE_CONFIG: >-


### PR DESCRIPTION
### Jira link

See [EXUI-5084](https://tools.hmcts.net/jira/browse/EXUI-5084)

### Change description

Changes only the XUI WebApp AAT overlay from EM ICP to XUI ICP. This enables a controlled consumer validation while EM remains unchanged. There is no XUI Media Viewer Flux overlay in this repository; Media Viewer is validated through its own Jenkins configuration branch.

### Testing done

- [x] YAML parse validation
- [x] git diff --check
- [ ] Flux reconciliation and XUI WebApp AAT journey: required after merge

### Rollback

Revert this one-line AAT overlay change.