### PR TITLE
Run ET ITHC migration cutover

### DIFF
--- a/apps/et/et-cos/ithc.yaml
+++ b/apps/et/et-cos/ithc.yaml
@@ -11,7 +11,7 @@ spec:
         CCD_DATA_MIGRATION_SOURCE_JURISDICTION: EMPLOYMENT
         ET_CCD_DATA_MIGRATION_CRON: "0 */10 * * * *" # every 10mins, 24/7 (db lock prevents parallel running)
         ET_CCD_DATA_MIGRATION_ENABLED: true
-        ET_CCD_DATA_MIGRATION_MODE: PRELOAD_EVENTS
+        ET_CCD_DATA_MIGRATION_MODE: CUTOVER
         ET_SERVICEBUS_SCHEDULER_ENABLED: false
         RD_PROFESSIONAL_API_URL: http://rd-professional-api-ithc.service.core-compute-ithc.internal
         AAC_URL: http://aac-manage-case-assignment-ithc.service.core-compute-ithc.internal


### PR DESCRIPTION
### Change description

Switch the ET ITHC CCD data migration from `PRELOAD_EVENTS` to `CUTOVER`. The preload is caught up at source event high-water mark 195371.

### Merge requirement

Merge only during the agreed ITHC cutover window after central CCD writes for the ET case types have been frozen and in-flight writes have drained. Verify the migration progress row reaches `COMPLETE` before merging either decentralisation follow-up PR.

### Testing

- Parsed the changed manifest successfully with `yq`
- `git diff --check` passes