### PR TITLE
Stage Demo Rota worker scale-to-zero with KEDA

### DIFF
--- a/apps/rota/demo/base/kustomization.yaml
+++ b/apps/rota/demo/base/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 namespace: rota
 patches:
   - path: ../../rota-resource/demo.yaml
+  - path: ../../rota-optimiser/demo.yaml
   - path: ../../rota-worker/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/rota/rota-optimiser/demo.yaml
+++ b/apps/rota/rota-optimiser/demo.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: rota-optimiser
+spec:
+  values:
+    queueMetrics:
+      enabled: true
+    java:
+      startupPath: /livez
+      livenessPath: /livez
+      readinessPath: /readyz
+      environment:
+        MANAGEMENT_SERVER_PORT: 4551
+        MANAGEMENT_ENDPOINT_HEALTH_PROBES_ADD_ADDITIONAL_PATHS: true
+        MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health,info,prometheus,queuedjobs

--- a/apps/rota/rota-worker/aat.yaml
+++ b/apps/rota/rota-worker/aat.yaml
@@ -4,6 +4,8 @@ metadata:
   name: rota-worker
 spec:
   values:
+    keda:
+      enabled: false
     java:
       environment:
         WORKER_ENABLED: true

--- a/apps/rota/rota-worker/demo.yaml
+++ b/apps/rota/rota-worker/demo.yaml
@@ -4,6 +4,13 @@ metadata:
   name: rota-worker
 spec:
   values:
+    keda:
+      enabled: true
+      maxReplicaCount: 1
+      activeDeadlineSeconds: 86400
     java:
+      replicas: 0
+      pdb:
+        enabled: false
       environment:
         WORKER_ENABLED: true


### PR DESCRIPTION
## Summary

Stages the Demo Rota worker KEDA rollout only. The optimiser remains an always-running Deployment and PostgreSQL remains the queue. No shared KEDA installation, application database, pipeline or non-Rota configuration changes.

**Draft — do not merge yet.** The current image-policy pins still reference pre-KEDA application images. After the linked application PRs merge and their normal pipelines publish the images/charts, update/verify these pins against those releases before marking this PR ready. The rollout must use worker chart >=0.1.5 and optimiser chart >=0.0.21 plus the matching new application images, not merely new charts with old images.

- Demo: opt in to the optimiser's internal queue-metrics service/NetworkPolicy on 4551; keep main-port health checks through `/livez` and `/readyz`.
- Demo: continuous worker Deployment replicas 0 and its Deployment PDB disabled; KEDA enabled with max 1 Job per cluster (2 across the existing dual-cluster deployment).
- Proposed Demo active deadline: 86400 seconds (24 hours). Confirm this exceeds the longest permitted solve including startup, persistence and termination margin before merge; this is an operational cap, not a measured solve budget.
- AAT: explicitly retain KEDA disabled and the existing continuous-worker configuration. Promotion is a later PR after Demo evidence.
- No application image-policy changes, new pipelines or shared chart changes are included.

## Dependencies

- https://github.com/hmcts/rota-optimiser/pull/31
- https://github.com/hmcts/rota-worker/pull/26

## Merge / deployment prerequisites

1. Merge and publish the linked optimiser and worker PRs via their existing pipelines; update/verify the image pins in this PR.
2. Confirm management-port network isolation is effective (NetworkPolicies are additive), KEDA 2.20 is healthy, Rota service-account/CSI identity works in both clusters, and the Job deadline covers the supported solve budget.
3. Drain existing continuous workers before activating this change.
4. Demonstrate idle zero Jobs; successful solve/callback; empty competing claim; maximum one active Job per cluster; worker interruption and lease recovery without stale writes; unavailable metrics do not create jobs; gradual update and drain/rollback. Capture cold-start and solve durations, queue wait and memory/CPU evidence.
5. Only then propose the equivalent AAT opt-in.

## Rollback

First pause KEDA (`keda.paused=true`) with the Deployment still at zero and allow active Jobs to drain. Then disable KEDA and restore the original continuous worker values (replicas 1 per cluster and its PDB). Do not remove the ScaledJob with active Jobs unless interruption/recovery is explicitly intended. The optimiser queue signal can remain available while reverting the worker.

## Validation

- Demo and AAT Kustomize builds.
- Both environments rendered using the locally changed application charts, with Java v5.3.0/library v2.2.2 dependency source tags.
- ScaledJob checked against KEDA 2.20 CRD; assertions cover zero continuous replicas in Demo, one continuous replica/no ScaledJob in AAT, Job bounds/exit lifecycle, namespace-qualified scaler DNS, identity/HMAC/CSI and identical image/resource settings.
- No live cluster changes or end-to-end Demo evidence claimed.
