### PR TITLE
EXUI-5084: point demo WebApp at XUI ICP

### DIFF
--- a/apps/xui/xui-webapp/demo.yaml
+++ b/apps/xui/xui-webapp/demo.yaml
@@ -25,7 +25,7 @@ spec:
         STUB: false
         SERVICES_CCD_CASE_ASSIGNMENT_API: http://aac-manage-case-assignment-demo.service.core-compute-demo.internal
         SERVICES_PRD_API: http://rd-professional-api-demo.service.core-compute-demo.internal
-        SERVICES_ICP_API: https://em-icp.demo.platform.hmcts.net
+        SERVICES_ICP_API: https://xui-icp.demo.platform.hmcts.net
         SERVICES_EM_DOCASSEMBLY_API: http://dg-docassembly-demo.service.core-compute-demo.internal
         SERVICES_LOCATION_API: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         SERVICES_CASE_JUDICIAL_API: http://rd-judicial-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
## Summary

Point the primary demo XUI WebApp deployment at the migrated XUI ICP API.

## Change

- Change `SERVICES_ICP_API` in `apps/xui/xui-webapp/demo.yaml` from the demo EM ICP endpoint to:
  `https://xui-icp.demo.platform.hmcts.net`
- Leave the separate integration applications unchanged so this remains a controlled consumer validation.

## Why

The XUI ICP demo HelmRelease is already present. This change exercises the real WebApp consumer against the migrated API while leaving EM ICP available for rollback/comparison.

## Validation

- YAML parsed successfully with `yq`.
- `git diff --check` passed.
- Flux/GitHub CI must validate the rendered demo overlay after opening the PR.

Jira: EXUI-5084
