### PR TITLE
Run ET preloads every ten minutes in demo and ITHC

### DIFF
--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -9,6 +9,7 @@ spec:
       image: hmctsprod.azurecr.io/et/cos:pr-3196-4de8fd7-20260909160906 #{"$imagepolicy": "flux-system:demo-et-cos"}
       environment:
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
+        ET_CCD_DATA_MIGRATION_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         ET_CCD_DATA_MIGRATION_ENABLED: true
         ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         ET_SERVICEBUS_SCHEDULER_ENABLED: false

--- a/apps/et/et-cos/demo.yaml
+++ b/apps/et/et-cos/demo.yaml
@@ -9,6 +9,7 @@ spec:
       image: hmctsprod.azurecr.io/et/cos:pr-3196-4de8fd7-20260909160906 #{"$imagepolicy": "flux-system:demo-et-cos"}
       environment:
         CCD_SDK_DECENTRALISED_ES_INDEXER_ENABLED: false
+        CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         ET_CCD_DATA_MIGRATION_ENABLED: true
         ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS

--- a/apps/et/et-cos/ithc.yaml
+++ b/apps/et/et-cos/ithc.yaml
@@ -8,6 +8,7 @@ spec:
     java:
       image: hmctsprod.azurecr.io/et/cos:pr-3395-2aca4ff-20260909113735 #{"$imagepolicy": "flux-system:ithc-et-cos"}
       environment:
+        CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         ET_CCD_DATA_MIGRATION_ENABLED: true
         ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS

--- a/apps/et/et-cos/ithc.yaml
+++ b/apps/et/et-cos/ithc.yaml
@@ -8,6 +8,7 @@ spec:
     java:
       image: hmctsprod.azurecr.io/et/cos:pr-3395-2aca4ff-20260909113735 #{"$imagepolicy": "flux-system:ithc-et-cos"}
       environment:
+        ET_CCD_DATA_MIGRATION_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         ET_CCD_DATA_MIGRATION_ENABLED: true
         ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
         ET_SERVICEBUS_SCHEDULER_ENABLED: false


### PR DESCRIPTION
### Change description

Override the ET CCD data migration cron in Demo and ITHC so `PRELOAD_EVENTS` runs every ten minutes, matching the schedule previously used for the production preload.

Concurrent invocations are protected by the migration database lock. The service-bus scheduler remains disabled.

### Testing

- Parsed both changed manifests successfully with `yq`
- `git diff --check` passes