### PR TITLE
Say where an application's chart comes from

### DIFF
--- a/docs/app-deployment-v2.md
+++ b/docs/app-deployment-v2.md
@@ -58,7 +58,19 @@ All application deployments are managed with `HelmRelease`.
 ### Add a new application
 
 - Standard naming convention for your application (`<application-name>`) is `<product>-<component>`. 
-- Add a `HelmRelease` manifest in `apps/<your-namespace>/<application-name>/<application-name>.yaml`. [See example](/apps/rpe/draft-store-service/draft-store-service.yaml)
+- Add a `HelmRelease` manifest in `apps/<your-namespace>/<application-name>/<application-name>.yaml`. [See example](/apps/rpe/draft-store-service/draft-store-service.yaml). [add-helm-release.sh](../bin/v2/add-helm-release.sh) will generate a starting point, but it targets `sbox` and writes a `hmctssandbox` image reference you will need to change.
+- **Your chart comes from the [hmcts-charts](https://github.com/hmcts/hmcts-charts) repository, not from an ACR.** Jenkins publishes it to `stable/<application-name>` there whenever a master build produces a chart version that is not published yet, and flux polls that repository every minute — so no chart version is pinned and a chart change deploys on its own. This is what the vast majority of releases in this repo do.
+    ```yaml
+      chart:
+        spec:
+          chart: ./stable/<application-name>
+          sourceRef:
+            kind: GitRepository
+            name: hmcts-charts
+            namespace: flux-system
+          interval: 1m
+    ```
+- **Do not point `sourceRef` at an OCI `HelmRepository` (`hmctsprod-oci`, `hmctspublic-oci`) with a `version:` range.** A range against an OCI registry is only resolved when source-controller restarts, so a newly published chart is never picked up while the `HelmChart` carries on reporting `Ready` on the old one. If your chart is published *only* to an ACR — which happens when your pipeline is not the standard Jenkins one — pin an exact `version:` and bump it when you publish, as the other OCI-sourced releases here do.
 - Run [add-image-policies.sh](../bin/v2/add-image-policies.sh) with your namespace, product,component and registry. Registry argument is optional which defaults to **hmctspublic**.
 
  ```bash


### PR DESCRIPTION
`docs/app-deployment-v2.md` is what the README points at for ["Adding an app to flux"](https://github.com/hmcts/cnp-flux-config#adding-an-app-to-flux), and it's the doc with the actual procedure — namespace, workload identity, image policies, env patches, single-cluster caveats, local `kustomize build`.

It never mentioned the chart source. `chart:`, `sourceRef`, `hmcts-charts` and `stable/` appeared **nowhere** in the file. The only way to learn the most important field in a HelmRelease was to open the linked example and notice it.

The one place that does state it is the [GitOps page](https://hmcts.github.io/cloud-native-platform/new-component/gitops-flux.html#application-config-in-flux) on hmcts.github.io — the only mention of `hmcts-charts` anywhere on that site — and it isn't on the path anyone follows to add an app to this repo.

This adds three things:

- **The chart block**, stated as coming from `hmcts-charts` rather than an ACR.
- **A warning against an OCI `HelmRepository` with a `version:` range.** Those are only re-resolved when source-controller restarts: every OCI-sourced `HelmChart` artifact on both AAT clusters is stamped at its source-controller's start time, so a newly published chart is silently never deployed while the `HelmChart` reports `Ready`. Nine releases here are in that state — measured, one has been deploying a chart from 2026-03-03 in preference to 28 later publishes. Teams whose chart only reaches an ACR should pin an exact version, as the other 98 OCI-sourced releases do.
- **A mention of `bin/v2/add-helm-release.sh`**, which generates the correct manifest and was referenced by no documentation anywhere. Qualified, because it targets `sbox` and writes a `hmctssandbox` image reference regardless of the ACR argument.

Companion PR on the docs site names the publish destination in the Jenkins section, which currently says only "the chart will be published" without saying where.