### PR TITLE
ADOP-2904 Update IDAM_WEB_URL for HMCTS Access

### DIFF
--- a/apps/adoption/adoption-web/prod.yaml
+++ b/apps/adoption/adoption-web/prod.yaml
@@ -10,7 +10,7 @@ spec:
       environment:
         PCQ_ENABLED: "true"
         EQUALITY_URL: https://equality-and-diversity.platform.hmcts.net
-        IDAM_WEB_URL: https://hmcts-access.service.gov.uk/login
+        IDAM_WEB_URL: https://hmcts-access.service.gov.uk/o/authorize
         IDAM_API_URL: https://idam-api.platform.hmcts.net/o/token
         BANNER_ENABLED: 'false'
         BANNER_TITLE_TEXT_EN: 'Important'


### PR DESCRIPTION
### Jira link
[ADOP-2904](https://tools.hmcts.net/jira/browse/ADOP-2904)

### Change description
Apply HMCTS Access migration to prod:
- Point the production IDAM_WEB_URL
- Add production IDAM_END_SESSION_URL

### Testing done
See [ADOP-2904](https://tools.hmcts.net/jira/browse/ADOP-2904)

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] Does this PR introduce a breaking change - deploy before https://github.com/hmcts/adoption-web/pull/1847 + IDAM will need to migrate Production as part of the release. 


[ADOP-2904]: https://hmcts.atlassian.net/browse/ADOP-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADOP-2904]: https://hmcts.atlassian.net/browse/ADOP-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ