### PR TITLE
Route ET ITHC case types to decentralised persistence

### DIFF
--- a/apps/ccd/ccd-data-store-api/ithc.yaml
+++ b/apps/ccd/ccd-data-store-api/ithc.yaml
@@ -22,6 +22,22 @@ spec:
         CCD_DOCUMENT_URL_PATTERN: ^https?://(((?:api-gateway\.preprod\.dm\.reform\.hmcts\.net|dm-store-ithc\.service\.core-compute-ithc\.internal(?::\d+)?)\/documents\/[A-Za-z0-9-]+(?:\/binary)?)|(em-hrs-api-ithc\.service\.core-compute-ithc\.internal(?::\d+)?\/hearing-recordings\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\/((segments\/[0-9]+)|(file/\S+))))
         CCD_S2S_AUTHORISED_SERVICES_CASE_USER_ROLES: aac_manage_case_assignment,fpl_case_service,iac,finrem_case_orchestration,divorce_frontend,nfdiv_case_api,civil_service,adoption_cos_api,adoption_web,prl_cos_api,et_cos,civil_general_applications,et_sya_api,pcs_api,finrem_citizen_ui,pt_api,pt_frontend
         CCD_DECENTRALISED_CASE-TYPE-SERVICE-URLS_PCS: http://pcs-api-ithc.service.core-compute-ithc.internal
+        SPRING_APPLICATION_JSON: |
+          {
+            "ccd": {
+              "decentralised": {
+                "case-type-service-urls": {
+                  "ET_EnglandWales": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Scotland": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_EnglandWales_Listings": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Scotland_Listings": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_EnglandWales_Multiple": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Scotland_Multiple": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal",
+                  "ET_Admin": "http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+                }
+              }
+            }
+          }
         IDAM_USER_URL: https://idam-web-public.ithc.platform.hmcts.net
         DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,bulk_scan_payment_processor,pcq_consolidation_service,em_npa_app,ecm_consumer,aac_manage_case_assignment,am_role_assignment_service,nfdiv_cms,nfdiv_cos,divorce_frontend,wa_task_management_api,wa_workflow_api,wa_task_configuration_api,em_hrs_api,nfdiv_case_api,civil_service,wa_task_monitor,ccd_case_document_am_api,adoption_cos_api,adoption_web,prl_cos_api,et_sya_api,ds_ui,hmc_cft_hearing_service,prl_cos_api,ccd_next_hearing_date_updater,civil_general_applications,fis_hmc_api,et_cos,sptribs_case_api,em_annotation_app,et_hearings_api,et_msg_handler,sptribs_dss_update_case_web,pcs_api,pcs_frontend,finrem_citizen_ui,pt_api,pt_frontend
         DATA_STORE_DB_HOST: ccd-data-store-api-postgres-db-v15-ithc.postgres.database.azure.com


### PR DESCRIPTION
## Summary

Routes the seven ET ITHC case types from CCD Data Store to the ET COS decentralised persistence endpoint.

## Deployment order

Do not merge this PR until:

1. #47435 has been merged, the CUTOVER migration has run, and the migration progress is COMPLETE.
2. #47436 has been merged and deployed, and ET COS is healthy with decentralised persistence, the indexer, and the service bus scheduler enabled.

After deployment, verify all seven ET case types can be read and written through CCD before considering the cutover complete.

## Validation

- `yq eval . apps/ccd/ccd-data-store-api/ithc.yaml`
- `git diff --check`