### PR TITLE
Read the dtsse-github-metrics chart from hmcts-charts

### DIFF
--- a/apps/dtsse/dtsse-github-metrics/dtsse-github-metrics.yaml
+++ b/apps/dtsse/dtsse-github-metrics/dtsse-github-metrics.yaml
@@ -9,12 +9,13 @@ spec:
       image: hmctsprod.azurecr.io/dtsse/github-metrics:prod-ab0ad6f-20260909124330 #{"$imagepolicy": "flux-system:dtsse-github-metrics"}
     job:
       image: hmctsprod.azurecr.io/dtsse/github-metrics:prod-ab0ad6f-20260909124330 #{"$imagepolicy": "flux-system:dtsse-github-metrics"}
+    orgJob:
+      image: hmctsprod.azurecr.io/dtsse/github-metrics:prod-ab0ad6f-20260909124330 #{"$imagepolicy": "flux-system:dtsse-github-metrics"}
   chart:
     spec:
-      chart: dtsse-github-metrics
-      version: ">=0.0.2"
+      chart: ./stable/dtsse-github-metrics
       sourceRef:
-        kind: HelmRepository
-        name: hmctsprod-oci
+        kind: GitRepository
+        name: hmcts-charts
         namespace: flux-system
       interval: 1m


### PR DESCRIPTION
Follow-up to #47338, which pointed this HelmRelease at the `hmctsprod-oci` HelmRepository with `version: ">=0.0.2"`. That was the wrong source and new chart versions never deploy.

Nothing re-resolves an OCI chart version range. On both AAT clusters every OCI-sourced HelmChart artifact is stamped at its source-controller's start time and never again — `dtsse-dtsse-github-metrics` reads `0.0.5` from `09:05:08` on `cft-aat-01` and from `06:45:06` on `cft-aat-00`, both exactly the pod start. Chart `0.0.6` was published at `10:57:11`; four hours later, with `interval: 1m` and `Ready=True / ChartPullSucceeded`, it was still resolving `0.0.5`. In 6,000 lines of source-controller log the git-sourced charts appear ~56 times each and no OCI-sourced chart appears once.

The pipeline already auto-releases the chart to `hmcts/hmcts-charts` — `Auto-release dtsse-github-metrics 0.0.6`, five seconds after the ACR push — and flux polls that GitRepository every minute. So this just uses the source that 333 other HelmReleases use, including `dtsse-dashboard-ingestion` and `dtsse-ardoq-adapter` in the same namespace, and drops the version pin along with it.

Also sets `orgJob.image`. Chart `0.0.6` adds a second `job` dependency, aliased `orgJob`, for the organisation-graph CronJob. Its chart default is `:latest` — a tag that exists, so it would not have failed; it would have quietly run an unpinned image that image automation does not manage.

Verified with `kubectl kustomize --load-restrictor LoadRestrictionsNone apps/dtsse/aat/base`.