### PR TITLE
Follow expressjs-monorepo-template's ACR migration to hmctsprod

### DIFF
--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-api.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-api.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: expressjs-monorepo-template-api
-      version: ">=0.0.1-0"
+      version: "0.0.1-409bb46"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-api.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-api.yaml
@@ -8,13 +8,13 @@ spec:
   values:
     nodejs:
       releaseNameOverride: expressjs-monorepo-template-api
-      image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-api:prod-3a51ceb-20260507173737 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-api"}
+      image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-api:prod-409bb46-20260829152208 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-api"}
   chart:
     spec:
       chart: expressjs-monorepo-template-api
       version: ">=0.0.1-0"
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic-oci
+        name: hmctsprod-oci
         namespace: flux-system
       interval: 1m

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-crons.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-crons.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: expressjs-monorepo-template-crons
-      version: ">=0.0.1-0"
+      version: "0.0.1-409bb46"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-crons.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-crons.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     job:
       releaseNameOverride: expressjs-monorepo-template-crons
-      image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-crons:prod-3a51ceb-20260507173737 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-crons"}
+      image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-crons:prod-409bb46-20260829152208 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-crons"}
       schedule: "*/5 * * * *"
   chart:
     spec:
@@ -16,6 +16,6 @@ spec:
       version: ">=0.0.1-0"
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic-oci
+        name: hmctsprod-oci
         namespace: flux-system
       interval: 1m

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-postgres.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-postgres.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: expressjs-monorepo-template-postgres
-      version: ">=0.0.1-0"
+      version: "0.0.1-409bb46"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-postgres.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-postgres.yaml
@@ -8,13 +8,13 @@ spec:
   values:
     nodejs:
       releaseNameOverride: expressjs-monorepo-template-postgres
-      image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-postgres:prod-cc62685-20260505151610 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-postgres"}
+      image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-postgres:prod-409bb46-20260829152207 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-postgres"}
   chart:
     spec:
       chart: expressjs-monorepo-template-postgres
       version: ">=0.0.1-0"
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic-oci
+        name: hmctsprod-oci
         namespace: flux-system
       interval: 1m

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-web.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-web.yaml
@@ -8,13 +8,13 @@ spec:
   values:
     nodejs:
       releaseNameOverride: expressjs-monorepo-template-web
-      image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web:prod-3a51ceb-20260507173737 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-web"}
+      image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web:prod-409bb46-20260829152207 # {"$imagepolicy": "flux-system:expressjs-monorepo-template-web"}
   chart:
     spec:
       chart: expressjs-monorepo-template-web
       version: ">=0.0.1-0"
       sourceRef:
         kind: HelmRepository
-        name: hmctspublic-oci
+        name: hmctsprod-oci
         namespace: flux-system
       interval: 1m

--- a/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-web.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/expressjs-monorepo-template-web.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     spec:
       chart: expressjs-monorepo-template-web
-      version: ">=0.0.1-0"
+      version: "0.0.1-409bb46"
       sourceRef:
         kind: HelmRepository
         name: hmctsprod-oci

--- a/apps/dtsse/expressjs-monorepo-template/image-repo-api.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/image-repo-api.yaml
@@ -3,4 +3,4 @@ kind: ImageRepository
 metadata:
   name: expressjs-monorepo-template-api
 spec:
-  image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-api
+  image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-api

--- a/apps/dtsse/expressjs-monorepo-template/image-repo-crons.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/image-repo-crons.yaml
@@ -3,4 +3,4 @@ kind: ImageRepository
 metadata:
   name: expressjs-monorepo-template-crons
 spec:
-  image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-crons
+  image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-crons

--- a/apps/dtsse/expressjs-monorepo-template/image-repo-postgres.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/image-repo-postgres.yaml
@@ -3,4 +3,4 @@ kind: ImageRepository
 metadata:
   name: expressjs-monorepo-template-postgres
 spec:
-  image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-postgres
+  image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-postgres

--- a/apps/dtsse/expressjs-monorepo-template/image-repo-web.yaml
+++ b/apps/dtsse/expressjs-monorepo-template/image-repo-web.yaml
@@ -3,4 +3,4 @@ kind: ImageRepository
 metadata:
   name: expressjs-monorepo-template-web
 spec:
-  image: hmctspublic.azurecr.io/dtsse/expressjs-monorepo-template-web
+  image: hmctsprod.azurecr.io/dtsse/expressjs-monorepo-template-web


### PR DESCRIPTION
`hmcts/expressjs-monorepo-template` migrated registries on **2026-05-11** — [#624](https://github.com/hmcts/expressjs-monorepo-template/pull/624), *"chore: migrate ACR from hmctspublic to hmctsprod"* — and this config never followed it.

All four releases still point at `hmctspublic`, which has received nothing since **2026-05-07**:

| | pointed at | last artifact there | deployed today |
|---|---|---|---|
| charts | `hmctspublic-oci` | 2026-05-07 | `0.0.1-fd3c4e1` (2026-03-03) |
| images | `hmctspublic.azurecr.io` | 2026-05-07 | `prod-3a51ceb-20260507173737` |

Meanwhile `hmctsprod` holds 71 chart tags (newest 2026-08-29) and promoted prod images for all four components. So the AAT deployment has been frozen for four months with nothing reporting an error.

This moves charts, ImageRepositories and image values to `hmctsprod` together — `hmctspublic` no longer appears anywhere under this app. Image tags are set to the newest promoted images that exist there (`prod-409bb46-20260829152207/8`); image automation takes over from there.

**Scope:** registry only. The charts are versioned `0.0.1-<short-sha>`, and a git SHA used as a semver prerelease identifier compares lexically — so `>=0.0.1-0` resolves to the highest-*sorting* SHA, not the newest build. That is fixed separately in [expressjs-monorepo-template#758](https://github.com/hmcts/expressjs-monorepo-template/pull/758); until a build lands with the new scheme this will deploy the highest-sorting chart in `hmctsprod` rather than the latest.

Verified with `kubectl kustomize --load-restrictor LoadRestrictionsNone` on `apps/dtsse/aat/base` and `apps/dtsse/automation`.