### PR TITLE
Removing ET casetypes from R&D

### DIFF
--- a/apps/ccd/ccd-case-disposer/prod.yaml
+++ b/apps/ccd/ccd-case-disposer/prod.yaml
@@ -22,7 +22,7 @@ spec:
         DOCUMENT_STORE_HOST: "http://dm-store-prod.service.core-compute-prod.internal"
         DEFINITION_STORE_HOST: "http://ccd-definition-store-api-prod.service.core-compute-prod.internal"
         LOG_AND_AUDIT_HOST: "http://lau-case-backend-prod.service.core-compute-prod.internal"
-        DELETE_CASE_TYPES: "MoneyClaimCase, A58, CARE_SUPERVISION_EPO, ET_EnglandWales, ET_Scotland, GrantOfRepresentation, Caveat, PRLAPPS, NFD, HearingRecordings"
+        DELETE_CASE_TYPES: "MoneyClaimCase, A58, CARE_SUPERVISION_EPO, GrantOfRepresentation, Caveat, PRLAPPS, NFD, HearingRecordings"
         SIMULATED_CASE_TYPES:
         CCD_DISPOSER_REQUEST_LIMIT: "110000"
         CCD_DISPOSER_CUT_OFF_TIME: "03:00"


### PR DESCRIPTION
Temporarily suspend ET_EnglandWales and ET_Scotland from retain and dispose for ET decentralisation.

A re-enablement PR will follow up post decentralisation monitoring and existing TTL disarm.