### PR TITLE
Enable ET event preload in demo and ITHC

### DIFF
--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -9,6 +9,8 @@ spec:
       image: hmctsprod.azurecr.io/et/cos:pr-3196-4de8fd7-20260909160906 #{"$imagepolicy": "flux-system:demo-et-cos"}
       environment:
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
+        ET_CCD_DATA_MIGRATION_ENABLED: true
+        ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         ET_SERVICEBUS_SCHEDULER_ENABLED: false
         ELASTIC_SEARCH_HOSTS: http://ccd-data-0.service.core-compute-demo.internal:9200
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-demo.service.core-compute-demo.internal

--- a/apps/et/et-cos/ithc.yaml
+++ b/apps/et/et-cos/ithc.yaml
@@ -8,6 +8,9 @@ spec:
     java:
       image: hmctsprod.azurecr.io/et/cos:pr-3395-2aca4ff-20260909113735 #{"$imagepolicy": "flux-system:ithc-et-cos"}
       environment:
+        ET_CCD_DATA_MIGRATION_ENABLED: true
+        ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
+        ET_SERVICEBUS_SCHEDULER_ENABLED: false
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-ithc.service.core-compute-ithc.internal
         AAC_URL: http://aac-manage-case-assignment-ithc.service.core-compute-ithc.internal
         EXUI_CASE_DETAILS_URL: "https://manage-case.ithc.platform.hmcts.net/cases/case-details/"


### PR DESCRIPTION
### Change description

Enable the ET CCD data migration scheduler in Demo and ITHC using `PRELOAD_EVENTS` mode. Keep the ET service-bus scheduler disabled because these environments have not cut over to decentralised persistence.

### Configuration

- `ET_CCD_DATA_MIGRATION_ENABLED: true`
- `ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS`
- `ET_SERVICEBUS_SCHEDULER_ENABLED: false`

### Testing

- Parsed both changed manifests successfully with `yq`
- `git diff --check` passes