### PR TITLE
fix: route AAT WebApp Web PubSub to XUI

### DIFF
--- a/apps/xui/xui-webapp/aat.yaml
+++ b/apps/xui/xui-webapp/aat.yaml
@@ -30,6 +30,7 @@ spec:
         GLOBAL_SEARCH_SERVICES: IA,CIVIL,PRIVATELAW,PUBLICLAW,SSCS,ST_CIC,EMPLOYMENT,PCS
         SERVICE_REF_DATA_MAPPING: '[{"service":"IA", "serviceCodes":["BFA1"]}, {"service":"CIVIL", "serviceCodes":["AAA6", "AAA7"]}, {"service":"PRIVATELAW", "serviceCodes":["ABA5"]}, {"service":"PUBLICLAW", "serviceCodes":["ABA3"]}, {"service":"SSCS", "serviceCodes":["BBA3"]}, {"service":"ST_CIC", "serviceCodes":["BBA2"]}, {"service":"EMPLOYMENT", "serviceCodes":["BHA1"]}, {"service":"DIVORCE", "serviceCodes":["ABA1"]}, {"service":"FR", "serviceCodes":["ABA2"]}, {"service":"PROBATE", "serviceCodes":["ABA6"]}, {"service":"PCS", "serviceCodes":["AAA3"]}]'
         SERVICES_ICP_API: https://xui-icp.aat.platform.hmcts.net
+        WEBPUBSUB_URL: wss://xui-icp-webpubsub.aat.platform.hmcts.net
         FEATURE_LAU_SPECIFIC_CHALLENGED_ENABLED: true
         SERVICES_HEARINGS_COMPONENT_API_SSCS: http://sscs-tribunals-api-aat.service.core-compute-aat.internal
         DECENTRALISED_CASE_TYPE_CONFIG: >-


### PR DESCRIPTION
### Jira link

See [EXUI-5084](https://tools.hmcts.net/jira/browse/EXUI-5084)

### Change description

The earlier AAT consumer switch moved SERVICES_ICP_API to XUI but left WEBPUBSUB_URL on EM. This completes the controlled AAT WebApp validation path by routing both ICP API and Web PubSub to XUI. EM and all other environments remain unchanged.

### Testing done

- [x] git diff --check
- [x] Confirmed XUI ICP AAT health returns HTTP 200
- [x] Confirmed EM ICP AAT health returns HTTP 200
- [ ] Flux reconciliation and authenticated WebApp journey required after merge

### Rollback

Revert this single-line AAT overlay change.