### PR TITLE
EXUI-5084: restore demo WebApp to EM ICP

### DIFF
--- a/apps/xui/xui-webapp/demo.yaml
+++ b/apps/xui/xui-webapp/demo.yaml
@@ -25,7 +25,7 @@ spec:
         STUB: false
         SERVICES_CCD_CASE_ASSIGNMENT_API: http://aac-manage-case-assignment-demo.service.core-compute-demo.internal
         SERVICES_PRD_API: http://rd-professional-api-demo.service.core-compute-demo.internal
-        SERVICES_ICP_API: https://xui-icp.demo.platform.hmcts.net
+        SERVICES_ICP_API: https://em-icp.demo.platform.hmcts.net
         SERVICES_EM_DOCASSEMBLY_API: http://dg-docassembly-demo.service.core-compute-demo.internal
         SERVICES_LOCATION_API: http://rd-location-ref-api-demo.service.core-compute-demo.internal
         SERVICES_CASE_JUDICIAL_API: http://rd-judicial-api-demo.service.core-compute-demo.internal


### PR DESCRIPTION
## Jira

[EXUI-5084](https://tools.hmcts.net/jira/browse/EXUI-5084)

## Why

Demo currently switches only `SERVICES_ICP_API` to XUI while Web PubSub remains on EM. That is a partial cutover rather than a valid side-by-side test, and the XUI demo route is not fully exposed yet.

## Change

- restore the demo WebApp ICP API URL to the working EM endpoint;
- leave every other environment and all EM resources unchanged.

Once the independent XUI demo stack is reachable, a separate controlled cutover will change the ICP API and Web PubSub URLs together.

## Validation

- changed YAML parses successfully with `yq`;
- `git diff --check` passes;
- Flux repository CI remains the merge gate.

This PR does not introduce a breaking change.

AI assistance was used for migration parity analysis; the change still requires human review and CI approval.
